### PR TITLE
security: gate ai-task auto-label to repo owner only

### DIFF
--- a/.github/workflows/ai-task-auto-label.yml
+++ b/.github/workflows/ai-task-auto-label.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   auto-label:
+    if: github.event.issue.user.login == 'sigvardt'
     runs-on: ubuntu-latest
     steps:
       - name: Auto-manage ai-task label
@@ -18,14 +19,12 @@ jobs:
             const issue = context.payload.issue;
             const labels = issue.labels.map(l => l.name);
             
-            // Labels that exclude ai-task
-            const excludeLabels = ['backlog', 'ai-in-progress', 'ai-blocked', 'ai-debugging', 'ai-review-ready', 'wontfix', 'duplicate', 'invalid'];
+            const excludeLabels = ['backlog', 'ai-in-progress', 'ai-blocked', 'ai-review-ready', 'wontfix', 'duplicate', 'invalid'];
             
             const hasExclude = labels.some(l => excludeLabels.includes(l));
             const hasAiTask = labels.includes('ai-task');
             
             if (hasExclude && hasAiTask) {
-              // Remove ai-task if an exclude label is present
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -34,7 +33,6 @@ jobs:
               });
               console.log(`Removed ai-task from #${issue.number} (has exclude label)`);
             } else if (!hasExclude && !hasAiTask) {
-              // Add ai-task if no exclude label and no ai-task
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Only auto-label issues with `ai-task` when created by `sigvardt`. Prevents external users from injecting agent instructions via issue creation on public repos.