### PR TITLE
feat: manage geo analyses (#41)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -8,6 +8,7 @@ import {
   BloomreachEmailCampaignsService,
   BloomreachFlowsService,
   BloomreachFunnelsService,
+  BloomreachGeoAnalysesService,
   BloomreachPerformanceService,
   BloomreachRetentionsService,
   BloomreachScenariosService,
@@ -21,6 +22,7 @@ import type {
   FlowFilter,
   FunnelStep,
   FunnelFilter,
+  GeoFilter,
   SurveyQuestion,
   SurveyDisplayConditions,
   RetentionFilter,
@@ -2270,6 +2272,235 @@ flows
           printJson(result);
         } else {
           console.log('Flow analysis archive prepared.');
+          console.log(`  Analysis: ${options.analysisId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const geoAnalyses = program
+  .command('geo-analyses')
+  .description('Manage Bloomreach Engagement geo analyses');
+
+geoAnalyses
+  .command('list')
+  .description('List all geo analyses in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachGeoAnalysesService(options.project);
+      const result = await service.listGeoAnalyses({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No geo analyses found.');
+          return;
+        }
+        for (const analysis of result) {
+          console.log(`  ${analysis.name}`);
+          console.log(`    Attribute:   ${analysis.attribute}`);
+          console.log(`    Granularity: ${analysis.granularity}`);
+          console.log(`    ID:          ${analysis.id}`);
+          console.log(`    URL:         ${analysis.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+geoAnalyses
+  .command('view-results')
+  .description('View geographic distribution data for a geo analysis')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Geo analysis ID')
+  .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
+  .option('--end-date <date>', 'End date (YYYY-MM-DD)')
+  .option('--granularity <granularity>', 'Geographic granularity (country, region, city)')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      startDate?: string;
+      endDate?: string;
+      granularity?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachGeoAnalysesService(options.project);
+        const result = await service.viewGeoResults({
+          project: options.project,
+          analysisId: options.analysisId,
+          startDate: options.startDate,
+          endDate: options.endDate,
+          granularity: options.granularity,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log(`Geo Analysis: ${result.analysisName}`);
+          console.log(`  Attribute:   ${result.attribute}`);
+          console.log(`  Granularity: ${result.granularity}`);
+          console.log(`  Date range:  ${result.startDate} to ${result.endDate}`);
+          if (result.dataPoints.length === 0) {
+            console.log('  Data points: none');
+          } else {
+            console.log('  Data points:');
+            for (const dataPoint of result.dataPoints) {
+              console.log(
+                `    ${dataPoint.location}: count=${dataPoint.count}, percentage=${dataPoint.percentage}%`,
+              );
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+geoAnalyses
+  .command('create')
+  .description('Prepare creation of a new geo analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Geo analysis name')
+  .requiredOption('--attribute <attribute>', 'Event or customer attribute for geographic mapping')
+  .option('--granularity <granularity>', 'Geographic granularity (country, region, city)', 'country')
+  .option('--customer-attributes <json>', 'JSON object of customer attribute filters')
+  .option('--event-properties <json>', 'JSON object of event property filters')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      attribute: string;
+      granularity: string;
+      customerAttributes?: string;
+      eventProperties?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const filters: GeoFilter = {};
+        if (options.customerAttributes) {
+          filters.customerAttributes = JSON.parse(options.customerAttributes) as Record<
+            string,
+            string
+          >;
+        }
+        if (options.eventProperties) {
+          filters.eventProperties = JSON.parse(options.eventProperties) as Record<string, string>;
+        }
+
+        const service = new BloomreachGeoAnalysesService(options.project);
+        const result = service.prepareCreateGeoAnalysis({
+          project: options.project,
+          name: options.name,
+          attribute: options.attribute,
+          granularity: options.granularity,
+          filters: Object.keys(filters).length > 0 ? filters : undefined,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Geo analysis creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+geoAnalyses
+  .command('clone')
+  .description('Prepare cloning a geo analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Geo analysis ID to clone')
+  .option('--new-name <name>', 'Name for the cloned analysis')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      analysisId: string;
+      newName?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachGeoAnalysesService(options.project);
+        const result = service.prepareCloneGeoAnalysis({
+          project: options.project,
+          analysisId: options.analysisId,
+          newName: options.newName,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Geo analysis clone prepared.');
+          console.log(`  Source:   ${options.analysisId}`);
+          console.log(`  New name: ${options.newName ?? '(auto-generated)'}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+geoAnalyses
+  .command('archive')
+  .description('Prepare archiving a geo analysis (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--analysis-id <id>', 'Geo analysis ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; analysisId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachGeoAnalysesService(options.project);
+        const result = service.prepareArchiveGeoAnalysis({
+          project: options.project,
+          analysisId: options.analysisId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Geo analysis archive prepared.');
           console.log(`  Analysis: ${options.analysisId}`);
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);

--- a/packages/core/src/__tests__/bloomreachGeoAnalyses.test.ts
+++ b/packages/core/src/__tests__/bloomreachGeoAnalyses.test.ts
@@ -1,0 +1,1179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_GEO_ANALYSIS_ACTION_TYPE,
+  CLONE_GEO_ANALYSIS_ACTION_TYPE,
+  ARCHIVE_GEO_ANALYSIS_ACTION_TYPE,
+  GEO_ANALYSIS_RATE_LIMIT_WINDOW_MS,
+  GEO_ANALYSIS_CREATE_RATE_LIMIT,
+  GEO_ANALYSIS_MODIFY_RATE_LIMIT,
+  GEO_GRANULARITIES,
+  validateGeoAnalysisName,
+  validateGeoGranularity,
+  validateGeoAnalysisId,
+  validateAttribute,
+  buildGeoAnalysesUrl,
+  createGeoAnalysisActionExecutors,
+  BloomreachGeoAnalysesService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_GEO_ANALYSIS_ACTION_TYPE', () => {
+    expect(CREATE_GEO_ANALYSIS_ACTION_TYPE).toBe('geoanalyses.create_geo_analysis');
+  });
+
+  it('exports CLONE_GEO_ANALYSIS_ACTION_TYPE', () => {
+    expect(CLONE_GEO_ANALYSIS_ACTION_TYPE).toBe('geoanalyses.clone_geo_analysis');
+  });
+
+  it('exports ARCHIVE_GEO_ANALYSIS_ACTION_TYPE', () => {
+    expect(ARCHIVE_GEO_ANALYSIS_ACTION_TYPE).toBe('geoanalyses.archive_geo_analysis');
+  });
+
+  it('uses unique action type values', () => {
+    const values = [
+      CREATE_GEO_ANALYSIS_ACTION_TYPE,
+      CLONE_GEO_ANALYSIS_ACTION_TYPE,
+      ARCHIVE_GEO_ANALYSIS_ACTION_TYPE,
+    ];
+    expect(new Set(values).size).toBe(3);
+  });
+
+  it('uses geoanalyses namespace for all action types', () => {
+    expect(CREATE_GEO_ANALYSIS_ACTION_TYPE.startsWith('geoanalyses.')).toBe(true);
+    expect(CLONE_GEO_ANALYSIS_ACTION_TYPE.startsWith('geoanalyses.')).toBe(true);
+    expect(ARCHIVE_GEO_ANALYSIS_ACTION_TYPE.startsWith('geoanalyses.')).toBe(true);
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports GEO_ANALYSIS_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(GEO_ANALYSIS_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports GEO_ANALYSIS_CREATE_RATE_LIMIT', () => {
+    expect(GEO_ANALYSIS_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports GEO_ANALYSIS_MODIFY_RATE_LIMIT', () => {
+    expect(GEO_ANALYSIS_MODIFY_RATE_LIMIT).toBe(20);
+  });
+
+  it('uses create limit lower than modify limit', () => {
+    expect(GEO_ANALYSIS_CREATE_RATE_LIMIT).toBeLessThan(GEO_ANALYSIS_MODIFY_RATE_LIMIT);
+  });
+
+  it('uses positive numeric limits', () => {
+    expect(GEO_ANALYSIS_RATE_LIMIT_WINDOW_MS).toBeGreaterThan(0);
+    expect(GEO_ANALYSIS_CREATE_RATE_LIMIT).toBeGreaterThan(0);
+    expect(GEO_ANALYSIS_MODIFY_RATE_LIMIT).toBeGreaterThan(0);
+  });
+});
+
+describe('GEO_GRANULARITIES', () => {
+  it('contains 3 granularities', () => {
+    expect(GEO_GRANULARITIES).toHaveLength(3);
+  });
+
+  it('contains expected granularity values in order', () => {
+    expect(GEO_GRANULARITIES).toEqual(['country', 'region', 'city']);
+  });
+
+  it('contains only unique values', () => {
+    expect(new Set(GEO_GRANULARITIES).size).toBe(3);
+  });
+
+  it('all granularity values are lowercase', () => {
+    for (const granularity of GEO_GRANULARITIES) {
+      expect(granularity).toBe(granularity.toLowerCase());
+    }
+  });
+
+  it('all granularity values are non-empty strings', () => {
+    for (const granularity of GEO_GRANULARITIES) {
+      expect(typeof granularity).toBe('string');
+      expect(granularity.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('validateGeoAnalysisName', () => {
+  it('returns trimmed name for valid input with whitespace', () => {
+    expect(validateGeoAnalysisName('  Revenue by Geography  ')).toBe(
+      'Revenue by Geography',
+    );
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateGeoAnalysisName('A')).toBe('A');
+  });
+
+  it('accepts name at maximum length (200)', () => {
+    const name = 'x'.repeat(200);
+    expect(validateGeoAnalysisName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateGeoAnalysisName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateGeoAnalysisName('    ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const tooLong = 'x'.repeat(201);
+    expect(() => validateGeoAnalysisName(tooLong)).toThrow(
+      'must not exceed 200 characters',
+    );
+  });
+
+  it('trims tabs and newlines around valid name', () => {
+    expect(validateGeoAnalysisName('\n\tRegional Reach\t\n')).toBe('Regional Reach');
+  });
+
+  it('accepts alphanumeric name with punctuation', () => {
+    expect(validateGeoAnalysisName('Geo Analysis: Q1-2025 v2')).toBe(
+      'Geo Analysis: Q1-2025 v2',
+    );
+  });
+
+  it('accepts name containing inner multiple spaces', () => {
+    expect(validateGeoAnalysisName('Geo   Distribution   Report')).toBe(
+      'Geo   Distribution   Report',
+    );
+  });
+
+  it('accepts numeric name', () => {
+    expect(validateGeoAnalysisName('12345')).toBe('12345');
+  });
+
+  it('throws for tab-only name', () => {
+    expect(() => validateGeoAnalysisName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only name', () => {
+    expect(() => validateGeoAnalysisName('\n')).toThrow('must not be empty');
+  });
+
+  it('throws for mixed whitespace-only name', () => {
+    expect(() => validateGeoAnalysisName(' \n\t ')).toThrow('must not be empty');
+  });
+
+  it('reports actual length when exceeding max by one', () => {
+    expect(() => validateGeoAnalysisName('x'.repeat(201))).toThrow('(got 201)');
+  });
+
+  it('reports actual length when exceeding max by many', () => {
+    expect(() => validateGeoAnalysisName('x'.repeat(250))).toThrow('(got 250)');
+  });
+});
+
+describe('validateGeoGranularity', () => {
+  it('accepts country', () => {
+    expect(validateGeoGranularity('country')).toBe('country');
+  });
+
+  it('accepts region', () => {
+    expect(validateGeoGranularity('region')).toBe('region');
+  });
+
+  it('accepts city', () => {
+    expect(validateGeoGranularity('city')).toBe('city');
+  });
+
+  it('throws for unknown granularity', () => {
+    expect(() => validateGeoGranularity('continent')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for empty granularity', () => {
+    expect(() => validateGeoGranularity('')).toThrow('granularity must be one of');
+  });
+
+  it('throws for uppercase granularity', () => {
+    expect(() => validateGeoGranularity('COUNTRY')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for title-case granularity', () => {
+    expect(() => validateGeoGranularity('Country')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for granularity with trailing whitespace', () => {
+    expect(() => validateGeoGranularity('country ')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for granularity with leading whitespace', () => {
+    expect(() => validateGeoGranularity(' region')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('throws for granularity with slash', () => {
+    expect(() => validateGeoGranularity('country/region')).toThrow(
+      'granularity must be one of',
+    );
+  });
+
+  it('error includes received invalid value', () => {
+    expect(() => validateGeoGranularity('district')).toThrow('got "district"');
+  });
+});
+
+describe('validateGeoAnalysisId', () => {
+  it('returns trimmed geo analysis ID for valid input', () => {
+    expect(validateGeoAnalysisId('  geo-123  ')).toBe('geo-123');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateGeoAnalysisId('geo-456')).toBe('geo-456');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateGeoAnalysisId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateGeoAnalysisId('   ')).toThrow('must not be empty');
+  });
+
+  it('trims tab-wrapped ID', () => {
+    expect(validateGeoAnalysisId('\tgeo-tabbed\t')).toBe('geo-tabbed');
+  });
+
+  it('trims newline-wrapped ID', () => {
+    expect(validateGeoAnalysisId('\ngeo-newline\n')).toBe('geo-newline');
+  });
+
+  it('accepts IDs containing slashes', () => {
+    expect(validateGeoAnalysisId('analysis/geo/1')).toBe('analysis/geo/1');
+  });
+
+  it('accepts IDs containing colons', () => {
+    expect(validateGeoAnalysisId('geo:analysis:1')).toBe('geo:analysis:1');
+  });
+
+  it('accepts IDs containing dots', () => {
+    expect(validateGeoAnalysisId('geo.analysis.1')).toBe('geo.analysis.1');
+  });
+
+  it('throws for tab-only value', () => {
+    expect(() => validateGeoAnalysisId('\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only value', () => {
+    expect(() => validateGeoAnalysisId('\n')).toThrow('must not be empty');
+  });
+});
+
+describe('validateAttribute', () => {
+  it('returns trimmed attribute for valid input', () => {
+    expect(validateAttribute('  customer.country  ')).toBe('customer.country');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateAttribute('')).toThrow('attribute must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateAttribute('   ')).toThrow('attribute must not be empty');
+  });
+
+  it('trims tabs and newlines around valid attribute', () => {
+    expect(validateAttribute('\n\tcustomer.region\t\n')).toBe('customer.region');
+  });
+
+  it('accepts simple attribute name', () => {
+    expect(validateAttribute('city')).toBe('city');
+  });
+
+  it('accepts dotted attribute path', () => {
+    expect(validateAttribute('customer.address.city')).toBe('customer.address.city');
+  });
+
+  it('accepts underscored attribute name', () => {
+    expect(validateAttribute('shipping_country_code')).toBe('shipping_country_code');
+  });
+
+  it('accepts hyphenated attribute name', () => {
+    expect(validateAttribute('geo-country-code')).toBe('geo-country-code');
+  });
+
+  it('throws for tab-only attribute', () => {
+    expect(() => validateAttribute('\t\t')).toThrow('attribute must not be empty');
+  });
+
+  it('throws for newline-only attribute', () => {
+    expect(() => validateAttribute('\n')).toThrow('attribute must not be empty');
+  });
+});
+
+describe('buildGeoAnalysesUrl', () => {
+  it('builds URL for simple project name', () => {
+    expect(buildGeoAnalysesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/analytics/geoanalyses',
+    );
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildGeoAnalysesUrl('my project')).toBe(
+      '/p/my%20project/analytics/geoanalyses',
+    );
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildGeoAnalysesUrl('org/project')).toBe(
+      '/p/org%2Fproject/analytics/geoanalyses',
+    );
+  });
+
+  it('encodes plus signs in project name', () => {
+    expect(buildGeoAnalysesUrl('project+test')).toBe(
+      '/p/project%2Btest/analytics/geoanalyses',
+    );
+  });
+
+  it('encodes question marks in project name', () => {
+    expect(buildGeoAnalysesUrl('project?name')).toBe(
+      '/p/project%3Fname/analytics/geoanalyses',
+    );
+  });
+
+  it('encodes hash in project name', () => {
+    expect(buildGeoAnalysesUrl('project#1')).toBe(
+      '/p/project%231/analytics/geoanalyses',
+    );
+  });
+
+  it('encodes leading and trailing spaces when passed directly', () => {
+    expect(buildGeoAnalysesUrl('  my project  ')).toBe(
+      '/p/%20%20my%20project%20%20/analytics/geoanalyses',
+    );
+  });
+});
+
+describe('createGeoAnalysisActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createGeoAnalysisActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[CREATE_GEO_ANALYSIS_ACTION_TYPE]).toBeDefined();
+    expect(executors[CLONE_GEO_ANALYSIS_ACTION_TYPE]).toBeDefined();
+    expect(executors[ARCHIVE_GEO_ANALYSIS_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has actionType matching its key', () => {
+    const executors = createGeoAnalysisActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw not yet implemented on execute', async () => {
+    const executors = createGeoAnalysisActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+
+  it('returns stable set of keys', () => {
+    const executors = createGeoAnalysisActionExecutors();
+    expect(Object.keys(executors).sort()).toEqual(
+      [
+        CREATE_GEO_ANALYSIS_ACTION_TYPE,
+        CLONE_GEO_ANALYSIS_ACTION_TYPE,
+        ARCHIVE_GEO_ANALYSIS_ACTION_TYPE,
+      ].sort(),
+    );
+  });
+
+  it('returns new executor instances each call', () => {
+    const a = createGeoAnalysisActionExecutors();
+    const b = createGeoAnalysisActionExecutors();
+    expect(a[CREATE_GEO_ANALYSIS_ACTION_TYPE]).not.toBe(
+      b[CREATE_GEO_ANALYSIS_ACTION_TYPE],
+    );
+    expect(a[CLONE_GEO_ANALYSIS_ACTION_TYPE]).not.toBe(
+      b[CLONE_GEO_ANALYSIS_ACTION_TYPE],
+    );
+    expect(a[ARCHIVE_GEO_ANALYSIS_ACTION_TYPE]).not.toBe(
+      b[ARCHIVE_GEO_ANALYSIS_ACTION_TYPE],
+    );
+  });
+
+  it('create executor reports correct action type', () => {
+    const executors = createGeoAnalysisActionExecutors();
+    expect(executors[CREATE_GEO_ANALYSIS_ACTION_TYPE].actionType).toBe(
+      CREATE_GEO_ANALYSIS_ACTION_TYPE,
+    );
+  });
+
+  it('clone executor reports correct action type', () => {
+    const executors = createGeoAnalysisActionExecutors();
+    expect(executors[CLONE_GEO_ANALYSIS_ACTION_TYPE].actionType).toBe(
+      CLONE_GEO_ANALYSIS_ACTION_TYPE,
+    );
+  });
+
+  it('archive executor reports correct action type', () => {
+    const executors = createGeoAnalysisActionExecutors();
+    expect(executors[ARCHIVE_GEO_ANALYSIS_ACTION_TYPE].actionType).toBe(
+      ARCHIVE_GEO_ANALYSIS_ACTION_TYPE,
+    );
+  });
+});
+
+describe('BloomreachGeoAnalysesService', () => {
+  describe('constructor', () => {
+    it('creates service instance with valid project', () => {
+      const service = new BloomreachGeoAnalysesService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachGeoAnalysesService);
+    });
+
+    it('exposes the geoAnalysesUrl', () => {
+      const service = new BloomreachGeoAnalysesService('kingdom-of-joakim');
+      expect(service.geoAnalysesUrl).toBe('/p/kingdom-of-joakim/analytics/geoanalyses');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachGeoAnalysesService('  my-project  ');
+      expect(service.geoAnalysesUrl).toBe('/p/my-project/analytics/geoanalyses');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachGeoAnalysesService('')).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      expect(() => new BloomreachGeoAnalysesService('   ')).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for tab-only project', () => {
+      expect(() => new BloomreachGeoAnalysesService('\t\t')).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('encodes slash in project URL', () => {
+      const service = new BloomreachGeoAnalysesService('org/project');
+      expect(service.geoAnalysesUrl).toBe('/p/org%2Fproject/analytics/geoanalyses');
+    });
+
+    it('encodes space in project URL', () => {
+      const service = new BloomreachGeoAnalysesService('my project');
+      expect(service.geoAnalysesUrl).toBe('/p/my%20project/analytics/geoanalyses');
+    });
+  });
+
+  describe('listGeoAnalyses', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(service.listGeoAnalyses()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input is provided (empty string)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(service.listGeoAnalyses({ project: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates project when input is provided (whitespace-only)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(service.listGeoAnalyses({ project: '   ' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('accepts trimmed project and still reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(service.listGeoAnalyses({ project: '  test  ' })).rejects.toThrow(
+        'not yet implemented',
+      );
+    });
+
+    it('accepts encoded-looking project and still reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.listGeoAnalyses({ project: 'org/project' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('viewGeoResults', () => {
+    it('throws not-yet-implemented with valid minimal input', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({ project: 'test', analysisId: 'geo-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('throws not-yet-implemented with full valid input (including granularity, dates)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          granularity: 'region',
+          startDate: '2025-01-01',
+          endDate: '2025-01-31',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input (empty)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({ project: '', analysisId: 'geo-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates project input (whitespace-only)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({ project: '   ', analysisId: 'geo-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates analysisId input (whitespace-only)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({ project: 'test', analysisId: '   ' }),
+      ).rejects.toThrow('Geo analysis ID must not be empty');
+    });
+
+    it('validates analysisId input (empty)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({ project: 'test', analysisId: '' }),
+      ).rejects.toThrow('Geo analysis ID must not be empty');
+    });
+
+    it('validates granularity when provided (invalid value)', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          granularity: 'district',
+        }),
+      ).rejects.toThrow('granularity must be one of');
+    });
+
+    it('validates date range: malformed startDate', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          startDate: 'bad-date',
+        }),
+      ).rejects.toThrow('startDate must be a valid ISO-8601 date');
+    });
+
+    it('validates date range: malformed endDate', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          endDate: '31-01-2025',
+        }),
+      ).rejects.toThrow('endDate must be a valid ISO-8601 date');
+    });
+
+    it('validates date range: startDate after endDate', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          startDate: '2025-02-01',
+          endDate: '2025-01-01',
+        }),
+      ).rejects.toThrow('must not be after');
+    });
+
+    it('accepts only startDate and reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          startDate: '2025-01-01',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('accepts only endDate and reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          endDate: '2025-01-31',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('accepts country granularity and reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          granularity: 'country',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('accepts city granularity and reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          granularity: 'city',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('rejects invalid calendar startDate', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          startDate: '2025-02-30',
+        }),
+      ).rejects.toThrow('startDate is not a valid calendar date');
+    });
+
+    it('rejects invalid calendar endDate', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          endDate: '2025-02-30',
+        }),
+      ).rejects.toThrow('endDate is not a valid calendar date');
+    });
+
+    it('rejects granularity with whitespace', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({
+          project: 'test',
+          analysisId: 'geo-1',
+          granularity: ' region ',
+        }),
+      ).rejects.toThrow('granularity must be one of');
+    });
+
+    it('accepts trimmed project and analysisId and reaches not-yet-implemented', async () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      await expect(
+        service.viewGeoResults({ project: '  test  ', analysisId: '  geo-1  ' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareCreateGeoAnalysis', () => {
+    it('returns prepared action with valid minimal input (project, name, attribute)', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Revenue by Country',
+        attribute: 'customer.country',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'geoanalyses.create_geo_analysis',
+          project: 'test',
+          name: 'Revenue by Country',
+          attribute: 'customer.country',
+        }),
+      );
+    });
+
+    it('preparedActionId matches /^pa_/', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Name',
+        attribute: 'attr',
+      });
+      expect(result.preparedActionId).toMatch(/^pa_/);
+    });
+
+    it('confirmToken matches /^ct_stub_/', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Name',
+        attribute: 'attr',
+      });
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+    });
+
+    it('expiresAtMs is greater than Date.now()', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Name',
+        attribute: 'attr',
+      });
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+
+    it('includes granularity in preview when provided', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Regional Analysis',
+        attribute: 'customer.region',
+        granularity: 'region',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          granularity: 'region',
+        }),
+      );
+    });
+
+    it('includes filters in preview when provided (customerAttributes)', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'VIP Geo',
+        attribute: 'customer.country',
+        filters: {
+          customerAttributes: { segment: 'vip', tier: 'gold' },
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          filters: {
+            customerAttributes: { segment: 'vip', tier: 'gold' },
+          },
+        }),
+      );
+    });
+
+    it('includes filters in preview when provided (eventProperties)', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Geo by Currency',
+        attribute: 'customer.country',
+        filters: {
+          eventProperties: { currency: 'USD', channel: 'email' },
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          filters: {
+            eventProperties: { currency: 'USD', channel: 'email' },
+          },
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Geo Analysis',
+        attribute: 'customer.country',
+        operatorNote: 'Create ahead of monthly KPI review',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Create ahead of monthly KPI review',
+        }),
+      );
+    });
+
+    it('trims project, name, and attribute in preview', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: '  test  ',
+        name: '  Geo Name  ',
+        attribute: '  customer.city  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'test',
+          name: 'Geo Name',
+          attribute: 'customer.city',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: 'test',
+          name: '',
+          attribute: 'customer.country',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only name', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: 'test',
+          name: '   ',
+          attribute: 'customer.country',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: '',
+          name: 'Geo Name',
+          attribute: 'customer.country',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for too-long name (201 chars)', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: 'test',
+          name: 'x'.repeat(201),
+          attribute: 'customer.country',
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws for invalid granularity', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: 'test',
+          name: 'Geo Name',
+          attribute: 'customer.country',
+          granularity: 'district',
+        }),
+      ).toThrow('granularity must be one of');
+    });
+
+    it('throws for empty attribute', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: 'test',
+          name: 'Geo Name',
+          attribute: '',
+        }),
+      ).toThrow('attribute must not be empty');
+    });
+
+    it('throws for whitespace-only attribute', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCreateGeoAnalysis({
+          project: 'test',
+          name: 'Geo Name',
+          attribute: '   ',
+        }),
+      ).toThrow('attribute must not be empty');
+    });
+
+    it('accepts max-length name', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const maxName = 'x'.repeat(200);
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: maxName,
+        attribute: 'customer.country',
+      });
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: maxName,
+        }),
+      );
+    });
+
+    it('accepts country granularity', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'Country Analysis',
+        attribute: 'customer.country',
+        granularity: 'country',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ granularity: 'country' }));
+    });
+
+    it('accepts city granularity', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'City Analysis',
+        attribute: 'customer.city',
+        granularity: 'city',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ granularity: 'city' }));
+    });
+
+    it('allows undefined granularity', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCreateGeoAnalysis({
+        project: 'test',
+        name: 'No Granularity',
+        attribute: 'customer.country',
+      });
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: CREATE_GEO_ANALYSIS_ACTION_TYPE,
+          project: 'test',
+          name: 'No Granularity',
+          attribute: 'customer.country',
+        }),
+      );
+    });
+  });
+
+  describe('prepareCloneGeoAnalysis', () => {
+    it('returns prepared action with valid input', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCloneGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-789',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'geoanalyses.clone_geo_analysis',
+          project: 'test',
+          analysisId: 'geo-789',
+        }),
+      );
+    });
+
+    it('includes newName in preview when provided', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCloneGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-789',
+        newName: '  Cloned Geo Analysis  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName: 'Cloned Geo Analysis',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCloneGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-789',
+        operatorNote: 'Clone for regional team reporting',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Clone for regional team reporting',
+        }),
+      );
+    });
+
+    it('throws for empty analysisId', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCloneGeoAnalysis({
+          project: 'test',
+          analysisId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only analysisId', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCloneGeoAnalysis({
+          project: 'test',
+          analysisId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCloneGeoAnalysis({
+          project: '',
+          analysisId: 'geo-789',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName is whitespace only', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCloneGeoAnalysis({
+          project: 'test',
+          analysisId: 'geo-789',
+          newName: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when newName exceeds maximum length', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareCloneGeoAnalysis({
+          project: 'test',
+          analysisId: 'geo-789',
+          newName: 'x'.repeat(201),
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('trims project and analysisId in preview', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareCloneGeoAnalysis({
+        project: '  test  ',
+        analysisId: '  geo-789  ',
+      });
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'test',
+          analysisId: 'geo-789',
+        }),
+      );
+    });
+
+    it('accepts max-length newName', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const maxName = 'x'.repeat(200);
+      const result = service.prepareCloneGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-789',
+        newName: maxName,
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ newName: maxName }));
+    });
+  });
+
+  describe('prepareArchiveGeoAnalysis', () => {
+    it('returns prepared action with valid input', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareArchiveGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'geoanalyses.archive_geo_analysis',
+          project: 'test',
+          analysisId: 'geo-900',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareArchiveGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-900',
+        operatorNote: 'Archive duplicate geo analysis',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Archive duplicate geo analysis',
+        }),
+      );
+    });
+
+    it('throws for empty analysisId', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareArchiveGeoAnalysis({
+          project: 'test',
+          analysisId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only analysisId', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareArchiveGeoAnalysis({
+          project: 'test',
+          analysisId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      expect(() =>
+        service.prepareArchiveGeoAnalysis({
+          project: '',
+          analysisId: 'geo-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('trims project and analysisId in preview', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareArchiveGeoAnalysis({
+        project: '  test  ',
+        analysisId: '  geo-900  ',
+      });
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'test',
+          analysisId: 'geo-900',
+        }),
+      );
+    });
+
+    it('returns token and expiry metadata', () => {
+      const service = new BloomreachGeoAnalysesService('test');
+      const result = service.prepareArchiveGeoAnalysis({
+        project: 'test',
+        analysisId: 'geo-901',
+      });
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/packages/core/src/bloomreachGeoAnalyses.ts
+++ b/packages/core/src/bloomreachGeoAnalyses.ts
@@ -1,0 +1,305 @@
+import { validateProject } from './bloomreachDashboards.js';
+import { validateDateRange } from './bloomreachPerformance.js';
+import type { DateRangeFilter } from './bloomreachPerformance.js';
+
+export const CREATE_GEO_ANALYSIS_ACTION_TYPE = 'geoanalyses.create_geo_analysis';
+export const CLONE_GEO_ANALYSIS_ACTION_TYPE = 'geoanalyses.clone_geo_analysis';
+export const ARCHIVE_GEO_ANALYSIS_ACTION_TYPE = 'geoanalyses.archive_geo_analysis';
+
+export const GEO_ANALYSIS_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const GEO_ANALYSIS_CREATE_RATE_LIMIT = 10;
+export const GEO_ANALYSIS_MODIFY_RATE_LIMIT = 20;
+
+export const GEO_GRANULARITIES = ['country', 'region', 'city'] as const;
+export type GeoGranularity = (typeof GEO_GRANULARITIES)[number];
+
+export interface BloomreachGeoAnalysis {
+  id: string;
+  name: string;
+  attribute: string;
+  granularity: GeoGranularity;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface GeoFilter {
+  customerAttributes?: Record<string, string>;
+  eventProperties?: Record<string, string>;
+}
+
+export interface GeoDataPoint {
+  location: string;
+  count: number;
+  percentage: number;
+}
+
+export interface GeoResults {
+  analysisId: string;
+  analysisName: string;
+  attribute: string;
+  granularity: GeoGranularity;
+  startDate: string;
+  endDate: string;
+  dataPoints: GeoDataPoint[];
+  filters?: GeoFilter;
+}
+
+export interface ListGeoAnalysesInput {
+  project: string;
+}
+
+export interface CreateGeoAnalysisInput {
+  project: string;
+  name: string;
+  attribute: string;
+  granularity?: string;
+  filters?: GeoFilter;
+  operatorNote?: string;
+}
+
+export interface ViewGeoResultsInput {
+  project: string;
+  analysisId: string;
+  startDate?: string;
+  endDate?: string;
+  granularity?: string;
+}
+
+export interface CloneGeoAnalysisInput {
+  project: string;
+  analysisId: string;
+  newName?: string;
+  operatorNote?: string;
+}
+
+export interface ArchiveGeoAnalysisInput {
+  project: string;
+  analysisId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedGeoAnalysisAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_GEO_ANALYSIS_NAME_LENGTH = 200;
+const MIN_GEO_ANALYSIS_NAME_LENGTH = 1;
+
+export function validateGeoAnalysisName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_GEO_ANALYSIS_NAME_LENGTH) {
+    throw new Error('Geo analysis name must not be empty.');
+  }
+  if (trimmed.length > MAX_GEO_ANALYSIS_NAME_LENGTH) {
+    throw new Error(
+      `Geo analysis name must not exceed ${MAX_GEO_ANALYSIS_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateGeoGranularity(granularity: string): GeoGranularity {
+  if (!GEO_GRANULARITIES.includes(granularity as GeoGranularity)) {
+    throw new Error(
+      `granularity must be one of: ${GEO_GRANULARITIES.join(', ')} (got "${granularity}").`,
+    );
+  }
+  return granularity as GeoGranularity;
+}
+
+export function validateGeoAnalysisId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Geo analysis ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateAttribute(attribute: string): string {
+  const trimmed = attribute.trim();
+  if (trimmed.length === 0) {
+    throw new Error('attribute must not be empty.');
+  }
+  return trimmed;
+}
+
+export function buildGeoAnalysesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/analytics/geoanalyses`;
+}
+
+export interface GeoAnalysisActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateGeoAnalysisExecutor implements GeoAnalysisActionExecutor {
+  readonly actionType = CREATE_GEO_ANALYSIS_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateGeoAnalysisExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CloneGeoAnalysisExecutor implements GeoAnalysisActionExecutor {
+  readonly actionType = CLONE_GEO_ANALYSIS_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CloneGeoAnalysisExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ArchiveGeoAnalysisExecutor implements GeoAnalysisActionExecutor {
+  readonly actionType = ARCHIVE_GEO_ANALYSIS_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ArchiveGeoAnalysisExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createGeoAnalysisActionExecutors(): Record<
+  string,
+  GeoAnalysisActionExecutor
+> {
+  return {
+    [CREATE_GEO_ANALYSIS_ACTION_TYPE]: new CreateGeoAnalysisExecutor(),
+    [CLONE_GEO_ANALYSIS_ACTION_TYPE]: new CloneGeoAnalysisExecutor(),
+    [ARCHIVE_GEO_ANALYSIS_ACTION_TYPE]: new ArchiveGeoAnalysisExecutor(),
+  };
+}
+
+export class BloomreachGeoAnalysesService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildGeoAnalysesUrl(validateProject(project));
+  }
+
+  get geoAnalysesUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listGeoAnalyses(
+    input?: ListGeoAnalysesInput,
+  ): Promise<BloomreachGeoAnalysis[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listGeoAnalyses: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewGeoResults(input: ViewGeoResultsInput): Promise<GeoResults> {
+    validateProject(input.project);
+    validateGeoAnalysisId(input.analysisId);
+
+    if (input.granularity !== undefined) {
+      validateGeoGranularity(input.granularity);
+    }
+
+    if (input.startDate !== undefined || input.endDate !== undefined) {
+      const dateRange: DateRangeFilter = {
+        startDate: input.startDate,
+        endDate: input.endDate,
+      };
+      validateDateRange(dateRange);
+    }
+
+    throw new Error(
+      'viewGeoResults: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateGeoAnalysis(
+    input: CreateGeoAnalysisInput,
+  ): PreparedGeoAnalysisAction {
+    const project = validateProject(input.project);
+    const name = validateGeoAnalysisName(input.name);
+    const attribute = validateAttribute(input.attribute);
+    const granularity =
+      input.granularity !== undefined
+        ? validateGeoGranularity(input.granularity)
+        : undefined;
+
+    const preview = {
+      action: CREATE_GEO_ANALYSIS_ACTION_TYPE,
+      project,
+      name,
+      attribute,
+      granularity,
+      filters: input.filters,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCloneGeoAnalysis(
+    input: CloneGeoAnalysisInput,
+  ): PreparedGeoAnalysisAction {
+    const project = validateProject(input.project);
+    const analysisId = validateGeoAnalysisId(input.analysisId);
+    const newName =
+      input.newName !== undefined
+        ? validateGeoAnalysisName(input.newName)
+        : undefined;
+
+    const preview = {
+      action: CLONE_GEO_ANALYSIS_ACTION_TYPE,
+      project,
+      analysisId,
+      newName,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareArchiveGeoAnalysis(
+    input: ArchiveGeoAnalysisInput,
+  ): PreparedGeoAnalysisAction {
+    const project = validateProject(input.project);
+    const analysisId = validateGeoAnalysisId(input.analysisId);
+
+    const preview = {
+      action: ARCHIVE_GEO_ANALYSIS_ACTION_TYPE,
+      project,
+      analysisId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export * from './bloomreachScenarios.js';
 export * from './bloomreachSurveys.js';
 export * from './bloomreachRetentions.js';
 export * from './bloomreachTrends.js';
+export * from './bloomreachGeoAnalyses.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary
Add Geo Analyses feature module — geographic breakdowns of customer data and events at the `country`, `region`, and `city` granularity levels.

## Changes
- **`packages/core/src/bloomreachGeoAnalyses.ts`** (305 lines) — Core module with:
  - Action type constants (`geoanalyses.create_geo_analysis`, `clone`, `archive`)
  - Rate limit constants (10 creates/hr, 20 modifies/hr)
  - Geographic granularity enum (`country`, `region`, `city`)
  - Full TypeScript interfaces (analysis, results, filters, data points, inputs)
  - Input validators (name, granularity, analysis ID, attribute)
  - URL builder (`/p/{project}/analytics/geoanalyses`)
  - Action executors (create, clone, archive — browser automation stubs)
  - `BloomreachGeoAnalysesService` with list, viewResults, prepareCreate, prepareClone, prepareArchive

- **`packages/core/src/index.ts`** — Export new module

- **`packages/core/src/__tests__/bloomreachGeoAnalyses.test.ts`** (~1180 lines) — 145 comprehensive unit tests covering all validators, service methods, edge cases, and error paths

- **`packages/cli/src/bin/bloomreach.ts`** — CLI commands: `geo-analyses list|view-results|create|clone|archive`

## Quality Gates
- [x] TypeScript strict mode — clean
- [x] ESLint — clean
- [x] Tests — 2304 passed (26 test files, including 145 new geo analyses tests)
- [x] Build — both core and cli packages build successfully

## Pattern Compliance
Follows the exact same architecture as existing analytics modules (trends, funnels, retentions, flows) per ARCHITECTURE.md §3.

Closes #41
