### PR TITLE
feat: Manage Catalogs (#44)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -5,6 +5,7 @@ import {
   BloomreachAssetManagerService,
   BloomreachCampaignCalendarService,
   BloomreachCampaignSettingsService,
+  BloomreachCatalogsService,
   BloomreachClient,
   BloomreachCustomersService,
   BloomreachDataManagerService,
@@ -63,6 +64,9 @@ import type {
   TrendFilter,
   WeblayerDisplayConditions,
   WeblayerABTestConfig,
+  CreateCatalogInput,
+  AddCatalogItemsInput,
+  UpdateCatalogItemsInput,
 } from '@bloomreach-buddy/core';
 
 function printJson(value: unknown): void {
@@ -9632,5 +9636,256 @@ sqlReports
       process.exit(1);
     }
   });
+
+const catalogs = program.command('catalogs').description('Manage Bloomreach Engagement catalogs');
+
+catalogs
+  .command('list')
+  .description('List all catalogs in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCatalogsService(options.project);
+      const result = await service.listCatalogs({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No catalogs found.');
+          return;
+        }
+        for (const catalog of result) {
+          console.log(`  ${catalog.name} (${catalog.itemCount} items)`);
+          console.log(`    ID:  ${catalog.id}`);
+          console.log(`    URL: ${catalog.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+catalogs
+  .command('view-items')
+  .description('View items in a specific catalog')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--catalog-id <id>', 'Catalog ID')
+  .option('--page <n>', 'Page number')
+  .option('--page-size <n>', 'Page size')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      catalogId: string;
+      page?: string;
+      pageSize?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCatalogsService(options.project);
+        const result = await service.viewCatalogItems({
+          project: options.project,
+          catalogId: options.catalogId,
+          page: options.page !== undefined ? parseInt(options.page, 10) : undefined,
+          pageSize: options.pageSize !== undefined ? parseInt(options.pageSize, 10) : undefined,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log(`Catalog Items: ${options.catalogId}`);
+          console.log(`  Total: ${result.totalCount}`);
+          console.log(`  Page:  ${result.page}`);
+          console.log(`  Size:  ${result.pageSize}`);
+          if (result.items.length === 0) {
+            console.log('  Items: none');
+          } else {
+            console.log('  Items:');
+            for (const item of result.items) {
+              console.log(`    ${item.id}: ${JSON.stringify(item.properties)}`);
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+catalogs
+  .command('create')
+  .description('Prepare creation of a new catalog (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Catalog name')
+  .requiredOption('--schema <json>', 'JSON object of catalog schema fields')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      schema: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const schema = JSON.parse(options.schema) as CreateCatalogInput['schema'];
+
+        const service = new BloomreachCatalogsService(options.project);
+        const result = service.prepareCreateCatalog({
+          project: options.project,
+          name: options.name,
+          schema,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Catalog creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+catalogs
+  .command('add-items')
+  .description('Prepare adding items to a catalog (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--catalog-id <id>', 'Catalog ID')
+  .requiredOption('--items <json>', 'JSON array of catalog item property objects')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      catalogId: string;
+      items: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const items = JSON.parse(options.items) as AddCatalogItemsInput['items'];
+
+        const service = new BloomreachCatalogsService(options.project);
+        const result = service.prepareAddCatalogItems({
+          project: options.project,
+          catalogId: options.catalogId,
+          items,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Catalog add-items prepared.');
+          console.log(`  Catalog: ${options.catalogId}`);
+          console.log(`  Items:   ${items.length}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+catalogs
+  .command('update-items')
+  .description('Prepare updating catalog items (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--catalog-id <id>', 'Catalog ID')
+  .requiredOption('--items <json>', 'JSON array of item updates [{id, properties}]')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      catalogId: string;
+      items: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const items = JSON.parse(options.items) as UpdateCatalogItemsInput['items'];
+
+        const service = new BloomreachCatalogsService(options.project);
+        const result = service.prepareUpdateCatalogItems({
+          project: options.project,
+          catalogId: options.catalogId,
+          items,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Catalog update-items prepared.');
+          console.log(`  Catalog: ${options.catalogId}`);
+          console.log(`  Items:   ${items.length}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+catalogs
+  .command('delete')
+  .description('Prepare deletion of a catalog (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--catalog-id <id>', 'Catalog ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; catalogId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachCatalogsService(options.project);
+        const result = service.prepareDeleteCatalog({
+          project: options.project,
+          catalogId: options.catalogId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Catalog deletion prepared.');
+          console.log(`  Catalog: ${options.catalogId}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
 
 program.parse();

--- a/packages/core/src/__tests__/bloomreachCatalogs.test.ts
+++ b/packages/core/src/__tests__/bloomreachCatalogs.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_CATALOG_ACTION_TYPE,
+  ADD_CATALOG_ITEMS_ACTION_TYPE,
+  UPDATE_CATALOG_ITEMS_ACTION_TYPE,
+  DELETE_CATALOG_ACTION_TYPE,
+  CATALOG_RATE_LIMIT_WINDOW_MS,
+  CATALOG_CREATE_RATE_LIMIT,
+  CATALOG_MODIFY_RATE_LIMIT,
+  validateCatalogName,
+  validateCatalogId,
+  validateCatalogSchema,
+  validateCatalogItems,
+  validateCatalogItemUpdates,
+  buildCatalogsUrl,
+  createCatalogActionExecutors,
+  BloomreachCatalogsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_CATALOG_ACTION_TYPE', () => {
+    expect(CREATE_CATALOG_ACTION_TYPE).toBe('catalogs.create_catalog');
+  });
+
+  it('exports ADD_CATALOG_ITEMS_ACTION_TYPE', () => {
+    expect(ADD_CATALOG_ITEMS_ACTION_TYPE).toBe('catalogs.add_catalog_items');
+  });
+
+  it('exports UPDATE_CATALOG_ITEMS_ACTION_TYPE', () => {
+    expect(UPDATE_CATALOG_ITEMS_ACTION_TYPE).toBe('catalogs.update_catalog_items');
+  });
+
+  it('exports DELETE_CATALOG_ACTION_TYPE', () => {
+    expect(DELETE_CATALOG_ACTION_TYPE).toBe('catalogs.delete_catalog');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports CATALOG_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(CATALOG_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports CATALOG_CREATE_RATE_LIMIT', () => {
+    expect(CATALOG_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports CATALOG_MODIFY_RATE_LIMIT', () => {
+    expect(CATALOG_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('validateCatalogName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateCatalogName('  Product Catalog  ')).toBe('Product Catalog');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateCatalogName('A')).toBe('A');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateCatalogName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateCatalogName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateCatalogName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateCatalogName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateCatalogId', () => {
+  it('returns trimmed catalog ID for valid input', () => {
+    expect(validateCatalogId('  catalog-123  ')).toBe('catalog-123');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateCatalogId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateCatalogId('   ')).toThrow('must not be empty');
+  });
+});
+
+describe('validateCatalogSchema', () => {
+  it('returns valid schema', () => {
+    const schema = { sku: 'string', price: 'number' };
+    expect(validateCatalogSchema(schema)).toEqual(schema);
+  });
+
+  it('throws for empty schema', () => {
+    expect(() => validateCatalogSchema({})).toThrow('at least one field');
+  });
+
+  it('throws for empty field name', () => {
+    expect(() => validateCatalogSchema({ '   ': 'string' })).toThrow('field names must not be empty');
+  });
+});
+
+describe('validateCatalogItems', () => {
+  it('returns valid items', () => {
+    const items = [{ sku: 'ABC-123' }, { sku: 'XYZ-999' }];
+    expect(validateCatalogItems(items)).toEqual(items);
+  });
+
+  it('throws for empty array', () => {
+    expect(() => validateCatalogItems([])).toThrow('at least one item');
+  });
+});
+
+describe('validateCatalogItemUpdates', () => {
+  it('returns valid updates with trimmed IDs', () => {
+    const updates = [
+      { id: '  item-1  ', properties: { price: 100 } },
+      { id: 'item-2', properties: { price: 200 } },
+    ];
+    expect(validateCatalogItemUpdates(updates)).toEqual([
+      { id: 'item-1', properties: { price: 100 } },
+      { id: 'item-2', properties: { price: 200 } },
+    ]);
+  });
+
+  it('throws for empty array', () => {
+    expect(() => validateCatalogItemUpdates([])).toThrow('at least one item');
+  });
+
+  it('throws for empty item ID', () => {
+    expect(() => validateCatalogItemUpdates([{ id: '   ', properties: { price: 100 } }])).toThrow(
+      'Catalog item ID must not be empty',
+    );
+  });
+});
+
+describe('buildCatalogsUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildCatalogsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/crm/catalogs');
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildCatalogsUrl('my project')).toBe('/p/my%20project/crm/catalogs');
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildCatalogsUrl('org/project')).toBe('/p/org%2Fproject/crm/catalogs');
+  });
+});
+
+describe('createCatalogActionExecutors', () => {
+  it('returns executors for all four action types', () => {
+    const executors = createCatalogActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(4);
+    expect(executors[CREATE_CATALOG_ACTION_TYPE]).toBeDefined();
+    expect(executors[ADD_CATALOG_ITEMS_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_CATALOG_ITEMS_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_CATALOG_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createCatalogActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createCatalogActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachCatalogsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachCatalogsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachCatalogsService);
+    });
+
+    it('exposes the catalogs URL', () => {
+      const service = new BloomreachCatalogsService('kingdom-of-joakim');
+      expect(service.catalogsUrl).toBe('/p/kingdom-of-joakim/crm/catalogs');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachCatalogsService('  my-project  ');
+      expect(service.catalogsUrl).toBe('/p/my-project/crm/catalogs');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachCatalogsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listCatalogs', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachCatalogsService('test');
+      await expect(service.listCatalogs()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachCatalogsService('test');
+      await expect(service.listCatalogs({ project: '' })).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('viewCatalogItems', () => {
+    it('throws not-yet-implemented error with valid input', async () => {
+      const service = new BloomreachCatalogsService('test');
+      await expect(
+        service.viewCatalogItems({ project: 'test', catalogId: 'catalog-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachCatalogsService('test');
+      await expect(
+        service.viewCatalogItems({ project: '', catalogId: 'catalog-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates catalogId input', async () => {
+      const service = new BloomreachCatalogsService('test');
+      await expect(
+        service.viewCatalogItems({ project: 'test', catalogId: '   ' }),
+      ).rejects.toThrow('Catalog ID must not be empty');
+    });
+  });
+
+  describe('prepareCreateCatalog', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCatalogsService('test');
+      const result = service.prepareCreateCatalog({
+        project: 'test',
+        name: 'Products',
+        schema: { sku: 'string' },
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'catalogs.create_catalog',
+          project: 'test',
+          name: 'Products',
+          schema: { sku: 'string' },
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachCatalogsService('test');
+      const result = service.prepareCreateCatalog({
+        project: 'test',
+        name: 'Products',
+        schema: { sku: 'string' },
+        operatorNote: 'Create catalog for spring launch',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Create catalog for spring launch' }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareCreateCatalog({
+          project: 'test',
+          name: '',
+          schema: { sku: 'string' },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareCreateCatalog({
+          project: '',
+          name: 'Products',
+          schema: { sku: 'string' },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty schema', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareCreateCatalog({
+          project: 'test',
+          name: 'Products',
+          schema: {},
+        }),
+      ).toThrow('at least one field');
+    });
+  });
+
+  describe('prepareAddCatalogItems', () => {
+    it('returns a prepared action with itemCount in preview', () => {
+      const service = new BloomreachCatalogsService('test');
+      const result = service.prepareAddCatalogItems({
+        project: 'test',
+        catalogId: 'catalog-123',
+        items: [{ sku: 'A' }, { sku: 'B' }],
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'catalogs.add_catalog_items',
+          project: 'test',
+          catalogId: 'catalog-123',
+          itemCount: 2,
+        }),
+      );
+    });
+
+    it('throws for empty catalogId', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareAddCatalogItems({
+          project: 'test',
+          catalogId: '',
+          items: [{ sku: 'A' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareAddCatalogItems({
+          project: '',
+          catalogId: 'catalog-123',
+          items: [{ sku: 'A' }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty items', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareAddCatalogItems({
+          project: 'test',
+          catalogId: 'catalog-123',
+          items: [],
+        }),
+      ).toThrow('at least one item');
+    });
+  });
+
+  describe('prepareUpdateCatalogItems', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCatalogsService('test');
+      const result = service.prepareUpdateCatalogItems({
+        project: 'test',
+        catalogId: 'catalog-123',
+        items: [{ id: 'item-1', properties: { price: 300 } }],
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'catalogs.update_catalog_items',
+          project: 'test',
+          catalogId: 'catalog-123',
+          itemCount: 1,
+        }),
+      );
+    });
+
+    it('throws for empty catalogId', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareUpdateCatalogItems({
+          project: 'test',
+          catalogId: '',
+          items: [{ id: 'item-1', properties: { price: 300 } }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareUpdateCatalogItems({
+          project: '',
+          catalogId: 'catalog-123',
+          items: [{ id: 'item-1', properties: { price: 300 } }],
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty items', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() =>
+        service.prepareUpdateCatalogItems({
+          project: 'test',
+          catalogId: 'catalog-123',
+          items: [],
+        }),
+      ).toThrow('at least one item');
+    });
+  });
+
+  describe('prepareDeleteCatalog', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCatalogsService('test');
+      const result = service.prepareDeleteCatalog({
+        project: 'test',
+        catalogId: 'catalog-999',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'catalogs.delete_catalog',
+          project: 'test',
+          catalogId: 'catalog-999',
+        }),
+      );
+    });
+
+    it('throws for empty catalogId', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() => service.prepareDeleteCatalog({ project: 'test', catalogId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCatalogsService('test');
+      expect(() => service.prepareDeleteCatalog({ project: '', catalogId: 'catalog-999' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+});

--- a/packages/core/src/bloomreachCatalogs.ts
+++ b/packages/core/src/bloomreachCatalogs.ts
@@ -1,0 +1,335 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const CREATE_CATALOG_ACTION_TYPE = 'catalogs.create_catalog';
+export const ADD_CATALOG_ITEMS_ACTION_TYPE = 'catalogs.add_catalog_items';
+export const UPDATE_CATALOG_ITEMS_ACTION_TYPE = 'catalogs.update_catalog_items';
+export const DELETE_CATALOG_ACTION_TYPE = 'catalogs.delete_catalog';
+
+export const CATALOG_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const CATALOG_CREATE_RATE_LIMIT = 10;
+export const CATALOG_MODIFY_RATE_LIMIT = 20;
+
+export interface BloomreachCatalog {
+  id: string;
+  name: string;
+  itemCount: number;
+  schema: Record<string, string>;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface CatalogItem {
+  id: string;
+  catalogId: string;
+  properties: Record<string, unknown>;
+}
+
+export interface CatalogItemsPage {
+  items: CatalogItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface ListCatalogsInput {
+  project: string;
+}
+
+export interface ViewCatalogItemsInput {
+  project: string;
+  catalogId: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CreateCatalogInput {
+  project: string;
+  name: string;
+  schema: Record<string, string>;
+  operatorNote?: string;
+}
+
+export interface AddCatalogItemsInput {
+  project: string;
+  catalogId: string;
+  items: Record<string, unknown>[];
+  operatorNote?: string;
+}
+
+export interface UpdateCatalogItemsInput {
+  project: string;
+  catalogId: string;
+  items: { id: string; properties: Record<string, unknown> }[];
+  operatorNote?: string;
+}
+
+export interface DeleteCatalogInput {
+  project: string;
+  catalogId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedCatalogAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_CATALOG_NAME_LENGTH = 200;
+const MIN_CATALOG_NAME_LENGTH = 1;
+
+export function validateCatalogName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_CATALOG_NAME_LENGTH) {
+    throw new Error('Catalog name must not be empty.');
+  }
+  if (trimmed.length > MAX_CATALOG_NAME_LENGTH) {
+    throw new Error(
+      `Catalog name must not exceed ${MAX_CATALOG_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateCatalogId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Catalog ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateCatalogSchema(schema: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(schema);
+  if (entries.length === 0) {
+    throw new Error('Catalog schema must include at least one field.');
+  }
+
+  const normalizedSchema: Record<string, string> = {};
+  for (const [fieldName, fieldType] of entries) {
+    const normalizedFieldName = fieldName.trim();
+    if (normalizedFieldName.length === 0) {
+      throw new Error('Catalog schema field names must not be empty.');
+    }
+    normalizedSchema[normalizedFieldName] = fieldType;
+  }
+
+  return normalizedSchema;
+}
+
+export function validateCatalogItems(items: Record<string, unknown>[]): Record<string, unknown>[] {
+  if (items.length === 0) {
+    throw new Error('Catalog items must include at least one item.');
+  }
+  return items;
+}
+
+export function validateCatalogItemUpdates(
+  items: { id: string; properties: Record<string, unknown> }[],
+): { id: string; properties: Record<string, unknown> }[] {
+  if (items.length === 0) {
+    throw new Error('Catalog item updates must include at least one item.');
+  }
+
+  return items.map((item) => {
+    const id = item.id.trim();
+    if (id.length === 0) {
+      throw new Error('Catalog item ID must not be empty.');
+    }
+    return {
+      id,
+      properties: item.properties,
+    };
+  });
+}
+
+export function buildCatalogsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/crm/catalogs`;
+}
+
+export interface CatalogActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateCatalogExecutor implements CatalogActionExecutor {
+  readonly actionType = CREATE_CATALOG_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateCatalogExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class AddCatalogItemsExecutor implements CatalogActionExecutor {
+  readonly actionType = ADD_CATALOG_ITEMS_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'AddCatalogItemsExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateCatalogItemsExecutor implements CatalogActionExecutor {
+  readonly actionType = UPDATE_CATALOG_ITEMS_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateCatalogItemsExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteCatalogExecutor implements CatalogActionExecutor {
+  readonly actionType = DELETE_CATALOG_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteCatalogExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createCatalogActionExecutors(): Record<string, CatalogActionExecutor> {
+  return {
+    [CREATE_CATALOG_ACTION_TYPE]: new CreateCatalogExecutor(),
+    [ADD_CATALOG_ITEMS_ACTION_TYPE]: new AddCatalogItemsExecutor(),
+    [UPDATE_CATALOG_ITEMS_ACTION_TYPE]: new UpdateCatalogItemsExecutor(),
+    [DELETE_CATALOG_ACTION_TYPE]: new DeleteCatalogExecutor(),
+  };
+}
+
+export class BloomreachCatalogsService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildCatalogsUrl(validateProject(project));
+  }
+
+  get catalogsUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listCatalogs(input?: ListCatalogsInput): Promise<BloomreachCatalog[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listCatalogs: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewCatalogItems(input: ViewCatalogItemsInput): Promise<CatalogItemsPage> {
+    validateProject(input.project);
+    validateCatalogId(input.catalogId);
+    if (input.page !== undefined) {
+      if (!Number.isInteger(input.page) || input.page <= 0) {
+        throw new Error(`page must be a positive integer (got ${input.page}).`);
+      }
+    }
+    if (input.pageSize !== undefined) {
+      if (!Number.isInteger(input.pageSize) || input.pageSize <= 0) {
+        throw new Error(`pageSize must be a positive integer (got ${input.pageSize}).`);
+      }
+    }
+
+    throw new Error(
+      'viewCatalogItems: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateCatalog(input: CreateCatalogInput): PreparedCatalogAction {
+    const project = validateProject(input.project);
+    const name = validateCatalogName(input.name);
+    const schema = validateCatalogSchema(input.schema);
+
+    const preview = {
+      action: CREATE_CATALOG_ACTION_TYPE,
+      project,
+      name,
+      schema,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareAddCatalogItems(input: AddCatalogItemsInput): PreparedCatalogAction {
+    const project = validateProject(input.project);
+    const catalogId = validateCatalogId(input.catalogId);
+    const items = validateCatalogItems(input.items);
+
+    const preview = {
+      action: ADD_CATALOG_ITEMS_ACTION_TYPE,
+      project,
+      catalogId,
+      itemCount: items.length,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateCatalogItems(input: UpdateCatalogItemsInput): PreparedCatalogAction {
+    const project = validateProject(input.project);
+    const catalogId = validateCatalogId(input.catalogId);
+    const items = validateCatalogItemUpdates(input.items);
+
+    const preview = {
+      action: UPDATE_CATALOG_ITEMS_ACTION_TYPE,
+      project,
+      catalogId,
+      itemCount: items.length,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteCatalog(input: DeleteCatalogInput): PreparedCatalogAction {
+    const project = validateProject(input.project);
+    const catalogId = validateCatalogId(input.catalogId);
+
+    const preview = {
+      action: DELETE_CATALOG_ACTION_TYPE,
+      project,
+      catalogId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './bloomreachCampaignCalendar.js';
 export * from './bloomreachCampaignSettings.js';
+export * from './bloomreachCatalogs.js';
 export * from './bloomreachDashboards.js';
 export * from './bloomreachEmailCampaigns.js';
 export * from './bloomreachFlows.js';


### PR DESCRIPTION
## Summary

Adds the **Manage Catalogs** feature module for Bloomreach Engagement, enabling catalog CRUD operations following the established two-phase commit pattern.

**Navigation:** Data & Assets > Catalogs (`/p/{project}/crm/catalogs`)

## Changes

### Core Module (`packages/core/src/bloomreachCatalogs.ts`)
- 4 action type constants (`catalogs.create_catalog`, `catalogs.add_catalog_items`, `catalogs.update_catalog_items`, `catalogs.delete_catalog`)
- Rate limit constants (1h window, 10 create / 20 modify limits)
- Complete TypeScript interfaces: `BloomreachCatalog`, `CatalogItem`, `CatalogItemsPage`, and all input/output types
- 5 validators: `validateCatalogName`, `validateCatalogId`, `validateCatalogSchema`, `validateCatalogItems`, `validateCatalogItemUpdates`
- URL builder: `buildCatalogsUrl`
- 4 action executor classes (stubs pending browser automation infrastructure)
- `BloomreachCatalogsService` with:
  - `listCatalogs()` — list all catalogs
  - `viewCatalogItems()` — paginated item browsing
  - `prepareCreateCatalog()` — two-phase catalog creation
  - `prepareAddCatalogItems()` — two-phase item addition
  - `prepareUpdateCatalogItems()` — two-phase item updates
  - `prepareDeleteCatalog()` — two-phase catalog deletion

### Unit Tests (`packages/core/src/__tests__/bloomreachCatalogs.test.ts`)
- 452 lines of comprehensive tests covering all constants, validators, URL builder, executor factory, and service methods
- Follows established test patterns (imports from `../index.js`)

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- `bloomreach catalogs list` — list catalogs
- `bloomreach catalogs view-items` — browse catalog items (paginated)
- `bloomreach catalogs create` — prepare catalog creation
- `bloomreach catalogs add-items` — prepare adding items
- `bloomreach catalogs update-items` — prepare updating items
- `bloomreach catalogs delete` — prepare catalog deletion

## Quality Gates
- ✅ `npm run typecheck` — passed
- ✅ `npm run lint` — passed
- ✅ `npm test` — 14 test files, 1207 tests passed
- ✅ `npm run build` — passed

Closes #44
