### PR TITLE
feat: harden repo for public open-source (#2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sigvardt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    assignees:
+      - sigvardt
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    assignees:
+      - sigvardt
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '25 4 * * 1' # Monday 04:25 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: github/codeql-action/init@820e3160e279568db735cee8ed8f8e77a6da7818 # v3.32.6
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - uses: github/codeql-action/analyze@820e3160e279568db735cee8ed8f8e77a6da7818 # v3.32.6
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '25 4 * * 1' # Monday 04:25 UTC
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3.32.6
+        with:
+          sarif_file: results.sarif

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
## Summary

Harden the repo for public open-source with security workflows, dependency scanning, and supply chain protections. All new GitHub Actions are **SHA-pinned** to specific commits for maximum supply chain security.

## Changes

| File | Purpose |
|------|---------|
| `.github/dependabot.yml` | Weekly npm + GitHub Actions dependency updates, auto-assigned to @sigvardt, with grouped update PRs |
| `.github/workflows/codeql.yml` | CodeQL static analysis for JS/TS with `security-extended` queries on push/PR/weekly |
| `.github/workflows/dependency-review.yml` | Audit new dependencies on PRs, fail on high severity, post PR comment summaries |
| `.github/workflows/scorecard.yml` | OpenSSF Scorecard for supply chain security scoring, uploads SARIF to Code Scanning |
| `.npmrc` | `save-exact=true` to pin dependency versions exactly |
| `.github/CODEOWNERS` | `* @sigvardt` — all files owned by @sigvardt |

## Branch Protection Verification

| Setting | Status |
|---------|--------|
| Required status checks (`ci`) | ✅ Active |
| Required commit signatures | ✅ Active |
| Enforce admins | ✅ Active |
| No force pushes | ✅ Active |
| Strict status checks (up-to-date) | ⚠️ Currently `false` — consider enabling for stricter merge hygiene |

## Secrets Audit

No secrets, tokens, or credentials found in committed files. Only template/test placeholders (`'token-123'`, `'test-token'`) exist in source and tests.

## Notes

- **Dependency Review** requires the [Dependency Graph](https://github.com/sigvardt/bloomreach-buddy/settings/security_analysis) feature to be enabled in repo settings. The previous PR (#10) failed because this wasn't enabled. Enable it under Settings → Code security → Dependency graph.
- All quality gates pass locally: lint ✅, typecheck ✅, build ✅, tests ✅ (2/2)
- No existing files were modified — this PR only adds new files

Closes #2
