### PR TITLE
feat: manage recommendation models (#33)

### DIFF
--- a/packages/core/src/__tests__/bloomreachRecommendations.test.ts
+++ b/packages/core/src/__tests__/bloomreachRecommendations.test.ts
@@ -1,0 +1,730 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_RECOMMENDATION_MODEL_ACTION_TYPE,
+  CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE,
+  DELETE_RECOMMENDATION_MODEL_ACTION_TYPE,
+  RECOMMENDATION_RATE_LIMIT_WINDOW_MS,
+  RECOMMENDATION_CREATE_RATE_LIMIT,
+  RECOMMENDATION_MODIFY_RATE_LIMIT,
+  RECOMMENDATION_MODEL_STATUSES,
+  RECOMMENDATION_ALGORITHM_TYPES,
+  validateModelName,
+  validateModelId,
+  validateRecommendationModelStatus,
+  validateAlgorithmType,
+  validateFilterRules,
+  validateBoostRules,
+  validateMaxItems,
+  buildRecommendationsUrl,
+  createRecommendationActionExecutors,
+  BloomreachRecommendationsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_RECOMMENDATION_MODEL_ACTION_TYPE', () => {
+    expect(CREATE_RECOMMENDATION_MODEL_ACTION_TYPE).toBe('recommendations.create_model');
+  });
+
+  it('exports CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE', () => {
+    expect(CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE).toBe('recommendations.configure_model');
+  });
+
+  it('exports DELETE_RECOMMENDATION_MODEL_ACTION_TYPE', () => {
+    expect(DELETE_RECOMMENDATION_MODEL_ACTION_TYPE).toBe('recommendations.delete_model');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports RECOMMENDATION_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(RECOMMENDATION_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports RECOMMENDATION_CREATE_RATE_LIMIT', () => {
+    expect(RECOMMENDATION_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports RECOMMENDATION_MODIFY_RATE_LIMIT', () => {
+    expect(RECOMMENDATION_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('RECOMMENDATION_MODEL_STATUSES', () => {
+  it('contains 4 statuses', () => {
+    expect(RECOMMENDATION_MODEL_STATUSES).toHaveLength(4);
+  });
+
+  it('contains expected statuses in order', () => {
+    expect(RECOMMENDATION_MODEL_STATUSES).toEqual(['active', 'inactive', 'training', 'draft']);
+  });
+});
+
+describe('RECOMMENDATION_ALGORITHM_TYPES', () => {
+  it('contains 5 algorithm types', () => {
+    expect(RECOMMENDATION_ALGORITHM_TYPES).toHaveLength(5);
+  });
+
+  it('contains expected algorithm types in order', () => {
+    expect(RECOMMENDATION_ALGORITHM_TYPES).toEqual([
+      'collaborative_filtering',
+      'content_based',
+      'hybrid',
+      'trending',
+      'personalized',
+    ]);
+  });
+});
+
+describe('validateModelName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateModelName('  My Model  ')).toBe('My Model');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateModelName('A')).toBe('A');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateModelName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateModelName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateModelName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateModelName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateModelId', () => {
+  it('returns trimmed model ID for valid input', () => {
+    expect(validateModelId('  model-123  ')).toBe('model-123');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateModelId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateModelId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateModelId('model-456')).toBe('model-456');
+  });
+});
+
+describe('validateRecommendationModelStatus', () => {
+  it('accepts active', () => {
+    expect(validateRecommendationModelStatus('active')).toBe('active');
+  });
+
+  it('accepts inactive', () => {
+    expect(validateRecommendationModelStatus('inactive')).toBe('inactive');
+  });
+
+  it('accepts training', () => {
+    expect(validateRecommendationModelStatus('training')).toBe('training');
+  });
+
+  it('accepts draft', () => {
+    expect(validateRecommendationModelStatus('draft')).toBe('draft');
+  });
+
+  it('throws for unknown status', () => {
+    expect(() => validateRecommendationModelStatus('paused')).toThrow('status must be one of');
+  });
+
+  it('throws for empty status', () => {
+    expect(() => validateRecommendationModelStatus('')).toThrow('status must be one of');
+  });
+});
+
+describe('validateAlgorithmType', () => {
+  it('accepts collaborative_filtering', () => {
+    expect(validateAlgorithmType('collaborative_filtering')).toBe('collaborative_filtering');
+  });
+
+  it('accepts content_based', () => {
+    expect(validateAlgorithmType('content_based')).toBe('content_based');
+  });
+
+  it('accepts hybrid', () => {
+    expect(validateAlgorithmType('hybrid')).toBe('hybrid');
+  });
+
+  it('accepts trending', () => {
+    expect(validateAlgorithmType('trending')).toBe('trending');
+  });
+
+  it('accepts personalized', () => {
+    expect(validateAlgorithmType('personalized')).toBe('personalized');
+  });
+
+  it('throws for unknown type', () => {
+    expect(() => validateAlgorithmType('matrix_factorization')).toThrow('algorithm must be one of');
+  });
+
+  it('throws for empty type', () => {
+    expect(() => validateAlgorithmType('')).toThrow('algorithm must be one of');
+  });
+});
+
+describe('validateFilterRules', () => {
+  it('accepts valid filter rules array', () => {
+    const rules = [
+      { field: 'category', operator: 'equals', value: 'shoes' },
+      { field: 'in_stock', operator: 'equals', value: 'true' },
+    ];
+    expect(validateFilterRules(rules)).toEqual(rules);
+  });
+
+  it('accepts empty array', () => {
+    expect(validateFilterRules([])).toEqual([]);
+  });
+
+  it('throws for exceeding 50 rules', () => {
+    const rules = Array.from({ length: 51 }, (_, i) => ({
+      field: `field-${i}`,
+      operator: 'equals',
+      value: 'value',
+    }));
+    expect(() => validateFilterRules(rules)).toThrow('must contain at most 50');
+  });
+
+  it('throws for rule with empty field', () => {
+    const rules = [{ field: '', operator: 'equals', value: 'value' }];
+    expect(() => validateFilterRules(rules)).toThrow('field must not be empty');
+  });
+
+  it('throws for rule with empty operator', () => {
+    const rules = [{ field: 'category', operator: '', value: 'value' }];
+    expect(() => validateFilterRules(rules)).toThrow('operator must not be empty');
+  });
+
+  it('throws for rule with empty value', () => {
+    const rules = [{ field: 'category', operator: 'equals', value: '' }];
+    expect(() => validateFilterRules(rules)).toThrow('value must not be empty');
+  });
+});
+
+describe('validateBoostRules', () => {
+  it('accepts valid boost rules array', () => {
+    const rules = [
+      { field: 'margin', weight: 20 },
+      { field: 'recency', weight: 80 },
+    ];
+    expect(validateBoostRules(rules)).toEqual(rules);
+  });
+
+  it('accepts empty array', () => {
+    expect(validateBoostRules([])).toEqual([]);
+  });
+
+  it('throws for exceeding 50 rules', () => {
+    const rules = Array.from({ length: 51 }, (_, i) => ({
+      field: `field-${i}`,
+      weight: 10,
+    }));
+    expect(() => validateBoostRules(rules)).toThrow('must contain at most 50');
+  });
+
+  it('throws for weight below 0', () => {
+    const rules = [{ field: 'margin', weight: -1 }];
+    expect(() => validateBoostRules(rules)).toThrow('weight must be between 0 and 100');
+  });
+
+  it('throws for weight above 100', () => {
+    const rules = [{ field: 'margin', weight: 101 }];
+    expect(() => validateBoostRules(rules)).toThrow('weight must be between 0 and 100');
+  });
+
+  it('accepts weight at boundaries', () => {
+    expect(validateBoostRules([{ field: 'min-weight', weight: 0 }])).toBeDefined();
+    expect(validateBoostRules([{ field: 'max-weight', weight: 100 }])).toBeDefined();
+  });
+
+  it('throws for rule with empty field', () => {
+    const rules = [{ field: '', weight: 50 }];
+    expect(() => validateBoostRules(rules)).toThrow('field must not be empty');
+  });
+});
+
+describe('validateMaxItems', () => {
+  it('accepts valid integer', () => {
+    expect(validateMaxItems(10)).toBe(10);
+  });
+
+  it('accepts minimum value', () => {
+    expect(validateMaxItems(1)).toBe(1);
+  });
+
+  it('accepts maximum value', () => {
+    expect(validateMaxItems(100)).toBe(100);
+  });
+
+  it('throws for 0', () => {
+    expect(() => validateMaxItems(0)).toThrow('must be an integer between 1 and 100');
+  });
+
+  it('throws for 101', () => {
+    expect(() => validateMaxItems(101)).toThrow('must be an integer between 1 and 100');
+  });
+
+  it('throws for non-integer', () => {
+    expect(() => validateMaxItems(5.5)).toThrow('must be an integer between 1 and 100');
+  });
+});
+
+describe('buildRecommendationsUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildRecommendationsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/campaigns/recommendations',
+    );
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildRecommendationsUrl('my project')).toBe(
+      '/p/my%20project/campaigns/recommendations',
+    );
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildRecommendationsUrl('org/project')).toBe(
+      '/p/org%2Fproject/campaigns/recommendations',
+    );
+  });
+});
+
+describe('createRecommendationActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createRecommendationActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[CREATE_RECOMMENDATION_MODEL_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_RECOMMENDATION_MODEL_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createRecommendationActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createRecommendationActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachRecommendationsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachRecommendationsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachRecommendationsService);
+    });
+
+    it('exposes recommendationsUrl correctly', () => {
+      const service = new BloomreachRecommendationsService('kingdom-of-joakim');
+      expect(service.recommendationsUrl).toBe('/p/kingdom-of-joakim/campaigns/recommendations');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachRecommendationsService('  my-project  ');
+      expect(service.recommendationsUrl).toBe('/p/my-project/campaigns/recommendations');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachRecommendationsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listRecommendationModels', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachRecommendationsService('test');
+      await expect(service.listRecommendationModels()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates status when provided', async () => {
+      const service = new BloomreachRecommendationsService('test');
+      await expect(
+        service.listRecommendationModels({ project: 'test', status: 'paused' }),
+      ).rejects.toThrow('status must be one of');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachRecommendationsService('test');
+      await expect(
+        service.listRecommendationModels({ project: '', status: 'active' }),
+      ).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('viewModelPerformance', () => {
+    it('throws not-yet-implemented error with valid input', async () => {
+      const service = new BloomreachRecommendationsService('test');
+      await expect(
+        service.viewModelPerformance({ project: 'test', modelId: 'model-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachRecommendationsService('test');
+      await expect(
+        service.viewModelPerformance({ project: '', modelId: 'model-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates modelId input', async () => {
+      const service = new BloomreachRecommendationsService('test');
+      await expect(
+        service.viewModelPerformance({ project: 'test', modelId: '   ' }),
+      ).rejects.toThrow('Model ID must not be empty');
+    });
+  });
+
+  describe('prepareCreateRecommendationModel', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareCreateRecommendationModel({
+        project: 'test',
+        name: 'My Model',
+        modelType: 'product_recommendations',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'recommendations.create_model',
+          project: 'test',
+          name: 'My Model',
+        }),
+      );
+    });
+
+    it('includes modelType in preview', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareCreateRecommendationModel({
+        project: 'test',
+        name: 'Catalog Model',
+        modelType: 'category_recommendations',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ modelType: 'category_recommendations' }),
+      );
+    });
+
+    it('includes algorithm in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareCreateRecommendationModel({
+        project: 'test',
+        name: 'Hybrid Model',
+        modelType: 'product_recommendations',
+        algorithm: 'hybrid',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ algorithm: 'hybrid' }));
+    });
+
+    it('includes catalogId in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareCreateRecommendationModel({
+        project: 'test',
+        name: 'Catalog Model',
+        modelType: 'product_recommendations',
+        catalogId: 'catalog-123',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ catalogId: 'catalog-123' }));
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareCreateRecommendationModel({
+        project: 'test',
+        name: 'Model',
+        modelType: 'product_recommendations',
+        operatorNote: 'Created for spring merchandising',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Created for spring merchandising' }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareCreateRecommendationModel({
+          project: 'test',
+          name: '',
+          modelType: 'product_recommendations',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareCreateRecommendationModel({
+          project: '',
+          name: 'Model',
+          modelType: 'product_recommendations',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for too-long name', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareCreateRecommendationModel({
+          project: 'test',
+          name: 'x'.repeat(201),
+          modelType: 'product_recommendations',
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws for empty modelType', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareCreateRecommendationModel({
+          project: 'test',
+          name: 'Model',
+          modelType: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid algorithm type', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareCreateRecommendationModel({
+          project: 'test',
+          name: 'Model',
+          modelType: 'product_recommendations',
+          algorithm: 'matrix_factorization',
+        }),
+      ).toThrow('algorithm must be one of');
+    });
+  });
+
+  describe('prepareConfigureRecommendationModel', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'recommendations.configure_model',
+          project: 'test',
+          modelId: 'model-123',
+        }),
+      );
+    });
+
+    it('includes algorithm in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+        algorithm: 'personalized',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ algorithm: 'personalized' }));
+    });
+
+    it('includes catalogId in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+        catalogId: 'catalog-456',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ catalogId: 'catalog-456' }));
+    });
+
+    it('includes filters in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const filters = [{ field: 'category', operator: 'equals', value: 'shoes' }];
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+        filters,
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ filters }));
+    });
+
+    it('includes boostRules in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const boostRules = [{ field: 'margin', weight: 75 }];
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+        boostRules,
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ boostRules }));
+    });
+
+    it('includes maxItems in preview when provided', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+        maxItems: 25,
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ maxItems: 25 }));
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareConfigureRecommendationModel({
+        project: 'test',
+        modelId: 'model-123',
+        operatorNote: 'Tune recommendations for spring sale',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Tune recommendations for spring sale' }),
+      );
+    });
+
+    it('throws for empty modelId', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareConfigureRecommendationModel({
+          project: 'test',
+          modelId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareConfigureRecommendationModel({
+          project: '',
+          modelId: 'model-123',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid algorithm type', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareConfigureRecommendationModel({
+          project: 'test',
+          modelId: 'model-123',
+          algorithm: 'matrix_factorization',
+        }),
+      ).toThrow('algorithm must be one of');
+    });
+
+    it('throws for invalid filter rules', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareConfigureRecommendationModel({
+          project: 'test',
+          modelId: 'model-123',
+          filters: [{ field: '', operator: 'equals', value: 'x' }],
+        }),
+      ).toThrow('field must not be empty');
+    });
+
+    it('throws for invalid boost rules', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareConfigureRecommendationModel({
+          project: 'test',
+          modelId: 'model-123',
+          boostRules: [{ field: 'margin', weight: -1 }],
+        }),
+      ).toThrow('weight must be between 0 and 100');
+    });
+
+    it('throws for invalid maxItems', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareConfigureRecommendationModel({
+          project: 'test',
+          modelId: 'model-123',
+          maxItems: 101,
+        }),
+      ).toThrow('must be an integer between 1 and 100');
+    });
+  });
+
+  describe('prepareDeleteRecommendationModel', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareDeleteRecommendationModel({
+        project: 'test',
+        modelId: 'model-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'recommendations.delete_model',
+          project: 'test',
+          modelId: 'model-900',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachRecommendationsService('test');
+      const result = service.prepareDeleteRecommendationModel({
+        project: 'test',
+        modelId: 'model-900',
+        operatorNote: 'Remove outdated seasonal model',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Remove outdated seasonal model' }),
+      );
+    });
+
+    it('throws for empty modelId', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareDeleteRecommendationModel({
+          project: 'test',
+          modelId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachRecommendationsService('test');
+      expect(() =>
+        service.prepareDeleteRecommendationModel({
+          project: '',
+          modelId: 'model-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachRecommendations.ts
+++ b/packages/core/src/bloomreachRecommendations.ts
@@ -1,0 +1,438 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const CREATE_RECOMMENDATION_MODEL_ACTION_TYPE =
+  'recommendations.create_model';
+export const CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE =
+  'recommendations.configure_model';
+export const DELETE_RECOMMENDATION_MODEL_ACTION_TYPE =
+  'recommendations.delete_model';
+
+export const RECOMMENDATION_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const RECOMMENDATION_CREATE_RATE_LIMIT = 10;
+export const RECOMMENDATION_MODIFY_RATE_LIMIT = 20;
+
+export const RECOMMENDATION_MODEL_STATUSES = [
+  'active',
+  'inactive',
+  'training',
+  'draft',
+] as const;
+export type RecommendationModelStatus =
+  (typeof RECOMMENDATION_MODEL_STATUSES)[number];
+
+export const RECOMMENDATION_ALGORITHM_TYPES = [
+  'collaborative_filtering',
+  'content_based',
+  'hybrid',
+  'trending',
+  'personalized',
+] as const;
+export type RecommendationAlgorithmType =
+  (typeof RECOMMENDATION_ALGORITHM_TYPES)[number];
+
+export interface RecommendationFilterRule {
+  field: string;
+  operator: string;
+  value: string;
+}
+
+export interface RecommendationBoostRule {
+  field: string;
+  weight: number;
+}
+
+export interface RecommendationModelConfig {
+  algorithm: RecommendationAlgorithmType;
+  catalogId?: string;
+  filters?: RecommendationFilterRule[];
+  boostRules?: RecommendationBoostRule[];
+  /** Maximum number of items to recommend. */
+  maxItems?: number;
+}
+
+export interface BloomreachRecommendationModel {
+  id: string;
+  name: string;
+  status: RecommendationModelStatus;
+  modelType: string;
+  algorithm?: RecommendationAlgorithmType;
+  catalogId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface RecommendationModelPerformance {
+  modelId: string;
+  impressions: number;
+  clicks: number;
+  clickThroughRate: number;
+  conversions: number;
+  conversionRate: number;
+  revenue: number;
+  averageOrderValue: number;
+}
+
+export interface ListRecommendationModelsInput {
+  project: string;
+  status?: string;
+}
+
+export interface ViewRecommendationModelPerformanceInput {
+  project: string;
+  modelId: string;
+}
+
+export interface CreateRecommendationModelInput {
+  project: string;
+  name: string;
+  modelType: string;
+  algorithm?: string;
+  catalogId?: string;
+  operatorNote?: string;
+}
+
+export interface ConfigureRecommendationModelInput {
+  project: string;
+  modelId: string;
+  algorithm?: string;
+  catalogId?: string;
+  filters?: RecommendationFilterRule[];
+  boostRules?: RecommendationBoostRule[];
+  maxItems?: number;
+  operatorNote?: string;
+}
+
+export interface DeleteRecommendationModelInput {
+  project: string;
+  modelId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedRecommendationAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_MODEL_NAME_LENGTH = 200;
+const MIN_MODEL_NAME_LENGTH = 1;
+const MAX_FILTER_RULES = 50;
+const MAX_BOOST_RULES = 50;
+const MIN_BOOST_WEIGHT = 0;
+const MAX_BOOST_WEIGHT = 100;
+const MIN_MAX_ITEMS = 1;
+const MAX_MAX_ITEMS = 100;
+
+export function validateModelName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_MODEL_NAME_LENGTH) {
+    throw new Error('Model name must not be empty.');
+  }
+  if (trimmed.length > MAX_MODEL_NAME_LENGTH) {
+    throw new Error(
+      `Model name must not exceed ${MAX_MODEL_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateModelId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Model ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateRecommendationModelStatus(
+  status: string,
+): RecommendationModelStatus {
+  if (
+    !RECOMMENDATION_MODEL_STATUSES.includes(
+      status as RecommendationModelStatus,
+    )
+  ) {
+    throw new Error(
+      `status must be one of: ${RECOMMENDATION_MODEL_STATUSES.join(', ')} (got "${status}").`,
+    );
+  }
+  return status as RecommendationModelStatus;
+}
+
+export function validateAlgorithmType(
+  algorithm: string,
+): RecommendationAlgorithmType {
+  if (
+    !RECOMMENDATION_ALGORITHM_TYPES.includes(
+      algorithm as RecommendationAlgorithmType,
+    )
+  ) {
+    throw new Error(
+      `algorithm must be one of: ${RECOMMENDATION_ALGORITHM_TYPES.join(', ')} (got "${algorithm}").`,
+    );
+  }
+  return algorithm as RecommendationAlgorithmType;
+}
+
+export function validateFilterRules(
+  filters: RecommendationFilterRule[],
+): RecommendationFilterRule[] {
+  if (filters.length > MAX_FILTER_RULES) {
+    throw new Error(
+      `filters must contain at most ${MAX_FILTER_RULES} rules (got ${filters.length}).`,
+    );
+  }
+
+  return filters.map((filter, index) => {
+    const field = filter.field.trim();
+    const operator = filter.operator.trim();
+    const value = filter.value.trim();
+
+    if (field.length === 0) {
+      throw new Error(`filters[${index}].field must not be empty.`);
+    }
+    if (operator.length === 0) {
+      throw new Error(`filters[${index}].operator must not be empty.`);
+    }
+    if (value.length === 0) {
+      throw new Error(`filters[${index}].value must not be empty.`);
+    }
+
+    return {
+      field,
+      operator,
+      value,
+    };
+  });
+}
+
+export function validateBoostRules(
+  boostRules: RecommendationBoostRule[],
+): RecommendationBoostRule[] {
+  if (boostRules.length > MAX_BOOST_RULES) {
+    throw new Error(
+      `boostRules must contain at most ${MAX_BOOST_RULES} rules (got ${boostRules.length}).`,
+    );
+  }
+
+  return boostRules.map((boostRule, index) => {
+    const field = boostRule.field.trim();
+    if (field.length === 0) {
+      throw new Error(`boostRules[${index}].field must not be empty.`);
+    }
+
+    if (
+      boostRule.weight < MIN_BOOST_WEIGHT ||
+      boostRule.weight > MAX_BOOST_WEIGHT
+    ) {
+      throw new Error(
+        `boostRules[${index}].weight must be between ${MIN_BOOST_WEIGHT} and ${MAX_BOOST_WEIGHT} (got ${boostRule.weight}).`,
+      );
+    }
+
+    return {
+      field,
+      weight: boostRule.weight,
+    };
+  });
+}
+
+export function validateMaxItems(maxItems: number): number {
+  if (
+    !Number.isInteger(maxItems) ||
+    maxItems < MIN_MAX_ITEMS ||
+    maxItems > MAX_MAX_ITEMS
+  ) {
+    throw new Error(
+      `maxItems must be an integer between ${MIN_MAX_ITEMS} and ${MAX_MAX_ITEMS} (got ${maxItems}).`,
+    );
+  }
+
+  return maxItems;
+}
+
+export function buildRecommendationsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/campaigns/recommendations`;
+}
+
+export interface RecommendationActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateRecommendationModelExecutor implements RecommendationActionExecutor {
+  readonly actionType = CREATE_RECOMMENDATION_MODEL_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigureRecommendationModelExecutor
+  implements RecommendationActionExecutor
+{
+  readonly actionType = CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteRecommendationModelExecutor implements RecommendationActionExecutor {
+  readonly actionType = DELETE_RECOMMENDATION_MODEL_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createRecommendationActionExecutors(): Record<
+  string,
+  RecommendationActionExecutor
+> {
+  return {
+    [CREATE_RECOMMENDATION_MODEL_ACTION_TYPE]:
+      new CreateRecommendationModelExecutor(),
+    [CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE]:
+      new ConfigureRecommendationModelExecutor(),
+    [DELETE_RECOMMENDATION_MODEL_ACTION_TYPE]:
+      new DeleteRecommendationModelExecutor(),
+  };
+}
+
+export class BloomreachRecommendationsService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildRecommendationsUrl(validateProject(project));
+  }
+
+  get recommendationsUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listRecommendationModels(
+    input?: ListRecommendationModelsInput,
+  ): Promise<BloomreachRecommendationModel[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+      if (input.status !== undefined) {
+        validateRecommendationModelStatus(input.status);
+      }
+    }
+
+    throw new Error(
+      'listRecommendationModels: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewModelPerformance(
+    input: ViewRecommendationModelPerformanceInput,
+  ): Promise<RecommendationModelPerformance> {
+    validateProject(input.project);
+    validateModelId(input.modelId);
+
+    throw new Error(
+      'viewModelPerformance: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateRecommendationModel(
+    input: CreateRecommendationModelInput,
+  ): PreparedRecommendationAction {
+    const project = validateProject(input.project);
+    const name = validateModelName(input.name);
+    const modelType = input.modelType.trim();
+    if (modelType.length === 0) {
+      throw new Error('Model type must not be empty.');
+    }
+    const algorithm =
+      input.algorithm !== undefined
+        ? validateAlgorithmType(input.algorithm)
+        : undefined;
+
+    const preview = {
+      action: CREATE_RECOMMENDATION_MODEL_ACTION_TYPE,
+      project,
+      name,
+      modelType,
+      algorithm,
+      catalogId: input.catalogId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigureRecommendationModel(
+    input: ConfigureRecommendationModelInput,
+  ): PreparedRecommendationAction {
+    const project = validateProject(input.project);
+    const modelId = validateModelId(input.modelId);
+    const algorithm =
+      input.algorithm !== undefined
+        ? validateAlgorithmType(input.algorithm)
+        : undefined;
+    const filters =
+      input.filters !== undefined ? validateFilterRules(input.filters) : undefined;
+    const boostRules =
+      input.boostRules !== undefined
+        ? validateBoostRules(input.boostRules)
+        : undefined;
+    const maxItems =
+      input.maxItems !== undefined ? validateMaxItems(input.maxItems) : undefined;
+
+    const preview = {
+      action: CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE,
+      project,
+      modelId,
+      algorithm,
+      catalogId: input.catalogId,
+      filters,
+      boostRules,
+      maxItems,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteRecommendationModel(
+    input: DeleteRecommendationModelInput,
+  ): PreparedRecommendationAction {
+    const project = validateProject(input.project);
+    const modelId = validateModelId(input.modelId);
+
+    const preview = {
+      action: DELETE_RECOMMENDATION_MODEL_ACTION_TYPE,
+      project,
+      modelId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './bloomreachDashboards.js';
 export * from './bloomreachEmailCampaigns.js';
 export * from './bloomreachPerformance.js';
+export * from './bloomreachRecommendations.js';
 export * from './bloomreachScenarios.js';
 export * from './bloomreachSurveys.js';
 


### PR DESCRIPTION
## Summary

Add recommendation model management module for Bloomreach Engagement, enabling AI agents and CLI operators to manage product recommendation models via the two-phase commit pattern.

Closes #33

## Changes

### New Files
- **`packages/core/src/bloomreachRecommendations.ts`** — Core feature module with:
  - 3 action type constants (`recommendations.create_model`, `recommendations.configure_model`, `recommendations.delete_model`)
  - Rate limit constants (10 creates/hr, 20 modifies/hr)
  - Status enum (`active`, `inactive`, `training`, `draft`) and algorithm type enum (`collaborative_filtering`, `content_based`, `hybrid`, `trending`, `personalized`)
  - Domain interfaces for models, configs, filter/boost rules, and performance metrics
  - 7 validation functions (model name, model ID, status, algorithm type, filter rules, boost rules, max items)
  - URL builder for `/p/{project}/campaigns/recommendations`
  - 3 action executor classes (stub implementations pending browser automation)
  - `BloomreachRecommendationsService` with list, view performance, and 3 prepare methods

- **`packages/core/src/__tests__/bloomreachRecommendations.test.ts`** — 95 unit tests covering all exports, validators, executors, and service methods

### Modified Files
- **`packages/core/src/index.ts`** — Added re-export for `bloomreachRecommendations.js`

## Quality Gates
- ✅ TypeScript type check (`tsc --build`)
- ✅ ESLint
- ✅ 543 tests passing (95 new + 448 existing)
- ✅ Build (tsup, all packages)
