### PR TITLE
feat #38: add retention analysis feature module with core service, validators, tests, and CLI commands

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -8,9 +8,10 @@ import {
   BloomreachEmailCampaignsService,
   BloomreachFunnelsService,
   BloomreachPerformanceService,
+  BloomreachRetentionsService,
   BloomreachScenariosService,
-  BloomreachTrendsService,
   BloomreachSurveysService,
+  BloomreachTrendsService,
 } from '@bloomreach-buddy/core';
 import type {
   EmailCampaignSchedule,
@@ -19,6 +20,7 @@ import type {
   FunnelFilter,
   SurveyQuestion,
   SurveyDisplayConditions,
+  RetentionFilter,
   TrendFilter,
 } from '@bloomreach-buddy/core';
 
@@ -1965,6 +1967,266 @@ funnels
           printJson(result);
         } else {
           console.log('Funnel analysis archive prepared.');
+          console.log(`  Analysis: ${options.analysisId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+const retentions = program
+  .command('retentions')
+  .description('Manage Bloomreach Engagement retention analyses');
+
+retentions
+  .command('list')
+  .description('List all retention analyses in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachRetentionsService(options.project);
+      const result = await service.listRetentionAnalyses({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No retention analyses found.');
+          return;
+        }
+        for (const retention of result) {
+          console.log(`  ${retention.name}`);
+          console.log(`    Cohort event: ${retention.cohortEvent}`);
+          console.log(`    Return event: ${retention.returnEvent}`);
+          console.log(`    Granularity:  ${retention.granularity}`);
+          console.log(`    ID:           ${retention.id}`);
+          console.log(`    URL:          ${retention.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(1);
+    }
+  });
+
+retentions
+  .command('view-results')
+  .description('View cohort retention data for a retention analysis')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Retention analysis ID')
+  .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
+  .option('--end-date <date>', 'End date (YYYY-MM-DD)')
+  .option('--granularity <granularity>', 'Time granularity (daily, weekly, monthly)')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      startDate?: string;
+      endDate?: string;
+      granularity?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachRetentionsService(options.project);
+        const result = await service.viewRetentionResults({
+          project: options.project,
+          analysisId: options.analysisId,
+          startDate: options.startDate,
+          endDate: options.endDate,
+          granularity: options.granularity,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log(`Retention Analysis: ${result.analysisName}`);
+          console.log(`  Cohort event: ${result.cohortEvent}`);
+          console.log(`  Return event: ${result.returnEvent}`);
+          console.log(`  Granularity:  ${result.granularity}`);
+          console.log(`  Date range:   ${result.startDate} to ${result.endDate}`);
+          if (result.cohorts.length === 0) {
+            console.log('  Cohorts: none');
+          } else {
+            console.log('  Cohorts:');
+            for (const cohort of result.cohorts) {
+              console.log(`    ${JSON.stringify(cohort)}`);
+            }
+          }
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+retentions
+  .command('create')
+  .description('Prepare creation of a new retention analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Retention analysis name')
+  .requiredOption('--cohort-event <event>', 'Cohort event name')
+  .requiredOption('--return-event <event>', 'Return event name')
+  .option('--granularity <granularity>', 'Time granularity (daily, weekly, monthly)', 'daily')
+  .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
+  .option('--end-date <date>', 'End date (YYYY-MM-DD)')
+  .option('--customer-attributes <json>', 'JSON object of customer attribute filters')
+  .option('--event-properties <json>', 'JSON object of event property filters')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      cohortEvent: string;
+      returnEvent: string;
+      granularity: string;
+      startDate?: string;
+      endDate?: string;
+      customerAttributes?: string;
+      eventProperties?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const filters: RetentionFilter = {};
+        if (options.customerAttributes) {
+          filters.customerAttributes = JSON.parse(options.customerAttributes) as Record<
+            string,
+            string
+          >;
+        }
+        if (options.eventProperties) {
+          filters.eventProperties = JSON.parse(options.eventProperties) as Record<
+            string,
+            string
+          >;
+        }
+
+        const dateRange =
+          options.startDate || options.endDate
+            ? { startDate: options.startDate, endDate: options.endDate }
+            : undefined;
+
+        const service = new BloomreachRetentionsService(options.project);
+        const result = service.prepareCreateRetentionAnalysis({
+          project: options.project,
+          name: options.name,
+          cohortEvent: options.cohortEvent,
+          returnEvent: options.returnEvent,
+          granularity: options.granularity,
+          dateRange,
+          filters: Object.keys(filters).length > 0 ? filters : undefined,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Retention analysis creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+retentions
+  .command('clone')
+  .description('Prepare cloning a retention analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Retention analysis ID to clone')
+  .option('--new-name <name>', 'Name for the cloned analysis')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      newName?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachRetentionsService(options.project);
+        const result = service.prepareCloneRetentionAnalysis({
+          project: options.project,
+          analysisId: options.analysisId,
+          newName: options.newName,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Retention analysis clone prepared.');
+          console.log(`  Source:   ${options.analysisId}`);
+          console.log(`  New name: ${options.newName ?? '(auto-generated)'}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+retentions
+  .command('archive')
+  .description('Prepare archiving a retention analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Retention analysis ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachRetentionsService(options.project);
+        const result = service.prepareArchiveRetentionAnalysis({
+          project: options.project,
+          analysisId: options.analysisId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Retention analysis archive prepared.');
           console.log(`  Analysis: ${options.analysisId}`);
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);

--- a/packages/core/src/__tests__/bloomreachRetentions.test.ts
+++ b/packages/core/src/__tests__/bloomreachRetentions.test.ts
@@ -1,0 +1,1121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_RETENTION_ACTION_TYPE,
+  CLONE_RETENTION_ACTION_TYPE,
+  ARCHIVE_RETENTION_ACTION_TYPE,
+  RETENTION_RATE_LIMIT_WINDOW_MS,
+  RETENTION_CREATE_RATE_LIMIT,
+  RETENTION_MODIFY_RATE_LIMIT,
+  RETENTION_GRANULARITIES,
+  validateRetentionName,
+  validateRetentionGranularity,
+  validateRetentionAnalysisId,
+  validateEventName,
+  buildRetentionsUrl,
+  createRetentionActionExecutors,
+  BloomreachRetentionsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_RETENTION_ACTION_TYPE', () => {
+    expect(CREATE_RETENTION_ACTION_TYPE).toBe('retentions.create_retention');
+  });
+
+  it('exports CLONE_RETENTION_ACTION_TYPE', () => {
+    expect(CLONE_RETENTION_ACTION_TYPE).toBe('retentions.clone_retention');
+  });
+
+  it('exports ARCHIVE_RETENTION_ACTION_TYPE', () => {
+    expect(ARCHIVE_RETENTION_ACTION_TYPE).toBe('retentions.archive_retention');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports RETENTION_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(RETENTION_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports RETENTION_CREATE_RATE_LIMIT', () => {
+    expect(RETENTION_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports RETENTION_MODIFY_RATE_LIMIT', () => {
+    expect(RETENTION_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('RETENTION_GRANULARITIES', () => {
+  it('contains exactly four values', () => {
+    expect(RETENTION_GRANULARITIES).toHaveLength(4);
+  });
+
+  it('contains hourly at index 0', () => {
+    expect(RETENTION_GRANULARITIES[0]).toBe('hourly');
+  });
+
+  it('contains daily at index 1', () => {
+    expect(RETENTION_GRANULARITIES[1]).toBe('daily');
+  });
+
+  it('contains weekly at index 2', () => {
+    expect(RETENTION_GRANULARITIES[2]).toBe('weekly');
+  });
+
+  it('contains monthly at index 3', () => {
+    expect(RETENTION_GRANULARITIES[3]).toBe('monthly');
+  });
+
+  it('matches the expected set exactly', () => {
+    expect(RETENTION_GRANULARITIES).toEqual([
+      'hourly',
+      'daily',
+      'weekly',
+      'monthly',
+    ]);
+  });
+});
+
+describe('validateRetentionName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateRetentionName('  My Retention  ')).toBe('My Retention');
+  });
+
+  it('returns trimmed name with tabs and newlines', () => {
+    expect(validateRetentionName('\n\tRetention Name\t\n')).toBe(
+      'Retention Name',
+    );
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateRetentionName('A')).toBe('A');
+  });
+
+  it('accepts numeric name', () => {
+    expect(validateRetentionName('123')).toBe('123');
+  });
+
+  it('accepts name with punctuation', () => {
+    expect(validateRetentionName('Retention: Weekly v2')).toBe(
+      'Retention: Weekly v2',
+    );
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateRetentionName(name)).toBe(name);
+  });
+
+  it('accepts mixed whitespace around valid name', () => {
+    expect(validateRetentionName(' \t  Cohort 7 Days \n ')).toBe(
+      'Cohort 7 Days',
+    );
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateRetentionName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateRetentionName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateRetentionName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateRetentionName('\n\n')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateRetentionName(name)).toThrow(
+      'must not exceed 200 characters',
+    );
+  });
+});
+
+describe('validateRetentionGranularity', () => {
+  it('accepts hourly granularity', () => {
+    expect(validateRetentionGranularity('hourly')).toBe('hourly');
+  });
+
+  it('accepts daily granularity', () => {
+    expect(validateRetentionGranularity('daily')).toBe('daily');
+  });
+
+  it('accepts weekly granularity', () => {
+    expect(validateRetentionGranularity('weekly')).toBe('weekly');
+  });
+
+  it('accepts monthly granularity', () => {
+    expect(validateRetentionGranularity('monthly')).toBe('monthly');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateRetentionGranularity('')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateRetentionGranularity('   ')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for invalid value', () => {
+    expect(() => validateRetentionGranularity('yearly')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for incorrect casing', () => {
+    expect(() => validateRetentionGranularity('Daily')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for value with trailing space', () => {
+    expect(() => validateRetentionGranularity('daily ')).toThrow(
+      'granularity must be one of',
+    );
+  });
+});
+
+describe('validateRetentionAnalysisId', () => {
+  it('returns trimmed retention analysis ID for valid input', () => {
+    expect(validateRetentionAnalysisId('  retention-123  ')).toBe(
+      'retention-123',
+    );
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateRetentionAnalysisId('retention-456')).toBe('retention-456');
+  });
+
+  it('returns ID containing slashes', () => {
+    expect(validateRetentionAnalysisId('analysis/segment/a')).toBe(
+      'analysis/segment/a',
+    );
+  });
+
+  it('returns ID containing dots and dashes', () => {
+    expect(validateRetentionAnalysisId('retention.v2-alpha')).toBe(
+      'retention.v2-alpha',
+    );
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateRetentionAnalysisId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateRetentionAnalysisId('   ')).toThrow(
+      'must not be empty',
+    );
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateRetentionAnalysisId('\n')).toThrow(
+      'must not be empty',
+    );
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateRetentionAnalysisId('\t')).toThrow(
+      'must not be empty',
+    );
+  });
+});
+
+describe('validateEventName', () => {
+  it('validates cohortEvent with trimmed input', () => {
+    expect(validateEventName('cohortEvent', '  first_open  ')).toBe(
+      'first_open',
+    );
+  });
+
+  it('validates returnEvent with trimmed input', () => {
+    expect(validateEventName('returnEvent', '  session_start  ')).toBe(
+      'session_start',
+    );
+  });
+
+  it('accepts punctuation in event name', () => {
+    expect(validateEventName('cohortEvent', 'checkout:started.v2')).toBe(
+      'checkout:started.v2',
+    );
+  });
+
+  it('accepts mixed alphanumeric event name', () => {
+    expect(validateEventName('returnEvent', 'return_event_v2')).toBe(
+      'return_event_v2',
+    );
+  });
+
+  it('throws for empty cohortEvent', () => {
+    expect(() => validateEventName('cohortEvent', '')).toThrow(
+      'cohortEvent must not be empty',
+    );
+  });
+
+  it('throws for whitespace-only cohortEvent', () => {
+    expect(() => validateEventName('cohortEvent', '   ')).toThrow(
+      'cohortEvent must not be empty',
+    );
+  });
+
+  it('throws for tab-only cohortEvent', () => {
+    expect(() => validateEventName('cohortEvent', '\t')).toThrow(
+      'cohortEvent must not be empty',
+    );
+  });
+
+  it('throws for empty returnEvent', () => {
+    expect(() => validateEventName('returnEvent', '')).toThrow(
+      'returnEvent must not be empty',
+    );
+  });
+
+  it('throws for whitespace-only returnEvent', () => {
+    expect(() => validateEventName('returnEvent', '   ')).toThrow(
+      'returnEvent must not be empty',
+    );
+  });
+
+  it('throws for newline-only returnEvent', () => {
+    expect(() => validateEventName('returnEvent', '\n')).toThrow(
+      'returnEvent must not be empty',
+    );
+  });
+});
+
+describe('buildRetentionsUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildRetentionsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/analytics/retentions',
+    );
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildRetentionsUrl('my project')).toBe(
+      '/p/my%20project/analytics/retentions',
+    );
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildRetentionsUrl('org/project')).toBe(
+      '/p/org%2Fproject/analytics/retentions',
+    );
+  });
+
+  it('encodes unicode characters in project name', () => {
+    expect(buildRetentionsUrl('projekt åäö')).toBe(
+      '/p/projekt%20%C3%A5%C3%A4%C3%B6/analytics/retentions',
+    );
+  });
+
+  it('encodes hash character in project name', () => {
+    expect(buildRetentionsUrl('my#project')).toBe(
+      '/p/my%23project/analytics/retentions',
+    );
+  });
+
+  it('keeps dashes unencoded in project name', () => {
+    expect(buildRetentionsUrl('team-alpha')).toBe(
+      '/p/team-alpha/analytics/retentions',
+    );
+  });
+});
+
+describe('createRetentionActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createRetentionActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[CREATE_RETENTION_ACTION_TYPE]).toBeDefined();
+    expect(executors[CLONE_RETENTION_ACTION_TYPE]).toBeDefined();
+    expect(executors[ARCHIVE_RETENTION_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createRetentionActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('create executor throws "not yet implemented" on execute', async () => {
+    const executors = createRetentionActionExecutors();
+    await expect(executors[CREATE_RETENTION_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('clone executor throws "not yet implemented" on execute', async () => {
+    const executors = createRetentionActionExecutors();
+    await expect(executors[CLONE_RETENTION_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('archive executor throws "not yet implemented" on execute', async () => {
+    const executors = createRetentionActionExecutors();
+    await expect(executors[ARCHIVE_RETENTION_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+});
+
+describe('BloomreachRetentionsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachRetentionsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachRetentionsService);
+    });
+
+    it('exposes the retentions URL', () => {
+      const service = new BloomreachRetentionsService('kingdom-of-joakim');
+      expect(service.retentionsUrl).toBe('/p/kingdom-of-joakim/analytics/retentions');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachRetentionsService('  my-project  ');
+      expect(service.retentionsUrl).toBe('/p/my-project/analytics/retentions');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachRetentionsService('')).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      expect(() => new BloomreachRetentionsService('   ')).toThrow('must not be empty');
+    });
+
+    it('encodes slashes in constructor project URL', () => {
+      const service = new BloomreachRetentionsService('org/project');
+      expect(service.retentionsUrl).toBe('/p/org%2Fproject/analytics/retentions');
+    });
+  });
+
+  describe('listRetentionAnalyses', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(service.listRetentionAnalyses()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(service.listRetentionAnalyses({ project: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates whitespace-only project when input is provided', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(service.listRetentionAnalyses({ project: '   ' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws not-yet-implemented error for valid project override', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.listRetentionAnalyses({ project: 'kingdom-of-joakim' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('throws not-yet-implemented error for trimmed project override', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.listRetentionAnalyses({ project: '  kingdom-of-joakim  ' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('viewRetentionResults', () => {
+    it('throws not-yet-implemented error with valid minimal input', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({ project: 'test', analysisId: 'retention-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('throws not-yet-implemented error with valid granularity', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: 'retention-1',
+          granularity: 'daily',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('throws not-yet-implemented error with valid date range', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: 'retention-1',
+          startDate: '2025-01-01',
+          endDate: '2025-01-31',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({ project: '', analysisId: 'retention-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates whitespace-only project input', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({ project: '   ', analysisId: 'retention-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates analysisId input', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({ project: 'test', analysisId: '   ' }),
+      ).rejects.toThrow('Retention analysis ID must not be empty');
+    });
+
+    it('validates empty analysisId input', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({ project: 'test', analysisId: '' }),
+      ).rejects.toThrow('Retention analysis ID must not be empty');
+    });
+
+    it('accepts trimmed analysisId and reaches not-yet-implemented', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: '  retention-99  ',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates granularity when provided', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: 'retention-1',
+          granularity: 'yearly',
+        }),
+      ).rejects.toThrow('granularity must be one of');
+    });
+
+    it('validates startDate format when date range is provided', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: 'retention-1',
+          startDate: '01-01-2025',
+        }),
+      ).rejects.toThrow('startDate must be a valid ISO-8601 date');
+    });
+
+    it('validates endDate format when date range is provided', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: 'retention-1',
+          endDate: '2025/01/31',
+        }),
+      ).rejects.toThrow('endDate must be a valid ISO-8601 date');
+    });
+
+    it('validates date ordering when both dates are provided', async () => {
+      const service = new BloomreachRetentionsService('test');
+      await expect(
+        service.viewRetentionResults({
+          project: 'test',
+          analysisId: 'retention-1',
+          startDate: '2025-02-01',
+          endDate: '2025-01-31',
+        }),
+      ).rejects.toThrow('must not be after endDate');
+    });
+  });
+
+  describe('prepareCreateRetentionAnalysis', () => {
+    it('returns a prepared action with valid minimal input', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Weekly Retention',
+        cohortEvent: 'signup',
+        returnEvent: 'purchase',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'retentions.create_retention',
+          project: 'test',
+          name: 'Weekly Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      );
+    });
+
+    it('includes granularity in preview when provided', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Daily Retention',
+        cohortEvent: 'signup',
+        returnEvent: 'session_start',
+        granularity: 'daily',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          granularity: 'daily',
+        }),
+      );
+    });
+
+    it('includes dateRange in preview when provided', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Range Retention',
+        cohortEvent: 'signup',
+        returnEvent: 'purchase',
+        dateRange: { startDate: '2025-01-01', endDate: '2025-01-31' },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          dateRange: { startDate: '2025-01-01', endDate: '2025-01-31' },
+        }),
+      );
+    });
+
+    it('includes filters in preview when provided', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Filtered Retention',
+        cohortEvent: 'signup',
+        returnEvent: 'purchase',
+        filters: {
+          customerAttributes: { segment: 'vip', locale: 'en_US' },
+          eventProperties: { channel: 'email' },
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          filters: {
+            customerAttributes: { segment: 'vip', locale: 'en_US' },
+            eventProperties: { channel: 'email' },
+          },
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Retention',
+        cohortEvent: 'signup',
+        returnEvent: 'purchase',
+        operatorNote: 'Create before weekly analytics review',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Create before weekly analytics review',
+        }),
+      );
+    });
+
+    it('trims project and name in preview', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: '  my-project  ',
+        name: '  My Retention  ',
+        cohortEvent: 'signup',
+        returnEvent: 'purchase',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+          name: 'My Retention',
+        }),
+      );
+    });
+
+    it('trims cohortEvent and returnEvent in preview', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Retention',
+        cohortEvent: '  signup  ',
+        returnEvent: '  purchase  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: '',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only name', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: '   ',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: '',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: '   ',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for too-long name', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'x'.repeat(201),
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws for invalid granularity', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+          granularity: 'yearly',
+        }),
+      ).toThrow('granularity must be one of');
+    });
+
+    it('throws for invalid start date in dateRange', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+          dateRange: { startDate: '2025/01/01', endDate: '2025-01-31' },
+        }),
+      ).toThrow('startDate must be a valid ISO-8601 date');
+    });
+
+    it('throws for invalid end date in dateRange', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+          dateRange: { startDate: '2025-01-01', endDate: '31-01-2025' },
+        }),
+      ).toThrow('endDate must be a valid ISO-8601 date');
+    });
+
+    it('throws for startDate after endDate in dateRange', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: 'purchase',
+          dateRange: { startDate: '2025-02-01', endDate: '2025-01-31' },
+        }),
+      ).toThrow('must not be after endDate');
+    });
+
+    it('throws for empty cohortEvent', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'Retention',
+          cohortEvent: '',
+          returnEvent: 'purchase',
+        }),
+      ).toThrow('cohortEvent must not be empty');
+    });
+
+    it('throws for whitespace-only returnEvent', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCreateRetentionAnalysis({
+          project: 'test',
+          name: 'Retention',
+          cohortEvent: 'signup',
+          returnEvent: '   ',
+        }),
+      ).toThrow('returnEvent must not be empty');
+    });
+
+    it('accepts max-length name and still prepares action', () => {
+      const service = new BloomreachRetentionsService('test');
+      const maxName = 'x'.repeat(200);
+      const result = service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: maxName,
+        cohortEvent: 'signup',
+        returnEvent: 'purchase',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: maxName,
+        }),
+      );
+    });
+  });
+
+  describe('prepareCloneRetentionAnalysis', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCloneRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-789',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'retentions.clone_retention',
+          project: 'test',
+          analysisId: 'retention-789',
+        }),
+      );
+    });
+
+    it('includes newName in preview when provided', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCloneRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-789',
+        newName: '  Cloned Retention  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName: 'Cloned Retention',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCloneRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-789',
+        operatorNote: 'Clone for campaign variant',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Clone for campaign variant',
+        }),
+      );
+    });
+
+    it('throws for empty analysisId', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCloneRetentionAnalysis({
+          project: 'test',
+          analysisId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only analysisId', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCloneRetentionAnalysis({
+          project: 'test',
+          analysisId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCloneRetentionAnalysis({
+          project: '',
+          analysisId: 'retention-789',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCloneRetentionAnalysis({
+          project: '   ',
+          analysisId: 'retention-789',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName is whitespace only', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCloneRetentionAnalysis({
+          project: 'test',
+          analysisId: 'retention-789',
+          newName: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName exceeds maximum length', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareCloneRetentionAnalysis({
+          project: 'test',
+          analysisId: 'retention-789',
+          newName: 'x'.repeat(201),
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('accepts max-length newName', () => {
+      const service = new BloomreachRetentionsService('test');
+      const newName = 'x'.repeat(200);
+      const result = service.prepareCloneRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-789',
+        newName,
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName,
+        }),
+      );
+    });
+
+    it('trims analysisId and reaches prepared state', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCloneRetentionAnalysis({
+        project: 'test',
+        analysisId: '  retention-789  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          analysisId: 'retention-789',
+        }),
+      );
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareCloneRetentionAnalysis({
+        project: '  my-project  ',
+        analysisId: 'retention-789',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+        }),
+      );
+    });
+  });
+
+  describe('prepareArchiveRetentionAnalysis', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareArchiveRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'retentions.archive_retention',
+          project: 'test',
+          analysisId: 'retention-900',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareArchiveRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-900',
+        operatorNote: 'Archive legacy retention analysis',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Archive legacy retention analysis',
+        }),
+      );
+    });
+
+    it('throws for empty analysisId', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareArchiveRetentionAnalysis({
+          project: 'test',
+          analysisId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only analysisId', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareArchiveRetentionAnalysis({
+          project: 'test',
+          analysisId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareArchiveRetentionAnalysis({
+          project: '',
+          analysisId: 'retention-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachRetentionsService('test');
+      expect(() =>
+        service.prepareArchiveRetentionAnalysis({
+          project: '   ',
+          analysisId: 'retention-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('accepts trimmed analysisId and reaches prepared state', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareArchiveRetentionAnalysis({
+        project: 'test',
+        analysisId: '  retention-900  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          analysisId: 'retention-900',
+        }),
+      );
+    });
+
+    it('trims project and reaches prepared state', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareArchiveRetentionAnalysis({
+        project: '  my-project  ',
+        analysisId: 'retention-900',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+        }),
+      );
+    });
+
+    it('keeps slash-containing analysisId after trim', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareArchiveRetentionAnalysis({
+        project: 'test',
+        analysisId: '  retention/group/a  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          analysisId: 'retention/group/a',
+        }),
+      );
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachRetentionsService('test');
+      const result = service.prepareArchiveRetentionAnalysis({
+        project: 'test',
+        analysisId: 'retention-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/packages/core/src/bloomreachRetentions.ts
+++ b/packages/core/src/bloomreachRetentions.ts
@@ -1,0 +1,327 @@
+import { validateProject } from './bloomreachDashboards.js';
+import { validateDateRange } from './bloomreachPerformance.js';
+import type { DateRangeFilter } from './bloomreachPerformance.js';
+
+export const CREATE_RETENTION_ACTION_TYPE = 'retentions.create_retention';
+export const CLONE_RETENTION_ACTION_TYPE = 'retentions.clone_retention';
+export const ARCHIVE_RETENTION_ACTION_TYPE = 'retentions.archive_retention';
+
+export const RETENTION_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const RETENTION_CREATE_RATE_LIMIT = 10;
+export const RETENTION_MODIFY_RATE_LIMIT = 20;
+
+export const RETENTION_GRANULARITIES = [
+  'hourly',
+  'daily',
+  'weekly',
+  'monthly',
+] as const;
+export type RetentionGranularity = (typeof RETENTION_GRANULARITIES)[number];
+
+export interface BloomreachRetentionAnalysis {
+  id: string;
+  name: string;
+  cohortEvent: string;
+  returnEvent: string;
+  granularity: RetentionGranularity;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface RetentionFilter {
+  customerAttributes?: Record<string, string>;
+  eventProperties?: Record<string, string>;
+}
+
+export interface RetentionCohortRow {
+  cohortDate: string;
+  cohortSize: number;
+  retentionByPeriod: number[];
+}
+
+export interface RetentionResults {
+  analysisId: string;
+  analysisName: string;
+  cohortEvent: string;
+  returnEvent: string;
+  granularity: RetentionGranularity;
+  startDate: string;
+  endDate: string;
+  cohorts: RetentionCohortRow[];
+  filters?: RetentionFilter;
+}
+
+export interface ListRetentionAnalysesInput {
+  project: string;
+}
+
+export interface CreateRetentionAnalysisInput {
+  project: string;
+  name: string;
+  cohortEvent: string;
+  returnEvent: string;
+  granularity?: string;
+  dateRange?: DateRangeFilter;
+  filters?: RetentionFilter;
+  operatorNote?: string;
+}
+
+export interface ViewRetentionResultsInput {
+  project: string;
+  analysisId: string;
+  startDate?: string;
+  endDate?: string;
+  granularity?: string;
+}
+
+export interface CloneRetentionAnalysisInput {
+  project: string;
+  analysisId: string;
+  newName?: string;
+  operatorNote?: string;
+}
+
+export interface ArchiveRetentionAnalysisInput {
+  project: string;
+  analysisId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedRetentionAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_RETENTION_NAME_LENGTH = 200;
+const MIN_RETENTION_NAME_LENGTH = 1;
+
+export function validateRetentionName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_RETENTION_NAME_LENGTH) {
+    throw new Error('Retention name must not be empty.');
+  }
+  if (trimmed.length > MAX_RETENTION_NAME_LENGTH) {
+    throw new Error(
+      `Retention name must not exceed ${MAX_RETENTION_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateRetentionGranularity(
+  granularity: string,
+): RetentionGranularity {
+  if (
+    !RETENTION_GRANULARITIES.includes(granularity as RetentionGranularity)
+  ) {
+    throw new Error(
+      `granularity must be one of: ${RETENTION_GRANULARITIES.join(', ')} (got "${granularity}").`,
+    );
+  }
+  return granularity as RetentionGranularity;
+}
+
+export function validateRetentionAnalysisId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Retention analysis ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateEventName(label: string, eventName: string): string {
+  const trimmed = eventName.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label} must not be empty.`);
+  }
+  return trimmed;
+}
+
+export function buildRetentionsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/analytics/retentions`;
+}
+
+export interface RetentionActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateRetentionExecutor implements RetentionActionExecutor {
+  readonly actionType = CREATE_RETENTION_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateRetentionExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CloneRetentionExecutor implements RetentionActionExecutor {
+  readonly actionType = CLONE_RETENTION_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CloneRetentionExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ArchiveRetentionExecutor implements RetentionActionExecutor {
+  readonly actionType = ARCHIVE_RETENTION_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ArchiveRetentionExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createRetentionActionExecutors(): Record<
+  string,
+  RetentionActionExecutor
+> {
+  return {
+    [CREATE_RETENTION_ACTION_TYPE]: new CreateRetentionExecutor(),
+    [CLONE_RETENTION_ACTION_TYPE]: new CloneRetentionExecutor(),
+    [ARCHIVE_RETENTION_ACTION_TYPE]: new ArchiveRetentionExecutor(),
+  };
+}
+
+export class BloomreachRetentionsService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildRetentionsUrl(validateProject(project));
+  }
+
+  get retentionsUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listRetentionAnalyses(
+    input?: ListRetentionAnalysesInput,
+  ): Promise<BloomreachRetentionAnalysis[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listRetentionAnalyses: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewRetentionResults(
+    input: ViewRetentionResultsInput,
+  ): Promise<RetentionResults> {
+    validateProject(input.project);
+    validateRetentionAnalysisId(input.analysisId);
+
+    if (input.granularity !== undefined) {
+      validateRetentionGranularity(input.granularity);
+    }
+
+    if (input.startDate !== undefined || input.endDate !== undefined) {
+      const dateRange: DateRangeFilter = {
+        startDate: input.startDate,
+        endDate: input.endDate,
+      };
+      validateDateRange(dateRange);
+    }
+
+    throw new Error(
+      'viewRetentionResults: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateRetentionAnalysis(
+    input: CreateRetentionAnalysisInput,
+  ): PreparedRetentionAction {
+    const project = validateProject(input.project);
+    const name = validateRetentionName(input.name);
+    const cohortEvent = validateEventName('cohortEvent', input.cohortEvent);
+    const returnEvent = validateEventName('returnEvent', input.returnEvent);
+    const granularity =
+      input.granularity !== undefined
+        ? validateRetentionGranularity(input.granularity)
+        : undefined;
+
+    if (input.dateRange !== undefined) {
+      validateDateRange(input.dateRange);
+    }
+
+    const preview = {
+      action: CREATE_RETENTION_ACTION_TYPE,
+      project,
+      name,
+      cohortEvent,
+      returnEvent,
+      granularity,
+      dateRange: input.dateRange,
+      filters: input.filters,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCloneRetentionAnalysis(
+    input: CloneRetentionAnalysisInput,
+  ): PreparedRetentionAction {
+    const project = validateProject(input.project);
+    const analysisId = validateRetentionAnalysisId(input.analysisId);
+    const newName =
+      input.newName !== undefined
+        ? validateRetentionName(input.newName)
+        : undefined;
+
+    const preview = {
+      action: CLONE_RETENTION_ACTION_TYPE,
+      project,
+      analysisId,
+      newName,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareArchiveRetentionAnalysis(
+    input: ArchiveRetentionAnalysisInput,
+  ): PreparedRetentionAction {
+    const project = validateProject(input.project);
+    const analysisId = validateRetentionAnalysisId(input.analysisId);
+
+    const preview = {
+      action: ARCHIVE_RETENTION_ACTION_TYPE,
+      project,
+      analysisId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from './bloomreachPerformance.js';
 export * from './bloomreachRecommendations.js';
 export * from './bloomreachScenarios.js';
 export * from './bloomreachSurveys.js';
+export * from './bloomreachRetentions.js';
 export * from './bloomreachTrends.js';
 
 export interface BloomreachClientConfig {


### PR DESCRIPTION
## Summary

Add Retention Analyses feature module — cohort retention tracking over time, accessible at `/p/{project}/analytics/retentions`.

## Changes

### Core Module (`packages/core/src/bloomreachRetentions.ts`)
- `BloomreachRetentionsService` with read-only methods (`listRetentionAnalyses`, `viewRetentionResults`) and two-phase commit prepare methods (`prepareCreateRetentionAnalysis`, `prepareCloneRetentionAnalysis`, `prepareArchiveRetentionAnalysis`)
- Action executors: `CreateRetentionExecutor`, `CloneRetentionExecutor`, `ArchiveRetentionExecutor` (stub implementations pending browser automation)
- Validators: retention name (1-200 chars), granularity (hourly/daily/weekly/monthly), analysis ID, event names
- TypeScript interfaces: `BloomreachRetentionAnalysis`, `RetentionResults`, `RetentionCohortRow`, `RetentionFilter`
- Rate limit constants for create (10/hr) and modify (20/hr) operations
- Exported from `packages/core/src/index.ts`

### Unit Tests (`packages/core/src/__tests__/bloomreachRetentions.test.ts`)
- 126 comprehensive test cases covering all validators, constants, executors, and service methods
- Edge cases: empty input, whitespace-only, boundary values, invalid granularity, date range validation

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- `bloomreach retentions list` — List all retention analyses
- `bloomreach retentions view-results` — View cohort retention data
- `bloomreach retentions create` — Prepare creation (two-phase commit) with cohort/return events, granularity, date range, filters
- `bloomreach retentions clone` — Prepare cloning
- `bloomreach retentions archive` — Prepare archiving

## Quality Gates
- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 22 files, 1694 tests passed
- ✅ `npm run build` — both core and CLI build successfully

Closes #38
