### PR TITLE
feat: harden repo for public open-source (#2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sigvardt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - sigvardt
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - sigvardt
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      security-workflows:
+        patterns:
+          - "github/codeql-action"
+          - "actions/dependency-review-action"
+          - "ossf/scorecard-action"
+          - "actions/checkout"
+          - "actions/upload-artifact"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "30 1 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: "Dependency Review"
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 120

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: "Scorecard"
+
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to Code Scanning
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: results.sarif

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
## Summary

Hardens the repository for public open-source readiness with security workflows, dependency scanning, and governance files.

## Changes

### Security Workflows (all actions SHA-pinned)
- **CodeQL** (`.github/workflows/codeql.yml`) — Static analysis for JavaScript/TypeScript on push to main, PRs, and weekly schedule. Uses `security-extended` query suite for broader coverage.
- **Dependency Review** (`.github/workflows/dependency-review.yml`) — Audits new dependencies on PRs, fails on high-severity vulnerabilities, posts summary comments.
- **OpenSSF Scorecard** (`.github/workflows/scorecard.yml`) — Supply chain security scoring on push to main and weekly. Publishes results to the public Scorecard API and uploads SARIF to Code Scanning.

### Dependency Management
- **Dependabot** (`.github/dependabot.yml`) — Weekly updates for npm and GitHub Actions dependencies, auto-assigned to @sigvardt. Groups security workflow action updates together.
- **`.npmrc`** — `save-exact=true` to pin dependency versions exactly.

### Governance
- **`CODEOWNERS`** — All files assigned to @sigvardt for required review.

### Verification
- **Branch protection** — Confirmed all required settings are active:
  - ✅ Required status checks: `ci` (strict)
  - ✅ Required commit signatures
  - ✅ Enforce admins
  - ✅ No force pushes allowed
- **Secrets audit** — No secrets, tokens, or credentials found in committed files.

## Security Notes
- All GitHub Actions are pinned to full SHA commits (not mutable tags) for supply chain integrity
- Dependabot will automatically propose updates when pinned SHAs become outdated
- Minimal `permissions` scoping on all workflows (principle of least privilege)

Closes #2
