### PR TITLE
feat: manage weblayers (#32)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -27,6 +27,7 @@ import {
   BloomreachTagManagerService,
   BloomreachTrendsService,
   BloomreachVouchersService,
+  BloomreachWeblayersService,
 } from '@bloomreach-buddy/core';
 import type {
   CustomerIds,
@@ -52,6 +53,8 @@ import type {
   SurveyQuestion,
   TagTriggerConditions,
   TrendFilter,
+  WeblayerDisplayConditions,
+  WeblayerABTestConfig,
 } from '@bloomreach-buddy/core';
 
 function printJson(value: unknown): void {
@@ -8359,6 +8362,357 @@ evaluationSettingsVoucherMapping
         }
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const weblayers = program
+  .command('weblayers')
+  .description('Manage Bloomreach Engagement weblayers');
+
+weblayers
+  .command('list')
+  .description('List all weblayers in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--status <status>', 'Filter by status (active, inactive, draft, archived)')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; status?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachWeblayersService(options.project);
+      const input: { project: string; status?: string } = { project: options.project };
+      if (options.status) input.status = options.status;
+
+      const result = await service.listWeblayers(input);
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No weblayers found.');
+          return;
+        }
+        for (const weblayer of result) {
+          console.log(`  ${weblayer.name}`);
+          console.log(`    Status: ${weblayer.status}`);
+          if (weblayer.displayType) {
+            console.log(`    Type:   ${weblayer.displayType}`);
+          }
+          console.log(`    ID:     ${weblayer.id}`);
+          console.log(`    URL:    ${weblayer.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(1);
+    }
+  });
+
+weblayers
+  .command('view-performance')
+  .description('View impressions, clicks and conversions for a weblayer')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--weblayer-id <id>', 'Weblayer ID')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      weblayerId: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachWeblayersService(options.project);
+        const result = await service.viewWeblayerPerformance({
+          project: options.project,
+          weblayerId: options.weblayerId,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log(`Weblayer Performance: ${result.weblayerId}`);
+          console.log(`  Impressions:  ${result.impressions}`);
+          console.log(`  Clicks:       ${result.clicks}`);
+          console.log(`  Conversions:  ${result.conversions}`);
+          console.log(`  CTR:          ${(result.clickThroughRate * 100).toFixed(1)}%`);
+          console.log(`  Conv. Rate:   ${(result.conversionRate * 100).toFixed(1)}%`);
+          console.log(`  Revenue:      ${result.revenue}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+weblayers
+  .command('create')
+  .description('Prepare creation of a new weblayer (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Weblayer name')
+  .option('--display-type <type>', 'Display type (overlay, banner, popup, slide_in)')
+  .option('--template-id <id>', 'Template ID to use')
+  .option('--audience <audience>', 'Audience segment identifier')
+  .option('--page-url-filter <filter>', 'Page URL filter pattern')
+  .option('--delay-ms <ms>', 'Display delay in milliseconds')
+  .option('--scroll-percentage <n>', 'Show after scroll percentage (0-100)')
+  .option('--frequency-cap <n>', 'Max impressions per visitor')
+  .option('--ab-variants <n>', 'Number of A/B test variants')
+  .option('--ab-split <percent>', 'A/B test split percentage')
+  .option('--ab-winner <criteria>', 'A/B test winner criteria')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      displayType?: string;
+      templateId?: string;
+      audience?: string;
+      pageUrlFilter?: string;
+      delayMs?: string;
+      scrollPercentage?: string;
+      frequencyCap?: string;
+      abVariants?: string;
+      abSplit?: string;
+      abWinner?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        let displayConditions: WeblayerDisplayConditions | undefined;
+        if (
+          options.audience ||
+          options.pageUrlFilter ||
+          options.delayMs ||
+          options.scrollPercentage ||
+          options.frequencyCap
+        ) {
+          displayConditions = {
+            audience: options.audience,
+            pageUrlFilter: options.pageUrlFilter,
+            delayMs: options.delayMs ? parseInt(options.delayMs, 10) : undefined,
+            scrollPercentage: options.scrollPercentage
+              ? parseInt(options.scrollPercentage, 10)
+              : undefined,
+            frequencyCap: options.frequencyCap
+              ? parseInt(options.frequencyCap, 10)
+              : undefined,
+          };
+        }
+
+        let abTest: WeblayerABTestConfig | undefined;
+        if (options.abVariants) {
+          abTest = {
+            enabled: true,
+            variants: parseInt(options.abVariants, 10),
+            splitPercentage: options.abSplit ? parseInt(options.abSplit, 10) : undefined,
+            winnerCriteria: options.abWinner,
+          };
+        }
+
+        const service = new BloomreachWeblayersService(options.project);
+        const result = service.prepareCreateWeblayer({
+          project: options.project,
+          name: options.name,
+          displayType: options.displayType,
+          templateId: options.templateId,
+          displayConditions,
+          abTest,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Weblayer creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+weblayers
+  .command('start')
+  .description('Prepare starting a weblayer (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--weblayer-id <id>', 'Weblayer ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      weblayerId: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachWeblayersService(options.project);
+        const result = service.prepareStartWeblayer({
+          project: options.project,
+          weblayerId: options.weblayerId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Weblayer start prepared.');
+          console.log(`  Weblayer: ${options.weblayerId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+weblayers
+  .command('stop')
+  .description('Prepare stopping a weblayer (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--weblayer-id <id>', 'Weblayer ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      weblayerId: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachWeblayersService(options.project);
+        const result = service.prepareStopWeblayer({
+          project: options.project,
+          weblayerId: options.weblayerId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Weblayer stop prepared.');
+          console.log(`  Weblayer: ${options.weblayerId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+weblayers
+  .command('clone')
+  .description('Prepare cloning a weblayer (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--weblayer-id <id>', 'Weblayer ID to clone')
+  .option('--new-name <name>', 'Name for the cloned weblayer')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      weblayerId: string;
+      newName?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachWeblayersService(options.project);
+        const result = service.prepareCloneWeblayer({
+          project: options.project,
+          weblayerId: options.weblayerId,
+          newName: options.newName,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Weblayer clone prepared.');
+          console.log(`  Source:   ${options.weblayerId}`);
+          console.log(`  New name: ${options.newName ?? '(auto-generated)'}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+weblayers
+  .command('archive')
+  .description('Prepare archiving a weblayer (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--weblayer-id <id>', 'Weblayer ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      weblayerId: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachWeblayersService(options.project);
+        const result = service.prepareArchiveWeblayer({
+          project: options.project,
+          weblayerId: options.weblayerId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Weblayer archive prepared.');
+          console.log(`  Weblayer: ${options.weblayerId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
         process.exit(1);
       }
     },

--- a/packages/core/src/__tests__/bloomreachWeblayers.test.ts
+++ b/packages/core/src/__tests__/bloomreachWeblayers.test.ts
@@ -1,0 +1,662 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_WEBLAYER_ACTION_TYPE,
+  START_WEBLAYER_ACTION_TYPE,
+  STOP_WEBLAYER_ACTION_TYPE,
+  CLONE_WEBLAYER_ACTION_TYPE,
+  ARCHIVE_WEBLAYER_ACTION_TYPE,
+  WEBLAYER_RATE_LIMIT_WINDOW_MS,
+  WEBLAYER_CREATE_RATE_LIMIT,
+  WEBLAYER_MODIFY_RATE_LIMIT,
+  WEBLAYER_STATUSES,
+  WEBLAYER_DISPLAY_TYPES,
+  validateWeblayerName,
+  validateWeblayerStatus,
+  validateWeblayerId,
+  validateWeblayerDisplayType,
+  validateWeblayerABTestConfig,
+  validateDisplayConditions,
+  buildWeblayersUrl,
+  createWeblayerActionExecutors,
+  BloomreachWeblayersService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_WEBLAYER_ACTION_TYPE', () => {
+    expect(CREATE_WEBLAYER_ACTION_TYPE).toBe('weblayers.create_weblayer');
+  });
+
+  it('exports START_WEBLAYER_ACTION_TYPE', () => {
+    expect(START_WEBLAYER_ACTION_TYPE).toBe('weblayers.start_weblayer');
+  });
+
+  it('exports STOP_WEBLAYER_ACTION_TYPE', () => {
+    expect(STOP_WEBLAYER_ACTION_TYPE).toBe('weblayers.stop_weblayer');
+  });
+
+  it('exports CLONE_WEBLAYER_ACTION_TYPE', () => {
+    expect(CLONE_WEBLAYER_ACTION_TYPE).toBe('weblayers.clone_weblayer');
+  });
+
+  it('exports ARCHIVE_WEBLAYER_ACTION_TYPE', () => {
+    expect(ARCHIVE_WEBLAYER_ACTION_TYPE).toBe('weblayers.archive_weblayer');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports WEBLAYER_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(WEBLAYER_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports WEBLAYER_CREATE_RATE_LIMIT', () => {
+    expect(WEBLAYER_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports WEBLAYER_MODIFY_RATE_LIMIT', () => {
+    expect(WEBLAYER_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('WEBLAYER_STATUSES', () => {
+  it('contains 4 statuses', () => {
+    expect(WEBLAYER_STATUSES).toHaveLength(4);
+  });
+
+  it('contains expected statuses in order', () => {
+    expect(WEBLAYER_STATUSES).toEqual(['active', 'inactive', 'draft', 'archived']);
+  });
+});
+
+describe('WEBLAYER_DISPLAY_TYPES', () => {
+  it('contains 4 display types', () => {
+    expect(WEBLAYER_DISPLAY_TYPES).toHaveLength(4);
+  });
+
+  it('contains expected display types in order', () => {
+    expect(WEBLAYER_DISPLAY_TYPES).toEqual(['overlay', 'banner', 'popup', 'slide_in']);
+  });
+});
+
+describe('validateWeblayerName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateWeblayerName('  My Weblayer  ')).toBe('My Weblayer');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateWeblayerName('A')).toBe('A');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateWeblayerName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateWeblayerName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateWeblayerName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateWeblayerName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateWeblayerStatus', () => {
+  it('accepts active', () => {
+    expect(validateWeblayerStatus('active')).toBe('active');
+  });
+
+  it('accepts inactive', () => {
+    expect(validateWeblayerStatus('inactive')).toBe('inactive');
+  });
+
+  it('accepts draft', () => {
+    expect(validateWeblayerStatus('draft')).toBe('draft');
+  });
+
+  it('accepts archived', () => {
+    expect(validateWeblayerStatus('archived')).toBe('archived');
+  });
+
+  it('throws for unknown status', () => {
+    expect(() => validateWeblayerStatus('paused')).toThrow('status must be one of');
+  });
+
+  it('throws for empty status', () => {
+    expect(() => validateWeblayerStatus('')).toThrow('status must be one of');
+  });
+});
+
+describe('validateWeblayerId', () => {
+  it('returns trimmed weblayer ID for valid input', () => {
+    expect(validateWeblayerId('  weblayer-123  ')).toBe('weblayer-123');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateWeblayerId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateWeblayerId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateWeblayerId('weblayer-456')).toBe('weblayer-456');
+  });
+});
+
+describe('validateWeblayerDisplayType', () => {
+  it('accepts overlay', () => {
+    expect(validateWeblayerDisplayType('overlay')).toBe('overlay');
+  });
+
+  it('accepts banner', () => {
+    expect(validateWeblayerDisplayType('banner')).toBe('banner');
+  });
+
+  it('accepts popup', () => {
+    expect(validateWeblayerDisplayType('popup')).toBe('popup');
+  });
+
+  it('accepts slide_in', () => {
+    expect(validateWeblayerDisplayType('slide_in')).toBe('slide_in');
+  });
+
+  it('throws for unknown display type', () => {
+    expect(() => validateWeblayerDisplayType('modal')).toThrow('displayType must be one of');
+  });
+
+  it('throws for empty display type', () => {
+    expect(() => validateWeblayerDisplayType('')).toThrow('displayType must be one of');
+  });
+});
+
+describe('validateWeblayerABTestConfig', () => {
+  it('accepts valid config', () => {
+    const config = {
+      enabled: true,
+      variants: 2,
+      splitPercentage: 50,
+      winnerCriteria: 'click_rate',
+    };
+    expect(validateWeblayerABTestConfig(config)).toEqual(config);
+  });
+
+  it('throws for too few variants', () => {
+    expect(() =>
+      validateWeblayerABTestConfig({
+        enabled: true,
+        variants: 1,
+      }),
+    ).toThrow('A/B test variants must be an integer between 2 and 10');
+  });
+
+  it('throws for too many variants', () => {
+    expect(() =>
+      validateWeblayerABTestConfig({
+        enabled: true,
+        variants: 11,
+      }),
+    ).toThrow('A/B test variants must be an integer between 2 and 10');
+  });
+
+  it('throws for split percentage below 0', () => {
+    expect(() =>
+      validateWeblayerABTestConfig({
+        enabled: true,
+        variants: 2,
+        splitPercentage: -1,
+      }),
+    ).toThrow('A/B test split percentage must be between 0 and 100');
+  });
+
+  it('throws for split percentage above 100', () => {
+    expect(() =>
+      validateWeblayerABTestConfig({
+        enabled: true,
+        variants: 2,
+        splitPercentage: 101,
+      }),
+    ).toThrow('A/B test split percentage must be between 0 and 100');
+  });
+});
+
+describe('validateDisplayConditions', () => {
+  it('accepts valid conditions', () => {
+    const conditions = {
+      audience: 'new-visitors',
+      pageUrlFilter: '/pricing',
+      delayMs: 500,
+      scrollPercentage: 25,
+      frequencyCap: 3,
+    };
+    expect(validateDisplayConditions(conditions)).toEqual(conditions);
+  });
+
+  it('throws for negative delayMs', () => {
+    expect(() => validateDisplayConditions({ delayMs: -1 })).toThrow(
+      'delayMs must be greater than or equal to 0',
+    );
+  });
+
+  it('throws for scrollPercentage below 0', () => {
+    expect(() => validateDisplayConditions({ scrollPercentage: -1 })).toThrow(
+      'scrollPercentage must be between 0 and 100',
+    );
+  });
+
+  it('throws for scrollPercentage above 100', () => {
+    expect(() => validateDisplayConditions({ scrollPercentage: 101 })).toThrow(
+      'scrollPercentage must be between 0 and 100',
+    );
+  });
+
+  it('throws for zero frequencyCap', () => {
+    expect(() => validateDisplayConditions({ frequencyCap: 0 })).toThrow(
+      'frequencyCap must be greater than or equal to 1',
+    );
+  });
+});
+
+describe('buildWeblayersUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildWeblayersUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/campaigns/banners');
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildWeblayersUrl('my project')).toBe('/p/my%20project/campaigns/banners');
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildWeblayersUrl('org/project')).toBe('/p/org%2Fproject/campaigns/banners');
+  });
+});
+
+describe('createWeblayerActionExecutors', () => {
+  it('returns executors for all five action types', () => {
+    const executors = createWeblayerActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(5);
+    expect(executors[CREATE_WEBLAYER_ACTION_TYPE]).toBeDefined();
+    expect(executors[START_WEBLAYER_ACTION_TYPE]).toBeDefined();
+    expect(executors[STOP_WEBLAYER_ACTION_TYPE]).toBeDefined();
+    expect(executors[CLONE_WEBLAYER_ACTION_TYPE]).toBeDefined();
+    expect(executors[ARCHIVE_WEBLAYER_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createWeblayerActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createWeblayerActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachWeblayersService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachWeblayersService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachWeblayersService);
+    });
+
+    it('exposes the weblayers URL', () => {
+      const service = new BloomreachWeblayersService('kingdom-of-joakim');
+      expect(service.weblayersUrl).toBe('/p/kingdom-of-joakim/campaigns/banners');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachWeblayersService('  my-project  ');
+      expect(service.weblayersUrl).toBe('/p/my-project/campaigns/banners');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachWeblayersService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listWeblayers', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachWeblayersService('test');
+      await expect(service.listWeblayers()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates status when provided', async () => {
+      const service = new BloomreachWeblayersService('test');
+      await expect(
+        service.listWeblayers({ project: 'test', status: 'paused' }),
+      ).rejects.toThrow('status must be one of');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachWeblayersService('test');
+      await expect(
+        service.listWeblayers({ project: '', status: 'active' }),
+      ).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('viewWeblayerPerformance', () => {
+    it('throws not-yet-implemented error with valid input', async () => {
+      const service = new BloomreachWeblayersService('test');
+      await expect(
+        service.viewWeblayerPerformance({ project: 'test', weblayerId: 'weblayer-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachWeblayersService('test');
+      await expect(
+        service.viewWeblayerPerformance({ project: '', weblayerId: 'weblayer-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates weblayerId input', async () => {
+      const service = new BloomreachWeblayersService('test');
+      await expect(
+        service.viewWeblayerPerformance({ project: 'test', weblayerId: '   ' }),
+      ).rejects.toThrow('Weblayer ID must not be empty');
+    });
+  });
+
+  describe('prepareCreateWeblayer', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareCreateWeblayer({
+        project: 'test',
+        name: 'My Weblayer',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'weblayers.create_weblayer',
+          project: 'test',
+          name: 'My Weblayer',
+        }),
+      );
+    });
+
+    it('includes displayType, displayConditions, abTest, and operatorNote in preview', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareCreateWeblayer({
+        project: 'test',
+        name: 'AB Tested Weblayer',
+        displayType: 'overlay',
+        displayConditions: {
+          delayMs: 1000,
+          scrollPercentage: 50,
+          frequencyCap: 2,
+        },
+        abTest: {
+          enabled: true,
+          variants: 2,
+          splitPercentage: 50,
+          winnerCriteria: 'conversion_rate',
+        },
+        operatorNote: 'Prepare for homepage test',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          displayType: 'overlay',
+          displayConditions: {
+            delayMs: 1000,
+            scrollPercentage: 50,
+            frequencyCap: 2,
+          },
+          abTest: {
+            enabled: true,
+            variants: 2,
+            splitPercentage: 50,
+            winnerCriteria: 'conversion_rate',
+          },
+          operatorNote: 'Prepare for homepage test',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() => service.prepareCreateWeblayer({ project: 'test', name: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareCreateWeblayer({ project: '', name: 'Weblayer' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for too-long name', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareCreateWeblayer({
+          project: 'test',
+          name: 'x'.repeat(201),
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws for invalid displayType', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareCreateWeblayer({
+          project: 'test',
+          name: 'Weblayer',
+          displayType: 'modal',
+        }),
+      ).toThrow('displayType must be one of');
+    });
+  });
+
+  describe('prepareStartWeblayer', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareStartWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'weblayers.start_weblayer',
+          project: 'test',
+          weblayerId: 'weblayer-123',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareStartWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-123',
+        operatorNote: 'Start after QA signoff',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Start after QA signoff' }),
+      );
+    });
+
+    it('throws for empty weblayerId', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareStartWeblayer({ project: 'test', weblayerId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareStartWeblayer({ project: '', weblayerId: 'weblayer-123' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareStopWeblayer', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareStopWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-456',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'weblayers.stop_weblayer',
+          project: 'test',
+          weblayerId: 'weblayer-456',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareStopWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-456',
+        operatorNote: 'Pause for promotion update',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Pause for promotion update' }),
+      );
+    });
+
+    it('throws for empty weblayerId', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareStopWeblayer({ project: 'test', weblayerId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareStopWeblayer({ project: '', weblayerId: 'weblayer-456' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareCloneWeblayer', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareCloneWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-789',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'weblayers.clone_weblayer',
+          project: 'test',
+          weblayerId: 'weblayer-789',
+        }),
+      );
+    });
+
+    it('includes newName in preview when provided', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareCloneWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-789',
+        newName: '  Cloned Weblayer  ',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ newName: 'Cloned Weblayer' }));
+    });
+
+    it('throws for empty weblayerId', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareCloneWeblayer({ project: 'test', weblayerId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareCloneWeblayer({ project: '', weblayerId: 'weblayer-789' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName is whitespace only', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareCloneWeblayer({
+          project: 'test',
+          weblayerId: 'weblayer-789',
+          newName: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareArchiveWeblayer', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareArchiveWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'weblayers.archive_weblayer',
+          project: 'test',
+          weblayerId: 'weblayer-900',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachWeblayersService('test');
+      const result = service.prepareArchiveWeblayer({
+        project: 'test',
+        weblayerId: 'weblayer-900',
+        operatorNote: 'Archive completed spring campaign',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Archive completed spring campaign' }),
+      );
+    });
+
+    it('throws for empty weblayerId', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareArchiveWeblayer({ project: 'test', weblayerId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachWeblayersService('test');
+      expect(() =>
+        service.prepareArchiveWeblayer({ project: '', weblayerId: 'weblayer-900' }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachWeblayers.ts
+++ b/packages/core/src/bloomreachWeblayers.ts
@@ -1,0 +1,421 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const CREATE_WEBLAYER_ACTION_TYPE = 'weblayers.create_weblayer';
+export const START_WEBLAYER_ACTION_TYPE = 'weblayers.start_weblayer';
+export const STOP_WEBLAYER_ACTION_TYPE = 'weblayers.stop_weblayer';
+export const CLONE_WEBLAYER_ACTION_TYPE = 'weblayers.clone_weblayer';
+export const ARCHIVE_WEBLAYER_ACTION_TYPE = 'weblayers.archive_weblayer';
+
+export const WEBLAYER_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const WEBLAYER_CREATE_RATE_LIMIT = 10;
+export const WEBLAYER_MODIFY_RATE_LIMIT = 20;
+
+export const WEBLAYER_STATUSES = ['active', 'inactive', 'draft', 'archived'] as const;
+export type WeblayerStatus = (typeof WEBLAYER_STATUSES)[number];
+
+export const WEBLAYER_DISPLAY_TYPES = ['overlay', 'banner', 'popup', 'slide_in'] as const;
+export type WeblayerDisplayType = (typeof WEBLAYER_DISPLAY_TYPES)[number];
+
+export interface WeblayerDisplayConditions {
+  audience?: string;
+  pageUrlFilter?: string;
+  /** Delay in milliseconds before showing the weblayer. */
+  delayMs?: number;
+  /** Show after scrolling this percentage of the page (0-100). */
+  scrollPercentage?: number;
+  /** Maximum number of times to show per visitor. */
+  frequencyCap?: number;
+}
+
+export interface WeblayerABTestConfig {
+  enabled: boolean;
+  variants: number;
+  splitPercentage?: number;
+  winnerCriteria?: string;
+}
+
+export interface BloomreachWeblayer {
+  id: string;
+  name: string;
+  status: WeblayerStatus;
+  displayType?: WeblayerDisplayType;
+  displayConditions?: WeblayerDisplayConditions;
+  abTest?: WeblayerABTestConfig;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface WeblayerPerformance {
+  weblayerId: string;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  clickThroughRate: number;
+  conversionRate: number;
+  revenue: number;
+}
+
+export interface ListWeblayersInput {
+  project: string;
+  status?: string;
+}
+
+export interface ViewWeblayerPerformanceInput {
+  project: string;
+  weblayerId: string;
+}
+
+export interface CreateWeblayerInput {
+  project: string;
+  name: string;
+  displayType?: string;
+  templateId?: string;
+  displayConditions?: WeblayerDisplayConditions;
+  abTest?: WeblayerABTestConfig;
+  operatorNote?: string;
+}
+
+export interface StartWeblayerInput {
+  project: string;
+  weblayerId: string;
+  operatorNote?: string;
+}
+
+export interface StopWeblayerInput {
+  project: string;
+  weblayerId: string;
+  operatorNote?: string;
+}
+
+export interface CloneWeblayerInput {
+  project: string;
+  weblayerId: string;
+  newName?: string;
+  operatorNote?: string;
+}
+
+export interface ArchiveWeblayerInput {
+  project: string;
+  weblayerId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedWeblayerAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_WEBLAYER_NAME_LENGTH = 200;
+const MIN_WEBLAYER_NAME_LENGTH = 1;
+const MIN_AB_TEST_VARIANTS = 2;
+const MAX_AB_TEST_VARIANTS = 10;
+
+export function validateWeblayerName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_WEBLAYER_NAME_LENGTH) {
+    throw new Error('Weblayer name must not be empty.');
+  }
+  if (trimmed.length > MAX_WEBLAYER_NAME_LENGTH) {
+    throw new Error(
+      `Weblayer name must not exceed ${MAX_WEBLAYER_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateWeblayerStatus(status: string): WeblayerStatus {
+  if (!WEBLAYER_STATUSES.includes(status as WeblayerStatus)) {
+    throw new Error(
+      `status must be one of: ${WEBLAYER_STATUSES.join(', ')} (got "${status}").`,
+    );
+  }
+  return status as WeblayerStatus;
+}
+
+export function validateWeblayerId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Weblayer ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateWeblayerDisplayType(displayType: string): WeblayerDisplayType {
+  if (!WEBLAYER_DISPLAY_TYPES.includes(displayType as WeblayerDisplayType)) {
+    throw new Error(
+      `displayType must be one of: ${WEBLAYER_DISPLAY_TYPES.join(', ')} (got "${displayType}").`,
+    );
+  }
+  return displayType as WeblayerDisplayType;
+}
+
+export function validateWeblayerABTestConfig(config: WeblayerABTestConfig): WeblayerABTestConfig {
+  if (
+    !Number.isInteger(config.variants) ||
+    config.variants < MIN_AB_TEST_VARIANTS ||
+    config.variants > MAX_AB_TEST_VARIANTS
+  ) {
+    throw new Error(
+      `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${config.variants}).`,
+    );
+  }
+  if (config.splitPercentage !== undefined) {
+    if (config.splitPercentage < 0 || config.splitPercentage > 100) {
+      throw new Error(
+        `A/B test split percentage must be between 0 and 100 (got ${config.splitPercentage}).`,
+      );
+    }
+  }
+  return config;
+}
+
+export function validateDisplayConditions(
+  conditions: WeblayerDisplayConditions,
+): WeblayerDisplayConditions {
+  if (conditions.delayMs !== undefined && conditions.delayMs < 0) {
+    throw new Error(`delayMs must be greater than or equal to 0 (got ${conditions.delayMs}).`);
+  }
+  if (conditions.scrollPercentage !== undefined) {
+    if (conditions.scrollPercentage < 0 || conditions.scrollPercentage > 100) {
+      throw new Error(
+        `scrollPercentage must be between 0 and 100 (got ${conditions.scrollPercentage}).`,
+      );
+    }
+  }
+  if (conditions.frequencyCap !== undefined && conditions.frequencyCap < 1) {
+    throw new Error(
+      `frequencyCap must be greater than or equal to 1 (got ${conditions.frequencyCap}).`,
+    );
+  }
+  return conditions;
+}
+
+export function buildWeblayersUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/campaigns/banners`;
+}
+
+export interface WeblayerActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateWeblayerExecutor implements WeblayerActionExecutor {
+  readonly actionType = CREATE_WEBLAYER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateWeblayerExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class StartWeblayerExecutor implements WeblayerActionExecutor {
+  readonly actionType = START_WEBLAYER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'StartWeblayerExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class StopWeblayerExecutor implements WeblayerActionExecutor {
+  readonly actionType = STOP_WEBLAYER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'StopWeblayerExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CloneWeblayerExecutor implements WeblayerActionExecutor {
+  readonly actionType = CLONE_WEBLAYER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CloneWeblayerExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ArchiveWeblayerExecutor implements WeblayerActionExecutor {
+  readonly actionType = ARCHIVE_WEBLAYER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ArchiveWeblayerExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createWeblayerActionExecutors(): Record<string, WeblayerActionExecutor> {
+  return {
+    [CREATE_WEBLAYER_ACTION_TYPE]: new CreateWeblayerExecutor(),
+    [START_WEBLAYER_ACTION_TYPE]: new StartWeblayerExecutor(),
+    [STOP_WEBLAYER_ACTION_TYPE]: new StopWeblayerExecutor(),
+    [CLONE_WEBLAYER_ACTION_TYPE]: new CloneWeblayerExecutor(),
+    [ARCHIVE_WEBLAYER_ACTION_TYPE]: new ArchiveWeblayerExecutor(),
+  };
+}
+
+export class BloomreachWeblayersService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildWeblayersUrl(validateProject(project));
+  }
+
+  get weblayersUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listWeblayers(input?: ListWeblayersInput): Promise<BloomreachWeblayer[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+      if (input.status !== undefined) {
+        validateWeblayerStatus(input.status);
+      }
+    }
+
+    throw new Error(
+      'listWeblayers: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewWeblayerPerformance(
+    input: ViewWeblayerPerformanceInput,
+  ): Promise<WeblayerPerformance> {
+    validateProject(input.project);
+    validateWeblayerId(input.weblayerId);
+
+    throw new Error(
+      'viewWeblayerPerformance: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateWeblayer(input: CreateWeblayerInput): PreparedWeblayerAction {
+    const project = validateProject(input.project);
+    const name = validateWeblayerName(input.name);
+    const displayType =
+      input.displayType !== undefined
+        ? validateWeblayerDisplayType(input.displayType)
+        : undefined;
+    const displayConditions =
+      input.displayConditions !== undefined
+        ? validateDisplayConditions(input.displayConditions)
+        : undefined;
+    const abTest =
+      input.abTest !== undefined ? validateWeblayerABTestConfig(input.abTest) : undefined;
+
+    const preview = {
+      action: CREATE_WEBLAYER_ACTION_TYPE,
+      project,
+      name,
+      displayType,
+      templateId: input.templateId,
+      displayConditions,
+      abTest,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareStartWeblayer(input: StartWeblayerInput): PreparedWeblayerAction {
+    const project = validateProject(input.project);
+    const weblayerId = validateWeblayerId(input.weblayerId);
+
+    const preview = {
+      action: START_WEBLAYER_ACTION_TYPE,
+      project,
+      weblayerId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareStopWeblayer(input: StopWeblayerInput): PreparedWeblayerAction {
+    const project = validateProject(input.project);
+    const weblayerId = validateWeblayerId(input.weblayerId);
+
+    const preview = {
+      action: STOP_WEBLAYER_ACTION_TYPE,
+      project,
+      weblayerId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCloneWeblayer(input: CloneWeblayerInput): PreparedWeblayerAction {
+    const project = validateProject(input.project);
+    const weblayerId = validateWeblayerId(input.weblayerId);
+    const newName =
+      input.newName !== undefined ? validateWeblayerName(input.newName) : undefined;
+
+    const preview = {
+      action: CLONE_WEBLAYER_ACTION_TYPE,
+      project,
+      weblayerId,
+      newName,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareArchiveWeblayer(input: ArchiveWeblayerInput): PreparedWeblayerAction {
+    const project = validateProject(input.project);
+    const weblayerId = validateWeblayerId(input.weblayerId);
+
+    const preview = {
+      action: ARCHIVE_WEBLAYER_ACTION_TYPE,
+      project,
+      weblayerId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export * from './bloomreachProjectSettings.js';
 export * from './bloomreachChannelSettings.js';
 export * from './bloomreachSecuritySettings.js';
 export * from './bloomreachEvaluationSettings.js';
+export * from './bloomreachWeblayers.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Add weblayer management feature module for Bloomreach Engagement — on-site overlays, banners, and popups for website personalization.

- New core module `bloomreachWeblayers.ts` with full service class, validators, and two-phase commit pattern
- 83 unit tests covering all validators, executors, and service methods
- 7 CLI subcommands for weblayer management

## Changes

### Core Module (`packages/core/src/bloomreachWeblayers.ts`)
- 5 action type constants: create, start, stop, clone, archive
- Rate limit constants (1h window, 10 create / 20 modify)
- Status enum: active, inactive, draft, archived
- Display types: overlay, banner, popup, slide_in
- Display conditions: audience, page URL filter, delay, scroll percentage, frequency cap
- A/B test configuration with variant count and split percentage
- Performance metrics: impressions, clicks, conversions, CTR, conversion rate, revenue
- Full validation suite: name, status, ID, display type, A/B test config, display conditions
- 5 action executors (stubbed — awaiting browser automation infrastructure)
- `BloomreachWeblayersService` with `listWeblayers`, `viewWeblayerPerformance`, and 5 `prepare*` methods
- URL builder for `/p/{project}/campaigns/banners`

### Unit Tests (`packages/core/src/__tests__/bloomreachWeblayers.test.ts`)
- 83 tests covering all exported functions, constants, and service methods
- Follows exact same pattern as `bloomreachScenarios.test.ts`

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- `weblayers list` — List all weblayers with status filtering
- `weblayers view-performance` — View impressions, clicks, conversions
- `weblayers create` — Prepare creation with display conditions and A/B config
- `weblayers start` / `stop` — Activate or deactivate a weblayer
- `weblayers clone` — Duplicate an existing weblayer
- `weblayers archive` — Move to archived

### Index Export (`packages/core/src/index.ts`)
- Added `export * from './bloomreachWeblayers.js'`

## Quality Gates
- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 720 tests passed (12 files)
- ✅ `npm run build` — both core and CLI build successfully

Closes #32
