### PR TITLE
feat: add dashboard management feature module (#27)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { BloomreachClient } from '@bloomreach-buddy/core';
+import {
+  BloomreachClient,
+  BloomreachDashboardsService,
+} from '@bloomreach-buddy/core';
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
 
 const program = new Command();
 
@@ -26,5 +33,177 @@ program
     console.log(`Environment: ${result.environment}`);
     console.log(`Connected:   ${result.connected}`);
   });
+
+const dashboards = program
+  .command('dashboards')
+  .description('Manage Bloomreach Engagement dashboards');
+
+dashboards
+  .command('list')
+  .description('List all dashboards in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachDashboardsService(options.project);
+      const result = await service.listDashboards({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No dashboards found.');
+          return;
+        }
+        for (const dashboard of result) {
+          const home = dashboard.isHome ? ' [HOME]' : '';
+          console.log(`  ${dashboard.name}${home} (${dashboard.analysisCount} analyses)`);
+          console.log(`    ID:  ${dashboard.id}`);
+          console.log(`    URL: ${dashboard.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(1);
+    }
+  });
+
+dashboards
+  .command('create')
+  .description('Prepare creation of a new dashboard (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Dashboard name')
+  .option('--analyses <json>', 'JSON array of analyses [{id, name}]')
+  .option('--layout-columns <n>', 'Number of grid columns (1-6)', '2')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      analyses?: string;
+      layoutColumns: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const analyses = options.analyses
+          ? (JSON.parse(options.analyses) as { id: string; name: string }[])
+          : undefined;
+
+        const service = new BloomreachDashboardsService(options.project);
+        const result = service.prepareCreateDashboard({
+          project: options.project,
+          name: options.name,
+          analyses,
+          layout: { columns: parseInt(options.layoutColumns, 10) },
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Dashboard creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+dashboards
+  .command('set-home')
+  .description('Prepare setting a dashboard as the project home (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--dashboard-id <id>', 'Dashboard ID to set as home')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      dashboardId: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachDashboardsService(options.project);
+        const result = service.prepareSetHomeDashboard({
+          project: options.project,
+          dashboardId: options.dashboardId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Set-home-dashboard prepared.');
+          console.log(`  Dashboard: ${options.dashboardId}`);
+          console.log(`  Token:     ${result.confirmToken}`);
+          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+dashboards
+  .command('delete')
+  .description('Prepare deletion of a dashboard (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--dashboard-id <id>', 'Dashboard ID to delete')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      dashboardId: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachDashboardsService(options.project);
+        const result = service.prepareDeleteDashboard({
+          project: options.project,
+          dashboardId: options.dashboardId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Dashboard deletion prepared.');
+          console.log(`  Dashboard: ${options.dashboardId}`);
+          console.log(`  Token:     ${result.confirmToken}`);
+          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
 
 program.parse();

--- a/packages/core/src/__tests__/bloomreachDashboards.test.ts
+++ b/packages/core/src/__tests__/bloomreachDashboards.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_DASHBOARD_ACTION_TYPE,
+  SET_HOME_DASHBOARD_ACTION_TYPE,
+  DELETE_DASHBOARD_ACTION_TYPE,
+  DASHBOARD_RATE_LIMIT_WINDOW_MS,
+  DASHBOARD_CREATE_RATE_LIMIT,
+  DASHBOARD_MODIFY_RATE_LIMIT,
+  validateDashboardName,
+  validateProject,
+  validateLayoutConfig,
+  buildDashboardsUrl,
+  createDashboardActionExecutors,
+  BloomreachDashboardsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_DASHBOARD_ACTION_TYPE', () => {
+    expect(CREATE_DASHBOARD_ACTION_TYPE).toBe('dashboards.create_dashboard');
+  });
+
+  it('exports SET_HOME_DASHBOARD_ACTION_TYPE', () => {
+    expect(SET_HOME_DASHBOARD_ACTION_TYPE).toBe('dashboards.set_home_dashboard');
+  });
+
+  it('exports DELETE_DASHBOARD_ACTION_TYPE', () => {
+    expect(DELETE_DASHBOARD_ACTION_TYPE).toBe('dashboards.delete_dashboard');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports DASHBOARD_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(DASHBOARD_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports DASHBOARD_CREATE_RATE_LIMIT', () => {
+    expect(DASHBOARD_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports DASHBOARD_MODIFY_RATE_LIMIT', () => {
+    expect(DASHBOARD_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('validateDashboardName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateDashboardName('  My Dashboard  ')).toBe('My Dashboard');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateDashboardName('A')).toBe('A');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateDashboardName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateDashboardName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateDashboardName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateDashboardName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateProject', () => {
+  it('returns trimmed project for valid input', () => {
+    expect(validateProject('  kingdom-of-joakim  ')).toBe('kingdom-of-joakim');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateProject('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateProject('   ')).toThrow('must not be empty');
+  });
+});
+
+describe('validateLayoutConfig', () => {
+  it('accepts config without columns', () => {
+    expect(validateLayoutConfig({})).toEqual({});
+  });
+
+  it('accepts valid column count', () => {
+    expect(validateLayoutConfig({ columns: 3 })).toEqual({ columns: 3 });
+  });
+
+  it('accepts minimum column count (1)', () => {
+    expect(validateLayoutConfig({ columns: 1 })).toEqual({ columns: 1 });
+  });
+
+  it('accepts maximum column count (6)', () => {
+    expect(validateLayoutConfig({ columns: 6 })).toEqual({ columns: 6 });
+  });
+
+  it('throws for column count below minimum', () => {
+    expect(() => validateLayoutConfig({ columns: 0 })).toThrow('between 1 and 6');
+  });
+
+  it('throws for column count above maximum', () => {
+    expect(() => validateLayoutConfig({ columns: 7 })).toThrow('between 1 and 6');
+  });
+
+  it('throws for non-integer column count', () => {
+    expect(() => validateLayoutConfig({ columns: 2.5 })).toThrow('between 1 and 6');
+  });
+});
+
+describe('buildDashboardsUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildDashboardsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/dashboards');
+  });
+
+  it('encodes special characters in project name', () => {
+    expect(buildDashboardsUrl('my project')).toBe('/p/my%20project/dashboards');
+  });
+
+  it('handles project name with slashes', () => {
+    expect(buildDashboardsUrl('org/project')).toBe('/p/org%2Fproject/dashboards');
+  });
+});
+
+describe('createDashboardActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createDashboardActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[CREATE_DASHBOARD_ACTION_TYPE]).toBeDefined();
+    expect(executors[SET_HOME_DASHBOARD_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_DASHBOARD_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property', () => {
+    const executors = createDashboardActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createDashboardActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachDashboardsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachDashboardsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachDashboardsService);
+    });
+
+    it('exposes the dashboards URL', () => {
+      const service = new BloomreachDashboardsService('kingdom-of-joakim');
+      expect(service.dashboardsUrl).toBe('/p/kingdom-of-joakim/dashboards');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachDashboardsService('  my-project  ');
+      expect(service.dashboardsUrl).toBe('/p/my-project/dashboards');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachDashboardsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listDashboards', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachDashboardsService('test');
+      await expect(service.listDashboards()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareCreateDashboard', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'My Dashboard',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'dashboards.create_dashboard',
+          project: 'test',
+          name: 'My Dashboard',
+          analysisCount: 0,
+        }),
+      );
+    });
+
+    it('includes analyses count in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+        analyses: [
+          { id: 'a1', name: 'Analysis 1' },
+          { id: 'a2', name: 'Analysis 2' },
+        ],
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ analysisCount: 2 }));
+    });
+
+    it('includes layout in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+        layout: { columns: 3 },
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ layout: { columns: 3 } }));
+    });
+
+    it('defaults layout to 2 columns', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ layout: { columns: 2 } }));
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+        operatorNote: 'Created for weekly review',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Created for weekly review' }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareCreateDashboard({ project: 'test', name: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareCreateDashboard({ project: '', name: 'Dashboard' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid layout columns', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareCreateDashboard({
+          project: 'test',
+          name: 'Dashboard',
+          layout: { columns: 10 },
+        }),
+      ).toThrow('between 1 and 6');
+    });
+  });
+
+  describe('prepareSetHomeDashboard', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareSetHomeDashboard({
+        project: 'test',
+        dashboardId: 'dash-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'dashboards.set_home_dashboard',
+          project: 'test',
+          dashboardId: 'dash-123',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareSetHomeDashboard({
+        project: 'test',
+        dashboardId: 'dash-123',
+        operatorNote: 'Setting as default view',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Setting as default view' }),
+      );
+    });
+
+    it('throws for empty dashboardId', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareSetHomeDashboard({ project: 'test', dashboardId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareSetHomeDashboard({ project: '', dashboardId: 'dash-123' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareDeleteDashboard', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareDeleteDashboard({
+        project: 'test',
+        dashboardId: 'dash-456',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'dashboards.delete_dashboard',
+          project: 'test',
+          dashboardId: 'dash-456',
+        }),
+      );
+    });
+
+    it('throws for empty dashboardId', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareDeleteDashboard({ project: 'test', dashboardId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only dashboardId', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareDeleteDashboard({ project: 'test', dashboardId: '   ' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachDashboardsService('test');
+      expect(() =>
+        service.prepareDeleteDashboard({ project: '', dashboardId: 'dash-456' }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachDashboards.ts
+++ b/packages/core/src/bloomreachDashboards.ts
@@ -1,0 +1,269 @@
+export const CREATE_DASHBOARD_ACTION_TYPE = 'dashboards.create_dashboard';
+export const SET_HOME_DASHBOARD_ACTION_TYPE = 'dashboards.set_home_dashboard';
+export const DELETE_DASHBOARD_ACTION_TYPE = 'dashboards.delete_dashboard';
+
+/** Rate limit window for dashboard operations (1 hour in ms). */
+export const DASHBOARD_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const DASHBOARD_CREATE_RATE_LIMIT = 10;
+export const DASHBOARD_MODIFY_RATE_LIMIT = 20;
+
+export interface BloomreachDashboard {
+  id: string;
+  name: string;
+  isHome: boolean;
+  analysisCount: number;
+  /** ISO-8601 creation timestamp (if available). */
+  createdAt?: string;
+  /** Full URL path to the dashboard. */
+  url: string;
+}
+
+export interface DashboardAnalysis {
+  id: string;
+  name: string;
+}
+
+export interface DashboardLayoutConfig {
+  /** Number of columns in the dashboard grid (default: 2). */
+  columns?: number;
+}
+
+export interface ListDashboardsInput {
+  project: string;
+}
+
+export interface CreateDashboardInput {
+  project: string;
+  name: string;
+  analyses?: DashboardAnalysis[];
+  layout?: DashboardLayoutConfig;
+  operatorNote?: string;
+}
+
+export interface SetHomeDashboardInput {
+  project: string;
+  dashboardId: string;
+  operatorNote?: string;
+}
+
+export interface DeleteDashboardInput {
+  project: string;
+  dashboardId: string;
+  operatorNote?: string;
+}
+
+/** Staged action awaiting confirmation via two-phase commit. */
+export interface PreparedDashboardAction {
+  preparedActionId: string;
+  /** Cryptographic token required to confirm the action. */
+  confirmToken: string;
+  /** Timestamp (ms since epoch) when the token expires. */
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_DASHBOARD_NAME_LENGTH = 200;
+const MIN_DASHBOARD_NAME_LENGTH = 1;
+const MAX_LAYOUT_COLUMNS = 6;
+const MIN_LAYOUT_COLUMNS = 1;
+
+/** @throws {Error} If name is empty or exceeds 200 characters. */
+export function validateDashboardName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_DASHBOARD_NAME_LENGTH) {
+    throw new Error('Dashboard name must not be empty.');
+  }
+  if (trimmed.length > MAX_DASHBOARD_NAME_LENGTH) {
+    throw new Error(
+      `Dashboard name must not exceed ${MAX_DASHBOARD_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If project is empty. */
+export function validateProject(project: string): string {
+  const trimmed = project.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Project identifier must not be empty.');
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If column count is not an integer between 1 and 6. */
+export function validateLayoutConfig(
+  layout: DashboardLayoutConfig,
+): DashboardLayoutConfig {
+  if (layout.columns !== undefined) {
+    if (
+      !Number.isInteger(layout.columns) ||
+      layout.columns < MIN_LAYOUT_COLUMNS ||
+      layout.columns > MAX_LAYOUT_COLUMNS
+    ) {
+      throw new Error(
+        `Layout columns must be an integer between ${MIN_LAYOUT_COLUMNS} and ${MAX_LAYOUT_COLUMNS} (got ${layout.columns}).`,
+      );
+    }
+  }
+  return layout;
+}
+
+export function buildDashboardsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/dashboards`;
+}
+
+/**
+ * Executor for a confirmed dashboard mutation.
+ * Execute methods require browser automation infrastructure (not yet built).
+ */
+export interface DashboardActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateDashboardExecutor implements DashboardActionExecutor {
+  readonly actionType = CREATE_DASHBOARD_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateDashboardExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class SetHomeDashboardExecutor implements DashboardActionExecutor {
+  readonly actionType = SET_HOME_DASHBOARD_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'SetHomeDashboardExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteDashboardExecutor implements DashboardActionExecutor {
+  readonly actionType = DELETE_DASHBOARD_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteDashboardExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createDashboardActionExecutors(): Record<
+  string,
+  DashboardActionExecutor
+> {
+  return {
+    [CREATE_DASHBOARD_ACTION_TYPE]: new CreateDashboardExecutor(),
+    [SET_HOME_DASHBOARD_ACTION_TYPE]: new SetHomeDashboardExecutor(),
+    [DELETE_DASHBOARD_ACTION_TYPE]: new DeleteDashboardExecutor(),
+  };
+}
+
+/**
+ * Manages Bloomreach Engagement dashboards. Read methods return data directly.
+ * Mutation methods follow the two-phase commit pattern (prepare + confirm).
+ * Browser-dependent methods throw until Playwright infrastructure is available.
+ */
+export class BloomreachDashboardsService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildDashboardsUrl(validateProject(project));
+  }
+
+  get dashboardsUrl(): string {
+    return this.baseUrl;
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listDashboards(
+    _input?: ListDashboardsInput,
+  ): Promise<BloomreachDashboard[]> {
+    throw new Error(
+      'listDashboards: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateDashboard(input: CreateDashboardInput): PreparedDashboardAction {
+    const project = validateProject(input.project);
+    const name = validateDashboardName(input.name);
+    if (input.layout) {
+      validateLayoutConfig(input.layout);
+    }
+
+    // TODO: Wire into TwoPhaseCommitService when available
+    const preview = {
+      action: CREATE_DASHBOARD_ACTION_TYPE,
+      project,
+      name,
+      analysisCount: input.analyses?.length ?? 0,
+      layout: input.layout ?? { columns: 2 },
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareSetHomeDashboard(
+    input: SetHomeDashboardInput,
+  ): PreparedDashboardAction {
+    const project = validateProject(input.project);
+    const dashboardId = input.dashboardId.trim();
+    if (dashboardId.length === 0) {
+      throw new Error('Dashboard ID must not be empty.');
+    }
+
+    const preview = {
+      action: SET_HOME_DASHBOARD_ACTION_TYPE,
+      project,
+      dashboardId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareDeleteDashboard(input: DeleteDashboardInput): PreparedDashboardAction {
+    const project = validateProject(input.project);
+    const dashboardId = input.dashboardId.trim();
+    if (dashboardId.length === 0) {
+      throw new Error('Dashboard ID must not be empty.');
+    }
+
+    const preview = {
+      action: DELETE_DASHBOARD_ACTION_TYPE,
+      project,
+      dashboardId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+export * from './bloomreachDashboards.js';
+
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */
   environment: string;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: true,
+  dts: { compilerOptions: { composite: false } },
   clean: true,
   sourcemap: true,
 });


### PR DESCRIPTION
## Summary

Add dashboard management feature module for Bloomreach Engagement, implementing the core service, CLI commands, and comprehensive tests.

## Changes

### Core Feature Module (`packages/core/src/bloomreachDashboards.ts`)
- **Domain types**: `BloomreachDashboard`, `DashboardAnalysis`, `DashboardLayoutConfig`
- **Input interfaces**: `ListDashboardsInput`, `CreateDashboardInput`, `SetHomeDashboardInput`, `DeleteDashboardInput`
- **Prepared action type**: `PreparedDashboardAction` for two-phase commit flow
- **Validation helpers**: `validateDashboardName`, `validateProject`, `validateLayoutConfig` (pure, fully tested)
- **URL helper**: `buildDashboardsUrl` with proper URI encoding
- **Action executors**: `DashboardActionExecutor` interface + `createDashboardActionExecutors()` factory for 3 action types
- **Service class**: `BloomreachDashboardsService` with `listDashboards`, `prepareCreateDashboard`, `prepareSetHomeDashboard`, `prepareDeleteDashboard`
- **Constants**: Action types, rate limit configuration

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- `bloomreach dashboards list` — List project dashboards
- `bloomreach dashboards create` — Prepare dashboard creation (two-phase commit)
- `bloomreach dashboards set-home` — Prepare setting home dashboard
- `bloomreach dashboards delete` — Prepare dashboard deletion
- All commands support `--json` output and proper error handling

### Tests (`packages/core/src/__tests__/bloomreachDashboards.test.ts`)
- 49 unit tests covering all exported functions and the service class
- Validation edge cases (empty, whitespace, bounds)
- URL encoding, executor registry, prepare flow previews

### Build Fix
- Fixed tsup DTS generation for composite project references (`composite: false` override in tsup config)

## Architecture Notes

Browser-dependent methods (`listDashboards`, action executors) throw informative "not yet implemented" errors — they require the Playwright browser automation infrastructure which will be built in a future milestone. All pure logic (validation, URL building, prepare previews) is fully implemented and tested.

## Quality Gates
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm test` — 102 tests pass (49 new + 2 original, 51 unique tests run 2x due to dist/ inclusion)
- [x] `npm run build` — core + CLI build successfully

Closes #27
