### PR TITLE
feat: manage flow analyses (#40)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -6,6 +6,7 @@ import {
   BloomreachCampaignCalendarService,
   BloomreachDashboardsService,
   BloomreachEmailCampaignsService,
+  BloomreachFlowsService,
   BloomreachFunnelsService,
   BloomreachPerformanceService,
   BloomreachRetentionsService,
@@ -16,6 +17,8 @@ import {
 import type {
   EmailCampaignSchedule,
   EmailCampaignABTestConfig,
+  FlowEvent,
+  FlowFilter,
   FunnelStep,
   FunnelFilter,
   SurveyQuestion,
@@ -81,9 +84,7 @@ dashboards
         }
       }
     } catch (error) {
-      console.error(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -132,9 +133,7 @@ dashboards
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -148,12 +147,7 @@ dashboards
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      dashboardId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; dashboardId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachDashboardsService(options.project);
         const result = service.prepareSetHomeDashboard({
@@ -174,9 +168,7 @@ dashboards
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -190,12 +182,7 @@ dashboards
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      dashboardId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; dashboardId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachDashboardsService(options.project);
         const result = service.prepareDeleteDashboard({
@@ -216,9 +203,7 @@ dashboards
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -236,12 +221,7 @@ performance
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      startDate?: string;
-      endDate?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; startDate?: string; endDate?: string; json?: boolean }) => {
       try {
         const service = new BloomreachPerformanceService(options.project);
         const dateRange =
@@ -261,9 +241,7 @@ performance
           printJson(result.metrics);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -275,7 +253,10 @@ performance
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
-  .option('--channel <channel>', 'Filter to specific channel (email, sms, push, whatsapp, weblayer, in_app_message)')
+  .option(
+    '--channel <channel>',
+    'Filter to specific channel (email, sms, push, whatsapp, weblayer, in_app_message)',
+  )
   .option('--json', 'Output as JSON')
   .action(
     async (options: {
@@ -305,9 +286,7 @@ performance
           printJson(result.metrics);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -318,87 +297,75 @@ performance
   .description('View Bloomreach billing, event-tracking and usage statistics')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachPerformanceService(options.project);
-        const result = await service.viewBloomreachUsage({
-          project: options.project,
-        });
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachPerformanceService(options.project);
+      const result = await service.viewBloomreachUsage({
+        project: options.project,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Bloomreach Usage: ${result.project}`);
-          console.log(`  Source: ${result.source_url}`);
-          printJson(result.metrics);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Bloomreach Usage: ${result.project}`);
+        console.log(`  Source: ${result.source_url}`);
+        printJson(result.metrics);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 performance
   .command('overview')
   .description('View high-level project statistics')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachPerformanceService(options.project);
-        const result = await service.viewProjectOverview({
-          project: options.project,
-        });
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachPerformanceService(options.project);
+      const result = await service.viewProjectOverview({
+        project: options.project,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Project Overview: ${result.project}`);
-          console.log(`  Source: ${result.source_url}`);
-          printJson(result.metrics);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Project Overview: ${result.project}`);
+        console.log(`  Source: ${result.source_url}`);
+        printJson(result.metrics);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 performance
   .command('health')
   .description('View project health and data-quality indicators')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachPerformanceService(options.project);
-        const result = await service.viewProjectHealth({
-          project: options.project,
-        });
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachPerformanceService(options.project);
+      const result = await service.viewProjectHealth({
+        project: options.project,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Project Health: ${result.project}`);
-          console.log(`  Source: ${result.source_url}`);
-          printJson(result.metrics);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Project Health: ${result.project}`);
+        console.log(`  Source: ${result.source_url}`);
+        printJson(result.metrics);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 const scenarios = program
   .command('scenarios')
@@ -431,7 +398,7 @@ scenarios
           project: options.project,
         };
         if (options.status) input.status = options.status;
-        if (options.tags) input.tags = options.tags.split(',').map(t => t.trim());
+        if (options.tags) input.tags = options.tags.split(',').map((t) => t.trim());
         if (options.owner) input.owner = options.owner;
 
         const result = await service.listScenarios(input);
@@ -454,9 +421,7 @@ scenarios
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -468,40 +433,32 @@ scenarios
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--scenario-id <id>', 'Scenario ID')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      scenarioId: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachScenariosService(options.project);
-        const result = await service.viewScenario({
-          project: options.project,
-          scenarioId: options.scenarioId,
-        });
+  .action(async (options: { project: string; scenarioId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachScenariosService(options.project);
+      const result = await service.viewScenario({
+        project: options.project,
+        scenarioId: options.scenarioId,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Scenario: ${result.name}`);
-          console.log(`  Status: ${result.status}`);
-          console.log(`  Nodes:  ${result.nodes.length}`);
-          if (result.triggerDescription) {
-            console.log(`  Trigger: ${result.triggerDescription}`);
-          }
-          if (result.performance) {
-            console.log(`  Performance: ${JSON.stringify(result.performance)}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Scenario: ${result.name}`);
+        console.log(`  Status: ${result.status}`);
+        console.log(`  Nodes:  ${result.nodes.length}`);
+        if (result.triggerDescription) {
+          console.log(`  Trigger: ${result.triggerDescription}`);
         }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+        if (result.performance) {
+          console.log(`  Performance: ${JSON.stringify(result.performance)}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 scenarios
   .command('create')
@@ -527,7 +484,7 @@ scenarios
           project: options.project,
           name: options.name,
           templateId: options.templateId,
-          tags: options.tags ? options.tags.split(',').map(t => t.trim()) : undefined,
+          tags: options.tags ? options.tags.split(',').map((t) => t.trim()) : undefined,
           operatorNote: options.note,
         });
 
@@ -543,9 +500,7 @@ scenarios
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -559,12 +514,7 @@ scenarios
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      scenarioId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; scenarioId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachScenariosService(options.project);
         const result = service.prepareStartScenario({
@@ -585,9 +535,7 @@ scenarios
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -601,12 +549,7 @@ scenarios
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      scenarioId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; scenarioId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachScenariosService(options.project);
         const result = service.prepareStopScenario({
@@ -627,9 +570,7 @@ scenarios
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -673,9 +614,7 @@ scenarios
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -689,12 +628,7 @@ scenarios
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      scenarioId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; scenarioId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachScenariosService(options.project);
         const result = service.prepareArchiveScenario({
@@ -715,9 +649,7 @@ scenarios
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -731,46 +663,41 @@ emailCampaigns
   .command('list')
   .description('List all email campaigns in the project')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .option('--status <status>', 'Filter by status (draft, scheduled, sending, sent, paused, archived)')
+  .option(
+    '--status <status>',
+    'Filter by status (draft, scheduled, sending, sent, paused, archived)',
+  )
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      status?: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachEmailCampaignsService(options.project);
-        const input: { project: string; status?: string } = {
-          project: options.project,
-        };
-        if (options.status) input.status = options.status;
+  .action(async (options: { project: string; status?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachEmailCampaignsService(options.project);
+      const input: { project: string; status?: string } = {
+        project: options.project,
+      };
+      if (options.status) input.status = options.status;
 
-        const result = await service.listEmailCampaigns(input);
+      const result = await service.listEmailCampaigns(input);
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No email campaigns found.');
-            return;
-          }
-          for (const campaign of result) {
-            console.log(`  ${campaign.name}`);
-            console.log(`    Status:  ${campaign.status}`);
-            console.log(`    Subject: ${campaign.subjectLine}`);
-            console.log(`    ID:      ${campaign.id}`);
-            console.log(`    URL:     ${campaign.url}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No email campaigns found.');
+          return;
         }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+        for (const campaign of result) {
+          console.log(`  ${campaign.name}`);
+          console.log(`    Status:  ${campaign.status}`);
+          console.log(`    Subject: ${campaign.subjectLine}`);
+          console.log(`    ID:      ${campaign.id}`);
+          console.log(`    URL:     ${campaign.url}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 emailCampaigns
   .command('view-results')
@@ -778,41 +705,33 @@ emailCampaigns
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--campaign-id <id>', 'Email campaign ID')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      campaignId: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachEmailCampaignsService(options.project);
-        const result = await service.viewCampaignResults({
-          project: options.project,
-          campaignId: options.campaignId,
-        });
+  .action(async (options: { project: string; campaignId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachEmailCampaignsService(options.project);
+      const result = await service.viewCampaignResults({
+        project: options.project,
+        campaignId: options.campaignId,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Campaign Results: ${result.campaignId}`);
-          console.log(`  Sent:         ${result.sent}`);
-          console.log(`  Delivered:    ${result.delivered}`);
-          console.log(`  Opened:       ${result.opened}`);
-          console.log(`  Clicked:      ${result.clicked}`);
-          console.log(`  Bounced:      ${result.bounced}`);
-          console.log(`  Unsubscribed: ${result.unsubscribed}`);
-          console.log(`  Open Rate:    ${(result.openRate * 100).toFixed(1)}%`);
-          console.log(`  CTR:          ${(result.clickThroughRate * 100).toFixed(1)}%`);
-          console.log(`  Revenue:      ${result.revenue}`);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Campaign Results: ${result.campaignId}`);
+        console.log(`  Sent:         ${result.sent}`);
+        console.log(`  Delivered:    ${result.delivered}`);
+        console.log(`  Opened:       ${result.opened}`);
+        console.log(`  Clicked:      ${result.clicked}`);
+        console.log(`  Bounced:      ${result.bounced}`);
+        console.log(`  Unsubscribed: ${result.unsubscribed}`);
+        console.log(`  Open Rate:    ${(result.openRate * 100).toFixed(1)}%`);
+        console.log(`  CTR:          ${(result.clickThroughRate * 100).toFixed(1)}%`);
+        console.log(`  Revenue:      ${result.revenue}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 emailCampaigns
   .command('create')
@@ -861,9 +780,7 @@ emailCampaigns
           abTest = {
             enabled: true,
             variants: parseInt(options.abVariants, 10),
-            splitPercentage: options.abSplit
-              ? parseInt(options.abSplit, 10)
-              : undefined,
+            splitPercentage: options.abSplit ? parseInt(options.abSplit, 10) : undefined,
             winnerCriteria: options.abWinner,
           };
         }
@@ -893,9 +810,7 @@ emailCampaigns
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -909,12 +824,7 @@ emailCampaigns
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      campaignId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; campaignId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachEmailCampaignsService(options.project);
         const result = service.prepareSendEmailCampaign({
@@ -935,9 +845,7 @@ emailCampaigns
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -981,9 +889,7 @@ emailCampaigns
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -997,12 +903,7 @@ emailCampaigns
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      campaignId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; campaignId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachEmailCampaignsService(options.project);
         const result = service.prepareArchiveEmailCampaign({
@@ -1023,9 +924,7 @@ emailCampaigns
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1041,44 +940,36 @@ surveys
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--status <status>', 'Filter by status (active, inactive, draft, archived)')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      status?: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachSurveysService(options.project);
-        const input: { project: string; status?: string } = {
-          project: options.project,
-        };
-        if (options.status) input.status = options.status;
+  .action(async (options: { project: string; status?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSurveysService(options.project);
+      const input: { project: string; status?: string } = {
+        project: options.project,
+      };
+      if (options.status) input.status = options.status;
 
-        const result = await service.listSurveys(input);
+      const result = await service.listSurveys(input);
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No surveys found.');
-            return;
-          }
-          for (const survey of result) {
-            console.log(`  ${survey.name}`);
-            console.log(`    Status:    ${survey.status}`);
-            console.log(`    Questions: ${survey.questions.length}`);
-            console.log(`    ID:        ${survey.id}`);
-            console.log(`    URL:       ${survey.url}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No surveys found.');
+          return;
         }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+        for (const survey of result) {
+          console.log(`  ${survey.name}`);
+          console.log(`    Status:    ${survey.status}`);
+          console.log(`    Questions: ${survey.questions.length}`);
+          console.log(`    ID:        ${survey.id}`);
+          console.log(`    URL:       ${survey.url}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 surveys
   .command('view-results')
@@ -1086,47 +977,42 @@ surveys
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--survey-id <id>', 'Survey ID')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      surveyId: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachSurveysService(options.project);
-        const result = await service.viewSurveyResults({
-          project: options.project,
-          surveyId: options.surveyId,
-        });
+  .action(async (options: { project: string; surveyId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSurveysService(options.project);
+      const result = await service.viewSurveyResults({
+        project: options.project,
+        surveyId: options.surveyId,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Survey Results: ${result.surveyId}`);
-          console.log(`  Total Responses:  ${result.totalResponses}`);
-          console.log(`  Completion Rate:  ${(result.completionRate * 100).toFixed(1)}%`);
-          for (const dist of result.responseDistribution) {
-            console.log(`  Question: ${dist.questionText}`);
-            for (const [answer, count] of Object.entries(dist.answers)) {
-              console.log(`    ${answer}: ${count}`);
-            }
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Survey Results: ${result.surveyId}`);
+        console.log(`  Total Responses:  ${result.totalResponses}`);
+        console.log(`  Completion Rate:  ${(result.completionRate * 100).toFixed(1)}%`);
+        for (const dist of result.responseDistribution) {
+          console.log(`  Question: ${dist.questionText}`);
+          for (const [answer, count] of Object.entries(dist.answers)) {
+            console.log(`    ${answer}: ${count}`);
           }
         }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 surveys
   .command('create')
   .description('Prepare creation of a new on-site survey (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--name <name>', 'Survey name')
-  .requiredOption('--questions <json>', 'JSON array of questions [{id, type, text, options?, required?}]')
+  .requiredOption(
+    '--questions <json>',
+    'JSON array of questions [{id, type, text, options?, required?}]',
+  )
   .option('--audience <audience>', 'Target audience segment')
   .option('--page-url <url>', 'Page URL where survey appears')
   .option('--trigger-event <event>', 'Trigger event name')
@@ -1192,9 +1078,7 @@ surveys
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1207,40 +1091,31 @@ surveys
   .requiredOption('--survey-id <id>', 'Survey ID')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      surveyId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachSurveysService(options.project);
-        const result = service.prepareStartSurvey({
-          project: options.project,
-          surveyId: options.surveyId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; surveyId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSurveysService(options.project);
+      const result = service.prepareStartSurvey({
+        project: options.project,
+        surveyId: options.surveyId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Survey start prepared.');
-          console.log(`  Survey:  ${options.surveyId}`);
-          console.log(`  Token:   ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Survey start prepared.');
+        console.log(`  Survey:  ${options.surveyId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 surveys
   .command('stop')
@@ -1249,40 +1124,31 @@ surveys
   .requiredOption('--survey-id <id>', 'Survey ID')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      surveyId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachSurveysService(options.project);
-        const result = service.prepareStopSurvey({
-          project: options.project,
-          surveyId: options.surveyId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; surveyId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSurveysService(options.project);
+      const result = service.prepareStopSurvey({
+        project: options.project,
+        surveyId: options.surveyId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Survey stop prepared.');
-          console.log(`  Survey:  ${options.surveyId}`);
-          console.log(`  Token:   ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Survey stop prepared.');
+        console.log(`  Survey:  ${options.surveyId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 surveys
   .command('archive')
@@ -1291,40 +1157,31 @@ surveys
   .requiredOption('--survey-id <id>', 'Survey ID')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      surveyId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachSurveysService(options.project);
-        const result = service.prepareArchiveSurvey({
-          project: options.project,
-          surveyId: options.surveyId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; surveyId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSurveysService(options.project);
+      const result = service.prepareArchiveSurvey({
+        project: options.project,
+        surveyId: options.surveyId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Survey archive prepared.');
-          console.log(`  Survey:  ${options.surveyId}`);
-          console.log(`  Token:   ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Survey archive prepared.');
+        console.log(`  Survey:  ${options.surveyId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 const campaignCalendar = program
   .command('campaigns-calendar')
@@ -1338,12 +1195,7 @@ campaignCalendar
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      startDate?: string;
-      endDate?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; startDate?: string; endDate?: string; json?: boolean }) => {
       try {
         const service = new BloomreachCampaignCalendarService(options.project);
         const result = await service.viewCampaignCalendar({
@@ -1370,9 +1222,7 @@ campaignCalendar
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1385,7 +1235,10 @@ campaignCalendar
   .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
   .option('--type <type>', 'Campaign type (email, sms, push, in_app, weblayer, webhook)')
-  .option('--status <status>', 'Campaign status (draft, scheduled, running, paused, stopped, finished)')
+  .option(
+    '--status <status>',
+    'Campaign status (draft, scheduled, running, paused, stopped, finished)',
+  )
   .option('--channel <channel>', 'Channel (email, sms, push, in_app, weblayer, webhook)')
   .option('--json', 'Output as JSON')
   .action(
@@ -1427,9 +1280,7 @@ campaignCalendar
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1442,7 +1293,10 @@ campaignCalendar
   .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
   .option('--type <type>', 'Campaign type filter (email, sms, push, in_app, weblayer, webhook)')
-  .option('--status <status>', 'Campaign status filter (draft, scheduled, running, paused, stopped, finished)')
+  .option(
+    '--status <status>',
+    'Campaign status filter (draft, scheduled, running, paused, stopped, finished)',
+  )
   .option('--channel <channel>', 'Channel filter (email, sms, push, in_app, weblayer, webhook)')
   .option('--format <format>', 'Export format (json, csv)', 'json')
   .option('--note <note>', 'Operator note for audit trail')
@@ -1484,17 +1338,13 @@ campaignCalendar
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
   );
 
-const trends = program
-  .command('trends')
-  .description('Manage Bloomreach Engagement trend analyses');
+const trends = program.command('trends').description('Manage Bloomreach Engagement trend analyses');
 
 trends
   .command('list')
@@ -1522,9 +1372,7 @@ trends
         }
       }
     } catch (error) {
-      console.error(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -1573,9 +1421,7 @@ trends
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1587,7 +1433,11 @@ trends
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--name <name>', 'Trend analysis name')
   .requiredOption('--events <csv>', 'Events to track (comma-separated)')
-  .option('--granularity <granularity>', 'Time granularity (hourly, daily, weekly, monthly)', 'daily')
+  .option(
+    '--granularity <granularity>',
+    'Time granularity (hourly, daily, weekly, monthly)',
+    'daily',
+  )
   .option('--customer-attributes <json>', 'JSON object of customer attribute filters')
   .option('--event-properties <json>', 'JSON object of event property filters')
   .option('--note <note>', 'Operator note for audit trail')
@@ -1612,17 +1462,14 @@ trends
           >;
         }
         if (options.eventProperties) {
-          filters.eventProperties = JSON.parse(options.eventProperties) as Record<
-            string,
-            string
-          >;
+          filters.eventProperties = JSON.parse(options.eventProperties) as Record<string, string>;
         }
 
         const service = new BloomreachTrendsService(options.project);
         const result = service.prepareCreateTrendAnalysis({
           project: options.project,
           name: options.name,
-          events: options.events.split(',').map(event => event.trim()),
+          events: options.events.split(',').map((event) => event.trim()),
           granularity: options.granularity,
           filters: Object.keys(filters).length > 0 ? filters : undefined,
           operatorNote: options.note,
@@ -1640,9 +1487,7 @@ trends
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1686,9 +1531,7 @@ trends
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1702,12 +1545,7 @@ trends
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      analysisId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; analysisId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachTrendsService(options.project);
         const result = service.prepareArchiveTrendAnalysis({
@@ -1728,9 +1566,7 @@ trends
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1766,9 +1602,7 @@ funnels
         }
       }
     } catch (error) {
-      console.error(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -1816,9 +1650,7 @@ funnels
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1856,10 +1688,7 @@ funnels
           >;
         }
         if (options.eventProperties) {
-          filters.eventProperties = JSON.parse(options.eventProperties) as Record<
-            string,
-            string
-          >;
+          filters.eventProperties = JSON.parse(options.eventProperties) as Record<string, string>;
         }
 
         const service = new BloomreachFunnelsService(options.project);
@@ -1868,9 +1697,7 @@ funnels
           name: options.name,
           steps,
           timeLimitMs:
-            options.timeLimitMs !== undefined
-              ? parseInt(options.timeLimitMs, 10)
-              : undefined,
+            options.timeLimitMs !== undefined ? parseInt(options.timeLimitMs, 10) : undefined,
           filters: Object.keys(filters).length > 0 ? filters : undefined,
           operatorNote: options.note,
         });
@@ -1887,9 +1714,7 @@ funnels
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1933,9 +1758,7 @@ funnels
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -1949,12 +1772,7 @@ funnels
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      analysisId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; analysisId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachFunnelsService(options.project);
         const result = service.prepareArchiveFunnelAnalysis({
@@ -1975,9 +1793,7 @@ funnels
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -2014,9 +1830,7 @@ retentions
         }
       }
     } catch (error) {
-      console.error(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -2067,9 +1881,7 @@ retentions
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -2112,10 +1924,7 @@ retentions
           >;
         }
         if (options.eventProperties) {
-          filters.eventProperties = JSON.parse(options.eventProperties) as Record<
-            string,
-            string
-          >;
+          filters.eventProperties = JSON.parse(options.eventProperties) as Record<string, string>;
         }
 
         const dateRange =
@@ -2147,9 +1956,7 @@ retentions
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -2193,9 +2000,7 @@ retentions
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -2209,12 +2014,7 @@ retentions
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      analysisId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; analysisId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachRetentionsService(options.project);
         const result = service.prepareArchiveRetentionAnalysis({
@@ -2235,9 +2035,250 @@ retentions
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const flows = program
+  .command('flows')
+  .description('Manage Bloomreach Engagement flow analyses (Sankey-style journey visualization)');
+
+flows
+  .command('list')
+  .description('List all flow analyses in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachFlowsService(options.project);
+      const result = await service.listFlowAnalyses({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No flow analyses found.');
+          return;
+        }
+        for (const flow of result) {
+          console.log(`  ${flow.name}`);
+          console.log(`    Starting event: ${flow.startingEvent}`);
+          console.log(`    Events:         ${flow.events.length}`);
+          console.log(`    Max depth:      ${flow.maxJourneyDepth ?? 'none'}`);
+          console.log(`    ID:             ${flow.id}`);
+          console.log(`    URL:            ${flow.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+flows
+  .command('view-results')
+  .description('View journey paths, volumes and drop-offs for a flow analysis')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Flow analysis ID')
+  .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
+  .option('--end-date <date>', 'End date (YYYY-MM-DD)')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      startDate?: string;
+      endDate?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachFlowsService(options.project);
+        const result = await service.viewFlowResults({
+          project: options.project,
+          analysisId: options.analysisId,
+          startDate: options.startDate,
+          endDate: options.endDate,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log(`Flow Analysis: ${result.analysisName}`);
+          console.log(`  Starting event:  ${result.startingEvent}`);
+          console.log(`  Date range:      ${result.startDate} to ${result.endDate}`);
+          console.log(`  Total journeys:  ${result.totalJourneys}`);
+          console.log(`  Max depth:       ${result.maxJourneyDepth ?? 'none'}`);
+          if (result.paths.length === 0) {
+            console.log('  Paths: none');
+          } else {
+            console.log('  Top paths:');
+            for (const path of result.paths) {
+              console.log(
+                `    ${path.events.join(' → ')} | volume=${path.volume}, conversion=${path.conversionRate}`,
+              );
+            }
+          }
+          if (result.dropOffs.length > 0) {
+            console.log('  Drop-offs:');
+            for (const dropOff of result.dropOffs) {
+              console.log(
+                `    After ${dropOff.afterEvent}: volume=${dropOff.volume}, rate=${dropOff.dropOffRate}`,
+              );
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+flows
+  .command('create')
+  .description('Prepare creation of a new flow analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Flow analysis name')
+  .requiredOption('--starting-event <event>', 'Starting event for the journey')
+  .requiredOption('--events <json>', 'JSON array of events to track [{order, eventName, label?}]')
+  .option('--max-journey-depth <n>', 'Maximum journey depth (1-20)')
+  .option('--customer-attributes <json>', 'JSON object of customer attribute filters')
+  .option('--event-properties <json>', 'JSON object of event property filters')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      startingEvent: string;
+      events: string;
+      maxJourneyDepth?: string;
+      customerAttributes?: string;
+      eventProperties?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const events = JSON.parse(options.events) as FlowEvent[];
+        const filters: FlowFilter = {};
+        if (options.customerAttributes) {
+          filters.customerAttributes = JSON.parse(options.customerAttributes) as Record<
+            string,
+            string
+          >;
+        }
+        if (options.eventProperties) {
+          filters.eventProperties = JSON.parse(options.eventProperties) as Record<string, string>;
+        }
+
+        const service = new BloomreachFlowsService(options.project);
+        const result = service.prepareCreateFlowAnalysis({
+          project: options.project,
+          name: options.name,
+          startingEvent: options.startingEvent,
+          events,
+          maxJourneyDepth:
+            options.maxJourneyDepth !== undefined
+              ? parseInt(options.maxJourneyDepth, 10)
+              : undefined,
+          filters: Object.keys(filters).length > 0 ? filters : undefined,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Flow analysis creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+flows
+  .command('clone')
+  .description('Prepare cloning a flow analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Flow analysis ID to clone')
+  .option('--new-name <name>', 'Name for the cloned analysis')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      newName?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachFlowsService(options.project);
+        const result = service.prepareCloneFlowAnalysis({
+          project: options.project,
+          analysisId: options.analysisId,
+          newName: options.newName,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Flow analysis clone prepared.');
+          console.log(`  Source:   ${options.analysisId}`);
+          console.log(`  New name: ${options.newName ?? '(auto-generated)'}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+flows
+  .command('archive')
+  .description('Prepare archiving a flow analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Flow analysis ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; analysisId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachFlowsService(options.project);
+        const result = service.prepareArchiveFlowAnalysis({
+          project: options.project,
+          analysisId: options.analysisId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Flow analysis archive prepared.');
+          console.log(`  Analysis: ${options.analysisId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },

--- a/packages/core/src/__tests__/bloomreachFlows.test.ts
+++ b/packages/core/src/__tests__/bloomreachFlows.test.ts
@@ -1,0 +1,1330 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_FLOW_ACTION_TYPE,
+  CLONE_FLOW_ACTION_TYPE,
+  ARCHIVE_FLOW_ACTION_TYPE,
+  FLOW_RATE_LIMIT_WINDOW_MS,
+  FLOW_CREATE_RATE_LIMIT,
+  FLOW_MODIFY_RATE_LIMIT,
+  validateFlowName,
+  validateFlowAnalysisId,
+  validateStartingEvent,
+  validateFlowEvents,
+  validateMaxJourneyDepth,
+  buildFlowsUrl,
+  createFlowActionExecutors,
+  BloomreachFlowsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_FLOW_ACTION_TYPE', () => {
+    expect(CREATE_FLOW_ACTION_TYPE).toBe('flows.create_flow');
+  });
+
+  it('exports CLONE_FLOW_ACTION_TYPE', () => {
+    expect(CLONE_FLOW_ACTION_TYPE).toBe('flows.clone_flow');
+  });
+
+  it('exports ARCHIVE_FLOW_ACTION_TYPE', () => {
+    expect(ARCHIVE_FLOW_ACTION_TYPE).toBe('flows.archive_flow');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports FLOW_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(FLOW_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports FLOW_CREATE_RATE_LIMIT', () => {
+    expect(FLOW_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports FLOW_MODIFY_RATE_LIMIT', () => {
+    expect(FLOW_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('validateFlowName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateFlowName('  My Flow  ')).toBe('My Flow');
+  });
+
+  it('returns trimmed name with tabs and newlines', () => {
+    expect(validateFlowName('\n\tRevenue Flow\t\n')).toBe('Revenue Flow');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateFlowName('A')).toBe('A');
+  });
+
+  it('accepts numeric name', () => {
+    expect(validateFlowName('123')).toBe('123');
+  });
+
+  it('accepts name with punctuation', () => {
+    expect(validateFlowName('Flow: Checkout v2')).toBe('Flow: Checkout v2');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateFlowName(name)).toBe(name);
+  });
+
+  it('accepts name with emoji', () => {
+    expect(validateFlowName('Flow 🚀')).toBe('Flow 🚀');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateFlowName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateFlowName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateFlowName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateFlowName('\n\n')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateFlowName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateFlowAnalysisId', () => {
+  it('returns trimmed flow analysis ID for valid input', () => {
+    expect(validateFlowAnalysisId('  flow-123  ')).toBe('flow-123');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateFlowAnalysisId('flow-456')).toBe('flow-456');
+  });
+
+  it('returns ID containing slashes', () => {
+    expect(validateFlowAnalysisId('analysis/segment/a')).toBe('analysis/segment/a');
+  });
+
+  it('returns ID containing hash', () => {
+    expect(validateFlowAnalysisId('analysis#1')).toBe('analysis#1');
+  });
+
+  it('returns ID containing spaces after trim', () => {
+    expect(validateFlowAnalysisId('  flow segment 1  ')).toBe('flow segment 1');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateFlowAnalysisId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateFlowAnalysisId('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateFlowAnalysisId('\n')).toThrow('must not be empty');
+  });
+});
+
+describe('validateStartingEvent', () => {
+  it('returns trimmed starting event for valid input', () => {
+    expect(validateStartingEvent('  session_start  ')).toBe('session_start');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateStartingEvent('purchase')).toBe('purchase');
+  });
+
+  it('accepts event name with spaces', () => {
+    expect(validateStartingEvent('view product')).toBe('view product');
+  });
+
+  it('accepts event name with punctuation', () => {
+    expect(validateStartingEvent('checkout:started')).toBe('checkout:started');
+  });
+
+  it('accepts event name with tabs and newlines around content', () => {
+    expect(validateStartingEvent('\n\tentry_event\t\n')).toBe('entry_event');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateStartingEvent('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateStartingEvent('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateStartingEvent('\t\t')).toThrow('must not be empty');
+  });
+});
+
+describe('validateFlowEvents', () => {
+  it('accepts one event with sequential order', () => {
+    const events = [{ order: 1, eventName: 'session_start' }];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'session_start', label: undefined },
+    ]);
+  });
+
+  it('accepts valid two-event flow', () => {
+    const events = [
+      { order: 1, eventName: 'view product' },
+      { order: 2, eventName: 'purchase' },
+    ];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'view product', label: undefined },
+      { order: 2, eventName: 'purchase', label: undefined },
+    ]);
+  });
+
+  it('accepts valid three-event flow', () => {
+    const events = [
+      { order: 1, eventName: 'open app' },
+      { order: 2, eventName: 'view category' },
+      { order: 3, eventName: 'purchase' },
+    ];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'open app', label: undefined },
+      { order: 2, eventName: 'view category', label: undefined },
+      { order: 3, eventName: 'purchase', label: undefined },
+    ]);
+  });
+
+  it('returns a new array', () => {
+    const events = [{ order: 1, eventName: 'entry' }];
+    const result = validateFlowEvents(events);
+    expect(result).not.toBe(events);
+  });
+
+  it('trims eventName values', () => {
+    const events = [{ order: 1, eventName: '  entry_event  ' }];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'entry_event', label: undefined },
+    ]);
+  });
+
+  it('trims label values when provided', () => {
+    const events = [{ order: 1, eventName: 'entry', label: '  Entry Label  ' }];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'entry', label: 'Entry Label' },
+    ]);
+  });
+
+  it('converts whitespace-only label to undefined', () => {
+    const events = [{ order: 1, eventName: 'entry', label: '   ' }];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'entry', label: undefined },
+    ]);
+  });
+
+  it('preserves undefined label', () => {
+    const events = [{ order: 1, eventName: 'entry' }];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'entry', label: undefined },
+    ]);
+  });
+
+  it('accepts empty-string label by normalizing to undefined', () => {
+    const events = [{ order: 1, eventName: 'entry', label: '' }];
+    expect(validateFlowEvents(events)).toEqual([
+      { order: 1, eventName: 'entry', label: undefined },
+    ]);
+  });
+
+  it('throws for empty array', () => {
+    expect(() => validateFlowEvents([])).toThrow('at least one event');
+  });
+
+  it('throws when order does not start at 1', () => {
+    expect(() => validateFlowEvents([{ order: 2, eventName: 'entry' }])).toThrow(
+      'events[0].order must be 1',
+    );
+  });
+
+  it('throws for non-sequential order with gap in two events', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 1, eventName: 'entry' },
+        { order: 3, eventName: 'purchase' },
+      ]),
+    ).toThrow('must be 2');
+  });
+
+  it('throws for non-sequential order with gap in three events', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 1, eventName: 'entry' },
+        { order: 2, eventName: 'view product' },
+        { order: 4, eventName: 'purchase' },
+      ]),
+    ).toThrow('must be 3');
+  });
+
+  it('throws for duplicate order values', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 1, eventName: 'entry' },
+        { order: 1, eventName: 'purchase' },
+      ]),
+    ).toThrow('must be 2');
+  });
+
+  it('throws for descending order values', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 2, eventName: 'purchase' },
+        { order: 1, eventName: 'entry' },
+      ]),
+    ).toThrow('events[0].order must be 1');
+  });
+
+  it('throws for zero order as first event', () => {
+    expect(() => validateFlowEvents([{ order: 0, eventName: 'entry' }])).toThrow(
+      'events[0].order must be 1',
+    );
+  });
+
+  it('throws for negative order as first event', () => {
+    expect(() => validateFlowEvents([{ order: -1, eventName: 'entry' }])).toThrow(
+      'events[0].order must be 1',
+    );
+  });
+
+  it('throws for zero order in second event', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 1, eventName: 'entry' },
+        { order: 0, eventName: 'purchase' },
+      ]),
+    ).toThrow('must be 2');
+  });
+
+  it('throws for negative order in second event', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 1, eventName: 'entry' },
+        { order: -2, eventName: 'purchase' },
+      ]),
+    ).toThrow('must be 2');
+  });
+
+  it('throws for empty eventName in single event', () => {
+    expect(() => validateFlowEvents([{ order: 1, eventName: '' }])).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only eventName in single event', () => {
+    expect(() => validateFlowEvents([{ order: 1, eventName: '   ' }])).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only eventName in single event', () => {
+    expect(() => validateFlowEvents([{ order: 1, eventName: '\t' }])).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only eventName in single event', () => {
+    expect(() => validateFlowEvents([{ order: 1, eventName: '\n' }])).toThrow('must not be empty');
+  });
+
+  it('throws for empty eventName in second event', () => {
+    expect(() =>
+      validateFlowEvents([
+        { order: 1, eventName: 'entry' },
+        { order: 2, eventName: '' },
+      ]),
+    ).toThrow('must not be empty');
+  });
+});
+
+describe('validateMaxJourneyDepth', () => {
+  it('returns undefined when depth is undefined', () => {
+    expect(validateMaxJourneyDepth(undefined)).toBeUndefined();
+  });
+
+  it('accepts integer 1', () => {
+    expect(validateMaxJourneyDepth(1)).toBe(1);
+  });
+
+  it('accepts integer 2', () => {
+    expect(validateMaxJourneyDepth(2)).toBe(2);
+  });
+
+  it('accepts integer 5', () => {
+    expect(validateMaxJourneyDepth(5)).toBe(5);
+  });
+
+  it('accepts integer 10', () => {
+    expect(validateMaxJourneyDepth(10)).toBe(10);
+  });
+
+  it('accepts integer 19', () => {
+    expect(validateMaxJourneyDepth(19)).toBe(19);
+  });
+
+  it('accepts integer 20', () => {
+    expect(validateMaxJourneyDepth(20)).toBe(20);
+  });
+
+  it('throws for 0', () => {
+    expect(() => validateMaxJourneyDepth(0)).toThrow('between 1 and 20');
+  });
+
+  it('throws for negative integer', () => {
+    expect(() => validateMaxJourneyDepth(-1)).toThrow('between 1 and 20');
+  });
+
+  it('throws for large negative integer', () => {
+    expect(() => validateMaxJourneyDepth(-100)).toThrow('between 1 and 20');
+  });
+
+  it('throws for decimal 1.5', () => {
+    expect(() => validateMaxJourneyDepth(1.5)).toThrow('integer between 1 and 20');
+  });
+
+  it('throws for decimal 10.01', () => {
+    expect(() => validateMaxJourneyDepth(10.01)).toThrow('integer between 1 and 20');
+  });
+
+  it('throws for Number.MIN_VALUE', () => {
+    expect(() => validateMaxJourneyDepth(Number.MIN_VALUE)).toThrow('integer between 1 and 20');
+  });
+
+  it('throws for NaN', () => {
+    expect(() => validateMaxJourneyDepth(Number.NaN)).toThrow('between 1 and 20');
+  });
+
+  it('throws for Infinity', () => {
+    expect(() => validateMaxJourneyDepth(Number.POSITIVE_INFINITY)).toThrow('between 1 and 20');
+  });
+
+  it('throws for negative Infinity', () => {
+    expect(() => validateMaxJourneyDepth(Number.NEGATIVE_INFINITY)).toThrow('between 1 and 20');
+  });
+
+  it('throws for 21', () => {
+    expect(() => validateMaxJourneyDepth(21)).toThrow('between 1 and 20');
+  });
+
+  it('throws for 100', () => {
+    expect(() => validateMaxJourneyDepth(100)).toThrow('between 1 and 20');
+  });
+});
+
+describe('buildFlowsUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildFlowsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/analytics/flows');
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildFlowsUrl('my project')).toBe('/p/my%20project/analytics/flows');
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildFlowsUrl('org/project')).toBe('/p/org%2Fproject/analytics/flows');
+  });
+
+  it('encodes unicode characters in project name', () => {
+    expect(buildFlowsUrl('projekt åäö')).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/analytics/flows');
+  });
+
+  it('encodes hash character in project name', () => {
+    expect(buildFlowsUrl('my#project')).toBe('/p/my%23project/analytics/flows');
+  });
+
+  it('keeps dashes unencoded in project name', () => {
+    expect(buildFlowsUrl('team-alpha')).toBe('/p/team-alpha/analytics/flows');
+  });
+});
+
+describe('createFlowActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createFlowActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[CREATE_FLOW_ACTION_TYPE]).toBeDefined();
+    expect(executors[CLONE_FLOW_ACTION_TYPE]).toBeDefined();
+    expect(executors[ARCHIVE_FLOW_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createFlowActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('create executor throws "not yet implemented" on execute', async () => {
+    const executors = createFlowActionExecutors();
+    await expect(executors[CREATE_FLOW_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('clone executor throws "not yet implemented" on execute', async () => {
+    const executors = createFlowActionExecutors();
+    await expect(executors[CLONE_FLOW_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('archive executor throws "not yet implemented" on execute', async () => {
+    const executors = createFlowActionExecutors();
+    await expect(executors[ARCHIVE_FLOW_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+});
+
+describe('BloomreachFlowsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachFlowsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachFlowsService);
+    });
+
+    it('exposes the flows URL', () => {
+      const service = new BloomreachFlowsService('kingdom-of-joakim');
+      expect(service.flowsUrl).toBe('/p/kingdom-of-joakim/analytics/flows');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachFlowsService('  my-project  ');
+      expect(service.flowsUrl).toBe('/p/my-project/analytics/flows');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachFlowsService('')).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      expect(() => new BloomreachFlowsService('   ')).toThrow('must not be empty');
+    });
+
+    it('throws for tab-only project', () => {
+      expect(() => new BloomreachFlowsService('\t\t')).toThrow('must not be empty');
+    });
+
+    it('encodes slashes in constructor project URL', () => {
+      const service = new BloomreachFlowsService('org/project');
+      expect(service.flowsUrl).toBe('/p/org%2Fproject/analytics/flows');
+    });
+
+    it('encodes spaces in constructor project URL', () => {
+      const service = new BloomreachFlowsService('my project');
+      expect(service.flowsUrl).toBe('/p/my%20project/analytics/flows');
+    });
+  });
+
+  describe('flowsUrl getter', () => {
+    it('returns stable value across multiple reads', () => {
+      const service = new BloomreachFlowsService('alpha');
+      expect(service.flowsUrl).toBe('/p/alpha/analytics/flows');
+      expect(service.flowsUrl).toBe('/p/alpha/analytics/flows');
+    });
+  });
+
+  describe('listFlowAnalyses', () => {
+    it('throws not-yet-implemented error without input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.listFlowAnalyses()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.listFlowAnalyses({ project: '' })).rejects.toThrow('must not be empty');
+    });
+
+    it('validates whitespace-only project when input is provided', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.listFlowAnalyses({ project: '   ' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates tab-only project when input is provided', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.listFlowAnalyses({ project: '\t' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws not-yet-implemented error for valid project override', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.listFlowAnalyses({ project: 'kingdom-of-joakim' })).rejects.toThrow(
+        'not yet implemented',
+      );
+    });
+
+    it('throws not-yet-implemented error for trimmed project override', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.listFlowAnalyses({ project: '  kingdom-of-joakim  ' })).rejects.toThrow(
+        'not yet implemented',
+      );
+    });
+  });
+
+  describe('viewFlowResults', () => {
+    it('throws not-yet-implemented error with valid minimal input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({ project: 'test', analysisId: 'flow-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('throws not-yet-implemented error with valid full input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({
+          project: '  test  ',
+          analysisId: '  flow-1  ',
+          startDate: '2025-01-01',
+          endDate: '2025-01-31',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.viewFlowResults({ project: '', analysisId: 'flow-1' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates whitespace-only project input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({ project: '   ', analysisId: 'flow-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates analysisId input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.viewFlowResults({ project: 'test', analysisId: '   ' })).rejects.toThrow(
+        'Flow analysis ID must not be empty',
+      );
+    });
+
+    it('validates empty analysisId input', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(service.viewFlowResults({ project: 'test', analysisId: '' })).rejects.toThrow(
+        'Flow analysis ID must not be empty',
+      );
+    });
+
+    it('accepts trimmed analysisId and reaches not-yet-implemented', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({ project: 'test', analysisId: '  flow-99  ' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates malformed startDate when provided', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({
+          project: 'test',
+          analysisId: 'flow-1',
+          startDate: '2025/01/01',
+        }),
+      ).rejects.toThrow('valid ISO-8601 date');
+    });
+
+    it('validates malformed endDate when provided', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({
+          project: 'test',
+          analysisId: 'flow-1',
+          endDate: '01-31-2025',
+        }),
+      ).rejects.toThrow('valid ISO-8601 date');
+    });
+
+    it('validates invalid calendar date for startDate', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({
+          project: 'test',
+          analysisId: 'flow-1',
+          startDate: '2025-02-30',
+        }),
+      ).rejects.toThrow('not a valid calendar date');
+    });
+
+    it('validates invalid calendar date for endDate', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({
+          project: 'test',
+          analysisId: 'flow-1',
+          endDate: '2025-11-31',
+        }),
+      ).rejects.toThrow('not a valid calendar date');
+    });
+
+    it('validates startDate before endDate ordering', async () => {
+      const service = new BloomreachFlowsService('test');
+      await expect(
+        service.viewFlowResults({
+          project: 'test',
+          analysisId: 'flow-1',
+          startDate: '2025-03-31',
+          endDate: '2025-03-01',
+        }),
+      ).rejects.toThrow('must not be after endDate');
+    });
+  });
+
+  describe('prepareCreateFlowAnalysis', () => {
+    it('returns a prepared action with valid minimal input', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Checkout Flow',
+        startingEvent: 'session_start',
+        events: [{ order: 1, eventName: 'purchase' }],
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'flows.create_flow',
+          project: 'test',
+          name: 'Checkout Flow',
+          startingEvent: 'session_start',
+          events: [{ order: 1, eventName: 'purchase', label: undefined }],
+          maxJourneyDepth: undefined,
+        }),
+      );
+    });
+
+    it('returns a prepared action with valid multi-event input', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Three Event Flow',
+        startingEvent: 'open_app',
+        events: [
+          { order: 1, eventName: 'view_category' },
+          { order: 2, eventName: 'view_product' },
+          { order: 3, eventName: 'purchase' },
+        ],
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: 'Three Event Flow',
+          startingEvent: 'open_app',
+          events: [
+            { order: 1, eventName: 'view_category', label: undefined },
+            { order: 2, eventName: 'view_product', label: undefined },
+            { order: 3, eventName: 'purchase', label: undefined },
+          ],
+        }),
+      );
+    });
+
+    it('includes maxJourneyDepth in preview when provided', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Deep Flow',
+        startingEvent: 'session_start',
+        events: [{ order: 1, eventName: 'purchase' }],
+        maxJourneyDepth: 12,
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          maxJourneyDepth: 12,
+        }),
+      );
+    });
+
+    it('includes filters in preview when provided', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Filtered Flow',
+        startingEvent: 'session_start',
+        events: [{ order: 1, eventName: 'purchase' }],
+        filters: {
+          customerAttributes: { segment: 'vip', locale: 'en_US' },
+          eventProperties: { currency: 'USD' },
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          filters: {
+            customerAttributes: { segment: 'vip', locale: 'en_US' },
+            eventProperties: { currency: 'USD' },
+          },
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Flow',
+        startingEvent: 'entry',
+        events: [{ order: 1, eventName: 'purchase' }],
+        operatorNote: 'Create before product launch review',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Create before product launch review',
+        }),
+      );
+    });
+
+    it('includes startingEvent in preview as trimmed value', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Flow',
+        startingEvent: '  session_start  ',
+        events: [{ order: 1, eventName: 'purchase' }],
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          startingEvent: 'session_start',
+        }),
+      );
+    });
+
+    it('includes normalized events in preview', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: 'Flow',
+        startingEvent: 'entry',
+        events: [
+          { order: 1, eventName: '  step_1  ', label: '  Step 1  ' },
+          { order: 2, eventName: '  step_2  ', label: '   ' },
+        ],
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          events: [
+            { order: 1, eventName: 'step_1', label: 'Step 1' },
+            { order: 2, eventName: 'step_2', label: undefined },
+          ],
+        }),
+      );
+    });
+
+    it('trims project and name in preview', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCreateFlowAnalysis({
+        project: '  my-project  ',
+        name: '  My Flow  ',
+        startingEvent: 'entry',
+        events: [{ order: 1, eventName: 'purchase' }],
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+          name: 'My Flow',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: '',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only name', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: '   ',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: '',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: '   ',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for too-long name', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'x'.repeat(201),
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws when events is empty', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [],
+        }),
+      ).toThrow('at least one event');
+    });
+
+    it('throws when events have empty eventName', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: '' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when events have whitespace-only eventName', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: '   ' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when events order is non-sequential', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [
+            { order: 1, eventName: 'visit' },
+            { order: 3, eventName: 'purchase' },
+          ],
+        }),
+      ).toThrow('must be 2');
+    });
+
+    it('throws when events order does not start at 1', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: 'entry',
+          events: [
+            { order: 2, eventName: 'visit' },
+            { order: 3, eventName: 'purchase' },
+          ],
+        }),
+      ).toThrow('events[0].order must be 1');
+    });
+
+    it('throws when startingEvent is empty', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: '',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('Starting event must not be empty');
+    });
+
+    it('throws when startingEvent is whitespace only', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Flow',
+          startingEvent: '   ',
+          events: [{ order: 1, eventName: 'purchase' }],
+        }),
+      ).toThrow('Starting event must not be empty');
+    });
+
+    it('throws when maxJourneyDepth is zero', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Deep Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+          maxJourneyDepth: 0,
+        }),
+      ).toThrow('between 1 and 20');
+    });
+
+    it('throws when maxJourneyDepth is greater than 20', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Deep Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+          maxJourneyDepth: 21,
+        }),
+      ).toThrow('between 1 and 20');
+    });
+
+    it('throws when maxJourneyDepth is non-integer', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCreateFlowAnalysis({
+          project: 'test',
+          name: 'Deep Flow',
+          startingEvent: 'entry',
+          events: [{ order: 1, eventName: 'purchase' }],
+          maxJourneyDepth: 12.5,
+        }),
+      ).toThrow('integer between 1 and 20');
+    });
+
+    it('accepts max-length name and still prepares action', () => {
+      const service = new BloomreachFlowsService('test');
+      const maxName = 'x'.repeat(200);
+      const result = service.prepareCreateFlowAnalysis({
+        project: 'test',
+        name: maxName,
+        startingEvent: 'entry',
+        events: [{ order: 1, eventName: 'purchase' }],
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: maxName,
+        }),
+      );
+    });
+  });
+
+  describe('prepareCloneFlowAnalysis', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCloneFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-789',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'flows.clone_flow',
+          project: 'test',
+          analysisId: 'flow-789',
+          newName: undefined,
+        }),
+      );
+    });
+
+    it('includes newName in preview when provided', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCloneFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-789',
+        newName: '  Cloned Flow  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName: 'Cloned Flow',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCloneFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-789',
+        operatorNote: 'Clone for region-specific experiment',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Clone for region-specific experiment',
+        }),
+      );
+    });
+
+    it('trims analysisId in preview', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCloneFlowAnalysis({
+        project: 'test',
+        analysisId: '  flow-789  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          analysisId: 'flow-789',
+        }),
+      );
+    });
+
+    it('throws for empty analysisId', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCloneFlowAnalysis({
+          project: 'test',
+          analysisId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only analysisId', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCloneFlowAnalysis({
+          project: 'test',
+          analysisId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCloneFlowAnalysis({
+          project: '',
+          analysisId: 'flow-789',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCloneFlowAnalysis({
+          project: '   ',
+          analysisId: 'flow-789',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName is whitespace only', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCloneFlowAnalysis({
+          project: 'test',
+          analysisId: 'flow-789',
+          newName: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName exceeds maximum length', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareCloneFlowAnalysis({
+          project: 'test',
+          analysisId: 'flow-789',
+          newName: 'x'.repeat(201),
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('accepts max-length newName', () => {
+      const service = new BloomreachFlowsService('test');
+      const newName = 'x'.repeat(200);
+      const result = service.prepareCloneFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-789',
+        newName,
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName,
+        }),
+      );
+    });
+
+    it('keeps undefined newName when omitted', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareCloneFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-789',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('prepareArchiveFlowAnalysis', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareArchiveFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'flows.archive_flow',
+          project: 'test',
+          analysisId: 'flow-900',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareArchiveFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-900',
+        operatorNote: 'Archive obsolete checkout flow analysis',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Archive obsolete checkout flow analysis',
+        }),
+      );
+    });
+
+    it('throws for empty analysisId', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareArchiveFlowAnalysis({
+          project: 'test',
+          analysisId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only analysisId', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareArchiveFlowAnalysis({
+          project: 'test',
+          analysisId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for tab-only analysisId', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareArchiveFlowAnalysis({
+          project: 'test',
+          analysisId: '\t',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareArchiveFlowAnalysis({
+          project: '',
+          analysisId: 'flow-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachFlowsService('test');
+      expect(() =>
+        service.prepareArchiveFlowAnalysis({
+          project: '   ',
+          analysisId: 'flow-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('accepts trimmed analysisId and reaches prepared state', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareArchiveFlowAnalysis({
+        project: 'test',
+        analysisId: '  flow-900  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          analysisId: 'flow-900',
+        }),
+      );
+    });
+
+    it('returns preview with action type', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareArchiveFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-901',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: ARCHIVE_FLOW_ACTION_TYPE,
+        }),
+      );
+    });
+
+    it('sets expiry in the future', () => {
+      const service = new BloomreachFlowsService('test');
+      const result = service.prepareArchiveFlowAnalysis({
+        project: 'test',
+        analysisId: 'flow-902',
+      });
+
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/packages/core/src/bloomreachFlows.ts
+++ b/packages/core/src/bloomreachFlows.ts
@@ -1,0 +1,325 @@
+import { validateProject } from './bloomreachDashboards.js';
+import { validateDateRange } from './bloomreachPerformance.js';
+import type { DateRangeFilter } from './bloomreachPerformance.js';
+
+export const CREATE_FLOW_ACTION_TYPE = 'flows.create_flow';
+export const CLONE_FLOW_ACTION_TYPE = 'flows.clone_flow';
+export const ARCHIVE_FLOW_ACTION_TYPE = 'flows.archive_flow';
+
+export const FLOW_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const FLOW_CREATE_RATE_LIMIT = 10;
+export const FLOW_MODIFY_RATE_LIMIT = 20;
+
+export interface FlowEvent {
+  order: number;
+  eventName: string;
+  label?: string;
+}
+
+export interface BloomreachFlowAnalysis {
+  id: string;
+  name: string;
+  startingEvent: string;
+  events: FlowEvent[];
+  maxJourneyDepth?: number;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface FlowFilter {
+  customerAttributes?: Record<string, string>;
+  eventProperties?: Record<string, string>;
+}
+
+export interface FlowPath {
+  events: string[];
+  volume: number;
+  conversionRate: number;
+}
+
+export interface FlowDropOff {
+  afterEvent: string;
+  volume: number;
+  dropOffRate: number;
+}
+
+export interface FlowResults {
+  analysisId: string;
+  analysisName: string;
+  startDate: string;
+  endDate: string;
+  startingEvent: string;
+  maxJourneyDepth?: number;
+  totalJourneys: number;
+  paths: FlowPath[];
+  dropOffs: FlowDropOff[];
+  filters?: FlowFilter;
+}
+
+export interface ListFlowAnalysesInput {
+  project: string;
+}
+
+export interface CreateFlowAnalysisInput {
+  project: string;
+  name: string;
+  startingEvent: string;
+  events: FlowEvent[];
+  maxJourneyDepth?: number;
+  filters?: FlowFilter;
+  operatorNote?: string;
+}
+
+export interface ViewFlowResultsInput {
+  project: string;
+  analysisId: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface CloneFlowAnalysisInput {
+  project: string;
+  analysisId: string;
+  newName?: string;
+  operatorNote?: string;
+}
+
+export interface ArchiveFlowAnalysisInput {
+  project: string;
+  analysisId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedFlowAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_FLOW_NAME_LENGTH = 200;
+const MIN_FLOW_NAME_LENGTH = 1;
+const MIN_JOURNEY_DEPTH = 1;
+const MAX_JOURNEY_DEPTH = 20;
+
+export function validateFlowName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_FLOW_NAME_LENGTH) {
+    throw new Error('Flow name must not be empty.');
+  }
+  if (trimmed.length > MAX_FLOW_NAME_LENGTH) {
+    throw new Error(
+      `Flow name must not exceed ${MAX_FLOW_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateFlowAnalysisId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Flow analysis ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateStartingEvent(eventName: string): string {
+  const trimmed = eventName.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Starting event must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateFlowEvents(events: FlowEvent[]): FlowEvent[] {
+  if (events.length < 1) {
+    throw new Error('events must contain at least one event to track.');
+  }
+
+  return events.map((event, index) => {
+    const expectedOrder = index + 1;
+    if (event.order !== expectedOrder) {
+      throw new Error(`events[${index}].order must be ${expectedOrder} (got ${event.order}).`);
+    }
+
+    const eventName = event.eventName.trim();
+    if (eventName.length === 0) {
+      throw new Error(`events[${index}].eventName must not be empty.`);
+    }
+
+    const label = event.label?.trim();
+
+    return {
+      order: event.order,
+      eventName,
+      label: label === undefined || label.length > 0 ? label : undefined,
+    };
+  });
+}
+
+export function validateMaxJourneyDepth(depth: number | undefined): number | undefined {
+  if (depth === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isInteger(depth) || depth < MIN_JOURNEY_DEPTH || depth > MAX_JOURNEY_DEPTH) {
+    throw new Error(
+      `maxJourneyDepth must be an integer between ${MIN_JOURNEY_DEPTH} and ${MAX_JOURNEY_DEPTH} (got ${depth}).`,
+    );
+  }
+
+  return depth;
+}
+
+export function buildFlowsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/analytics/flows`;
+}
+
+export interface FlowActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateFlowExecutor implements FlowActionExecutor {
+  readonly actionType = CREATE_FLOW_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateFlowExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CloneFlowExecutor implements FlowActionExecutor {
+  readonly actionType = CLONE_FLOW_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CloneFlowExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ArchiveFlowExecutor implements FlowActionExecutor {
+  readonly actionType = ARCHIVE_FLOW_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ArchiveFlowExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createFlowActionExecutors(): Record<string, FlowActionExecutor> {
+  return {
+    [CREATE_FLOW_ACTION_TYPE]: new CreateFlowExecutor(),
+    [CLONE_FLOW_ACTION_TYPE]: new CloneFlowExecutor(),
+    [ARCHIVE_FLOW_ACTION_TYPE]: new ArchiveFlowExecutor(),
+  };
+}
+
+export class BloomreachFlowsService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildFlowsUrl(validateProject(project));
+  }
+
+  get flowsUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listFlowAnalyses(input?: ListFlowAnalysesInput): Promise<BloomreachFlowAnalysis[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listFlowAnalyses: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewFlowResults(input: ViewFlowResultsInput): Promise<FlowResults> {
+    validateProject(input.project);
+    validateFlowAnalysisId(input.analysisId);
+
+    if (input.startDate !== undefined || input.endDate !== undefined) {
+      const dateRange: DateRangeFilter = {
+        startDate: input.startDate,
+        endDate: input.endDate,
+      };
+      validateDateRange(dateRange);
+    }
+
+    throw new Error(
+      'viewFlowResults: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateFlowAnalysis(input: CreateFlowAnalysisInput): PreparedFlowAction {
+    const project = validateProject(input.project);
+    const name = validateFlowName(input.name);
+    const startingEvent = validateStartingEvent(input.startingEvent);
+    const events = validateFlowEvents(input.events);
+    const maxJourneyDepth = validateMaxJourneyDepth(input.maxJourneyDepth);
+
+    const preview = {
+      action: CREATE_FLOW_ACTION_TYPE,
+      project,
+      name,
+      startingEvent,
+      events,
+      maxJourneyDepth,
+      filters: input.filters,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCloneFlowAnalysis(input: CloneFlowAnalysisInput): PreparedFlowAction {
+    const project = validateProject(input.project);
+    const analysisId = validateFlowAnalysisId(input.analysisId);
+    const newName = input.newName !== undefined ? validateFlowName(input.newName) : undefined;
+
+    const preview = {
+      action: CLONE_FLOW_ACTION_TYPE,
+      project,
+      analysisId,
+      newName,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareArchiveFlowAnalysis(input: ArchiveFlowAnalysisInput): PreparedFlowAction {
+    const project = validateProject(input.project);
+    const analysisId = validateFlowAnalysisId(input.analysisId);
+
+    const preview = {
+      action: ARCHIVE_FLOW_ACTION_TYPE,
+      project,
+      analysisId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './bloomreachCampaignCalendar.js';
 export * from './bloomreachDashboards.js';
 export * from './bloomreachEmailCampaigns.js';
+export * from './bloomreachFlows.js';
 export * from './bloomreachFunnels.js';
 export * from './bloomreachPerformance.js';
 export * from './bloomreachRecommendations.js';


### PR DESCRIPTION
## Summary

Implements the Flow analyses feature module — Sankey-style customer journey visualization for Bloomreach Engagement.

**Navigation:** Analyses > Flows (`/p/{project}/analytics/flows`)

## Changes

### Core Module (`packages/core/src/bloomreachFlows.ts`)
- **Interfaces**: `BloomreachFlowAnalysis`, `FlowEvent`, `FlowPath`, `FlowDropOff`, `FlowResults`, `FlowFilter`, and all input types
- **Validators**: `validateFlowName`, `validateFlowAnalysisId`, `validateStartingEvent`, `validateFlowEvents` (min 1 event), `validateMaxJourneyDepth` (1-20)
- **URL builder**: `buildFlowsUrl(project)` → `/p/{project}/analytics/flows`
- **Action executors**: Create, Clone, Archive (stub implementations pending browser automation)
- **Service class**: `BloomreachFlowsService` with `listFlowAnalyses`, `viewFlowResults`, `prepareCreateFlowAnalysis`, `prepareCloneFlowAnalysis`, `prepareArchiveFlowAnalysis`
- **Two-phase commit**: All mutations follow the prepare → confirm pattern

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- `bloomreach flows list` — List all flow analyses
- `bloomreach flows view-results` — View journey paths, volumes, and drop-offs
- `bloomreach flows create` — Prepare flow creation with starting event, events, max depth, filters
- `bloomreach flows clone` — Prepare cloning a flow analysis
- `bloomreach flows archive` — Prepare archiving a flow analysis

### Tests (`packages/core/src/__tests__/bloomreachFlows.test.ts`)
- 160 unit tests covering all validators, URL builder, executors, and service methods
- Follows established test patterns from existing modules

## Quality Gates
- ✅ TypeScript typecheck
- ✅ ESLint
- ✅ 1167 tests passing (160 new)
- ✅ Build successful

Closes #40
