### PR TITLE
feat: manage Asset Manager (templates, snippets, files) (#46)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import {
+  BloomreachAssetManagerService,
   BloomreachClient,
   BloomreachCampaignCalendarService,
   BloomreachCustomersService,
@@ -3029,6 +3030,671 @@ vouchers
           console.log(`  Pool:    ${options.poolId}`);
           console.log(`  Token:   ${result.confirmToken}`);
           console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const assets = program
+  .command('assets')
+  .description('Manage Asset Manager templates, snippets, and files');
+
+const assetEmailTemplates = assets
+  .command('email-templates')
+  .description('Manage email templates');
+
+assetEmailTemplates
+  .command('list')
+  .description('List all email templates in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const result = await service.listEmailTemplates({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No email templates found.');
+          return;
+        }
+
+        for (const template of result) {
+          console.log(`  ${template.name}`);
+          console.log(`    Status:  ${template.status}`);
+          console.log(`    Builder: ${template.builderType ?? 'n/a'}`);
+          console.log(`    ID:      ${template.id}`);
+          console.log(`    URL:     ${template.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+assetEmailTemplates
+  .command('create')
+  .description('Prepare creation of an email template (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Template name')
+  .option('--builder-type <type>', 'Builder type (visual, html)')
+  .option('--html-content <html>', 'Initial HTML content')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      builderType?: string;
+      htmlContent?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareCreateEmailTemplate({
+          project: options.project,
+          name: options.name,
+          builderType: options.builderType,
+          htmlContent: options.htmlContent,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Email template creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const assetWeblayerTemplates = assets
+  .command('weblayer-templates')
+  .description('Manage weblayer templates');
+
+assetWeblayerTemplates
+  .command('list')
+  .description('List all weblayer templates in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const result = await service.listWeblayerTemplates({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No weblayer templates found.');
+          return;
+        }
+
+        for (const template of result) {
+          console.log(`  ${template.name}`);
+          console.log(`    Status: ${template.status}`);
+          console.log(`    ID:     ${template.id}`);
+          console.log(`    URL:    ${template.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+assetWeblayerTemplates
+  .command('create')
+  .description('Prepare creation of a weblayer template (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Template name')
+  .option('--html-content <html>', 'Initial HTML content')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      htmlContent?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareCreateWeblayerTemplate({
+          project: options.project,
+          name: options.name,
+          htmlContent: options.htmlContent,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Weblayer template creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const assetBlocks = assets.command('blocks').description('Manage content blocks');
+
+assetBlocks
+  .command('list')
+  .description('List all blocks in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const result = await service.listBlocks({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No blocks found.');
+          return;
+        }
+
+        for (const block of result) {
+          console.log(`  ${block.name}`);
+          console.log(`    Status: ${block.status}`);
+          console.log(`    ID:     ${block.id}`);
+          console.log(`    URL:    ${block.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+assetBlocks
+  .command('create')
+  .description('Prepare creation of a block (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Block name')
+  .option('--html-content <html>', 'Initial HTML content')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      htmlContent?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareCreateBlock({
+          project: options.project,
+          name: options.name,
+          htmlContent: options.htmlContent,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Block creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const assetCustomRows = assets
+  .command('custom-rows')
+  .description('Manage custom rows');
+
+assetCustomRows
+  .command('list')
+  .description('List all custom rows in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const result = await service.listCustomRows({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No custom rows found.');
+          return;
+        }
+
+        for (const customRow of result) {
+          console.log(`  ${customRow.name}`);
+          console.log(`    Status: ${customRow.status}`);
+          console.log(`    ID:     ${customRow.id}`);
+          console.log(`    URL:    ${customRow.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+assetCustomRows
+  .command('create')
+  .description('Prepare creation of a custom row (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Custom row name')
+  .option('--html-content <html>', 'Initial HTML content')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      htmlContent?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareCreateCustomRow({
+          project: options.project,
+          name: options.name,
+          htmlContent: options.htmlContent,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Custom row creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const assetSnippets = assets.command('snippets').description('Manage snippets');
+
+assetSnippets
+  .command('list')
+  .description('List all snippets in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const result = await service.listSnippets({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No snippets found.');
+          return;
+        }
+
+        for (const snippet of result) {
+          console.log(`  ${snippet.name}`);
+          console.log(`    Language: ${snippet.language}`);
+          console.log(`    ID:       ${snippet.id}`);
+          console.log(`    URL:      ${snippet.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+assetSnippets
+  .command('create')
+  .description('Prepare creation of a snippet (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Snippet name')
+  .requiredOption('--language <language>', 'Snippet language (jinja, html)')
+  .requiredOption('--content <content>', 'Snippet content')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      language: string;
+      content: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareCreateSnippet({
+          project: options.project,
+          name: options.name,
+          language: options.language,
+          content: options.content,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Snippet creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+assetSnippets
+  .command('edit')
+  .description('Prepare editing a snippet (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--snippet-id <id>', 'Snippet ID')
+  .option('--name <name>', 'Snippet name')
+  .option('--language <language>', 'Snippet language (jinja, html)')
+  .option('--content <content>', 'Snippet content')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      snippetId: string;
+      name?: string;
+      language?: string;
+      content?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareEditSnippet({
+          project: options.project,
+          snippetId: options.snippetId,
+          name: options.name,
+          language: options.language,
+          content: options.content,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Snippet edit prepared.');
+          console.log(`  Snippet: ${options.snippetId}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const assetFiles = assets.command('files').description('Manage files');
+
+assetFiles
+  .command('list')
+  .description('List all files in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--category <category>', 'File category (image, document, font, other)')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; category?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const input: { project: string; category?: string } = { project: options.project };
+      if (options.category) input.category = options.category;
+
+      const result = await service.listFiles(input);
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No files found.');
+          return;
+        }
+
+        for (const file of result) {
+          console.log(`  ${file.name}`);
+          console.log(`    Category: ${file.category}`);
+          console.log(`    MIME:     ${file.mimeType}`);
+          console.log(`    ID:       ${file.id}`);
+          console.log(`    URL:      ${file.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+assetFiles
+  .command('upload')
+  .description('Prepare uploading a file (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'File name')
+  .requiredOption('--mime-type <type>', 'MIME type')
+  .option('--file-size <size>', 'File size in bytes')
+  .option('--category <category>', 'File category (image, document, font, other)')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      mimeType: string;
+      fileSize?: string;
+      category?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const fileSize = options.fileSize ? parseInt(options.fileSize, 10) : undefined;
+
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareUploadFile({
+          project: options.project,
+          name: options.name,
+          mimeType: options.mimeType,
+          fileSize,
+          category: options.category,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('File upload prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+assetFiles
+  .command('delete')
+  .description('Prepare deleting a file (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--file-id <id>', 'File ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; fileId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareDeleteFile({
+          project: options.project,
+          fileId: options.fileId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('File deletion prepared.');
+          console.log(`  File:    ${options.fileId}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+assets
+  .command('clone')
+  .description('Prepare cloning a template (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--template-id <id>', 'Template ID')
+  .requiredOption(
+    '--asset-type <type>',
+    'Asset type (email_template, weblayer_template, block, custom_row)',
+  )
+  .option('--new-name <name>', 'Name for the cloned template')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      templateId: string;
+      assetType: string;
+      newName?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareCloneTemplate({
+          project: options.project,
+          templateId: options.templateId,
+          assetType: options.assetType,
+          newName: options.newName,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Template clone prepared.');
+          console.log(`  Template: ${options.templateId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+assets
+  .command('archive')
+  .description('Prepare archiving a template (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--template-id <id>', 'Template ID')
+  .requiredOption(
+    '--asset-type <type>',
+    'Asset type (email_template, weblayer_template, block, custom_row)',
+  )
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      templateId: string;
+      assetType: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAssetManagerService(options.project);
+        const result = service.prepareArchiveTemplate({
+          project: options.project,
+          templateId: options.templateId,
+          assetType: options.assetType,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Template archive prepared.');
+          console.log(`  Template: ${options.templateId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
           console.log('To confirm, run:');
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);

--- a/packages/core/src/__tests__/bloomreachAssetManager.test.ts
+++ b/packages/core/src/__tests__/bloomreachAssetManager.test.ts
@@ -1,0 +1,809 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_EMAIL_TEMPLATE_ACTION_TYPE,
+  CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE,
+  CREATE_BLOCK_ACTION_TYPE,
+  CREATE_CUSTOM_ROW_ACTION_TYPE,
+  CREATE_SNIPPET_ACTION_TYPE,
+  EDIT_SNIPPET_ACTION_TYPE,
+  UPLOAD_FILE_ACTION_TYPE,
+  DELETE_FILE_ACTION_TYPE,
+  CLONE_TEMPLATE_ACTION_TYPE,
+  ARCHIVE_TEMPLATE_ACTION_TYPE,
+  ASSET_MANAGER_RATE_LIMIT_WINDOW_MS,
+  ASSET_MANAGER_CREATE_RATE_LIMIT,
+  ASSET_MANAGER_MODIFY_RATE_LIMIT,
+  ASSET_TYPES,
+  TEMPLATE_STATUSES,
+  FILE_CATEGORIES,
+  SNIPPET_LANGUAGES,
+  TEMPLATE_BUILDER_TYPES,
+  validateAssetName,
+  validateAssetType,
+  validateTemplateStatus,
+  validateFileCategory,
+  validateSnippetLanguage,
+  validateBuilderType,
+  validateSnippetContent,
+  validateMimeType,
+  validateAssetId,
+  buildEmailTemplatesUrl,
+  buildWeblayerTemplatesUrl,
+  buildBlocksUrl,
+  buildCustomRowsUrl,
+  buildSnippetsUrl,
+  buildFilesUrl,
+  createAssetManagerActionExecutors,
+  BloomreachAssetManagerService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_EMAIL_TEMPLATE_ACTION_TYPE', () => {
+    expect(CREATE_EMAIL_TEMPLATE_ACTION_TYPE).toBe('asset_manager.create_email_template');
+  });
+
+  it('exports CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE', () => {
+    expect(CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE).toBe(
+      'asset_manager.create_weblayer_template',
+    );
+  });
+
+  it('exports CREATE_BLOCK_ACTION_TYPE', () => {
+    expect(CREATE_BLOCK_ACTION_TYPE).toBe('asset_manager.create_block');
+  });
+
+  it('exports CREATE_CUSTOM_ROW_ACTION_TYPE', () => {
+    expect(CREATE_CUSTOM_ROW_ACTION_TYPE).toBe('asset_manager.create_custom_row');
+  });
+
+  it('exports CREATE_SNIPPET_ACTION_TYPE', () => {
+    expect(CREATE_SNIPPET_ACTION_TYPE).toBe('asset_manager.create_snippet');
+  });
+
+  it('exports EDIT_SNIPPET_ACTION_TYPE', () => {
+    expect(EDIT_SNIPPET_ACTION_TYPE).toBe('asset_manager.edit_snippet');
+  });
+
+  it('exports UPLOAD_FILE_ACTION_TYPE', () => {
+    expect(UPLOAD_FILE_ACTION_TYPE).toBe('asset_manager.upload_file');
+  });
+
+  it('exports DELETE_FILE_ACTION_TYPE', () => {
+    expect(DELETE_FILE_ACTION_TYPE).toBe('asset_manager.delete_file');
+  });
+
+  it('exports CLONE_TEMPLATE_ACTION_TYPE', () => {
+    expect(CLONE_TEMPLATE_ACTION_TYPE).toBe('asset_manager.clone_template');
+  });
+
+  it('exports ARCHIVE_TEMPLATE_ACTION_TYPE', () => {
+    expect(ARCHIVE_TEMPLATE_ACTION_TYPE).toBe('asset_manager.archive_template');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports ASSET_MANAGER_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(ASSET_MANAGER_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports ASSET_MANAGER_CREATE_RATE_LIMIT', () => {
+    expect(ASSET_MANAGER_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports ASSET_MANAGER_MODIFY_RATE_LIMIT', () => {
+    expect(ASSET_MANAGER_MODIFY_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('enum arrays', () => {
+  it('exports ASSET_TYPES in order', () => {
+    expect(ASSET_TYPES).toEqual([
+      'email_template',
+      'weblayer_template',
+      'block',
+      'custom_row',
+      'snippet',
+      'file',
+    ]);
+  });
+
+  it('exports TEMPLATE_STATUSES in order', () => {
+    expect(TEMPLATE_STATUSES).toEqual(['active', 'archived', 'draft']);
+  });
+
+  it('exports FILE_CATEGORIES in order', () => {
+    expect(FILE_CATEGORIES).toEqual(['image', 'document', 'font', 'other']);
+  });
+
+  it('exports SNIPPET_LANGUAGES in order', () => {
+    expect(SNIPPET_LANGUAGES).toEqual(['jinja', 'html']);
+  });
+
+  it('exports TEMPLATE_BUILDER_TYPES in order', () => {
+    expect(TEMPLATE_BUILDER_TYPES).toEqual(['visual', 'html']);
+  });
+});
+
+describe('validateAssetName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateAssetName('  Hero Template  ')).toBe('Hero Template');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateAssetName('A')).toBe('A');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateAssetName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateAssetName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateAssetName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    expect(() => validateAssetName('x'.repeat(201))).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateAssetType', () => {
+  it('accepts all known asset types', () => {
+    expect(validateAssetType('email_template')).toBe('email_template');
+    expect(validateAssetType('weblayer_template')).toBe('weblayer_template');
+    expect(validateAssetType('block')).toBe('block');
+    expect(validateAssetType('custom_row')).toBe('custom_row');
+    expect(validateAssetType('snippet')).toBe('snippet');
+    expect(validateAssetType('file')).toBe('file');
+  });
+
+  it('throws for unknown asset type', () => {
+    expect(() => validateAssetType('template')).toThrow('assetType must be one of');
+  });
+});
+
+describe('validateTemplateStatus', () => {
+  it('accepts all statuses', () => {
+    expect(validateTemplateStatus('active')).toBe('active');
+    expect(validateTemplateStatus('archived')).toBe('archived');
+    expect(validateTemplateStatus('draft')).toBe('draft');
+  });
+
+  it('throws for unknown status', () => {
+    expect(() => validateTemplateStatus('paused')).toThrow('status must be one of');
+  });
+});
+
+describe('validateFileCategory', () => {
+  it('accepts all categories', () => {
+    expect(validateFileCategory('image')).toBe('image');
+    expect(validateFileCategory('document')).toBe('document');
+    expect(validateFileCategory('font')).toBe('font');
+    expect(validateFileCategory('other')).toBe('other');
+  });
+
+  it('throws for unknown category', () => {
+    expect(() => validateFileCategory('video')).toThrow('category must be one of');
+  });
+});
+
+describe('validateSnippetLanguage', () => {
+  it('accepts jinja and html', () => {
+    expect(validateSnippetLanguage('jinja')).toBe('jinja');
+    expect(validateSnippetLanguage('html')).toBe('html');
+  });
+
+  it('throws for unknown language', () => {
+    expect(() => validateSnippetLanguage('liquid')).toThrow('language must be one of');
+  });
+});
+
+describe('validateBuilderType', () => {
+  it('accepts visual and html', () => {
+    expect(validateBuilderType('visual')).toBe('visual');
+    expect(validateBuilderType('html')).toBe('html');
+  });
+
+  it('throws for unknown builder type', () => {
+    expect(() => validateBuilderType('markdown')).toThrow('builderType must be one of');
+  });
+});
+
+describe('validateSnippetContent', () => {
+  it('accepts non-empty content', () => {
+    expect(validateSnippetContent('{% if customer %}Hello{% endif %}')).toBe(
+      '{% if customer %}Hello{% endif %}',
+    );
+  });
+
+  it('accepts content at maximum length', () => {
+    const content = 'x'.repeat(100_000);
+    expect(validateSnippetContent(content)).toBe(content);
+  });
+
+  it('throws for empty content', () => {
+    expect(() => validateSnippetContent('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only content', () => {
+    expect(() => validateSnippetContent('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for content above max length', () => {
+    expect(() => validateSnippetContent('x'.repeat(100_001))).toThrow(
+      'must not exceed 100000 characters',
+    );
+  });
+});
+
+describe('validateMimeType', () => {
+  it('returns trimmed mime type', () => {
+    expect(validateMimeType('  image/png  ')).toBe('image/png');
+  });
+
+  it('throws for empty mime type', () => {
+    expect(() => validateMimeType('')).toThrow('must not be empty');
+  });
+
+  it('throws when mime type has no slash', () => {
+    expect(() => validateMimeType('image')).toThrow('must include a "/"');
+  });
+});
+
+describe('validateAssetId', () => {
+  it('returns trimmed ID', () => {
+    expect(validateAssetId('  asset-123  ')).toBe('asset-123');
+  });
+
+  it('throws for empty ID', () => {
+    expect(() => validateAssetId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only ID', () => {
+    expect(() => validateAssetId('   ')).toThrow('must not be empty');
+  });
+});
+
+describe('URL builders', () => {
+  it('buildEmailTemplatesUrl handles simple, spaces, and slashes', () => {
+    expect(buildEmailTemplatesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/data/assets/email-templates',
+    );
+    expect(buildEmailTemplatesUrl('my project')).toBe(
+      '/p/my%20project/data/assets/email-templates',
+    );
+    expect(buildEmailTemplatesUrl('org/project')).toBe(
+      '/p/org%2Fproject/data/assets/email-templates',
+    );
+  });
+
+  it('buildWeblayerTemplatesUrl handles simple, spaces, and slashes', () => {
+    expect(buildWeblayerTemplatesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/data/assets/weblayer-templates',
+    );
+    expect(buildWeblayerTemplatesUrl('my project')).toBe(
+      '/p/my%20project/data/assets/weblayer-templates',
+    );
+    expect(buildWeblayerTemplatesUrl('org/project')).toBe(
+      '/p/org%2Fproject/data/assets/weblayer-templates',
+    );
+  });
+
+  it('buildBlocksUrl handles simple, spaces, and slashes', () => {
+    expect(buildBlocksUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/data/assets/blocks');
+    expect(buildBlocksUrl('my project')).toBe('/p/my%20project/data/assets/blocks');
+    expect(buildBlocksUrl('org/project')).toBe('/p/org%2Fproject/data/assets/blocks');
+  });
+
+  it('buildCustomRowsUrl handles simple, spaces, and slashes', () => {
+    expect(buildCustomRowsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/data/assets/custom-rows',
+    );
+    expect(buildCustomRowsUrl('my project')).toBe('/p/my%20project/data/assets/custom-rows');
+    expect(buildCustomRowsUrl('org/project')).toBe('/p/org%2Fproject/data/assets/custom-rows');
+  });
+
+  it('buildSnippetsUrl handles simple, spaces, and slashes', () => {
+    expect(buildSnippetsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/data/assets/snippets',
+    );
+    expect(buildSnippetsUrl('my project')).toBe('/p/my%20project/data/assets/snippets');
+    expect(buildSnippetsUrl('org/project')).toBe('/p/org%2Fproject/data/assets/snippets');
+  });
+
+  it('buildFilesUrl handles simple, spaces, and slashes', () => {
+    expect(buildFilesUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/data/assets/files');
+    expect(buildFilesUrl('my project')).toBe('/p/my%20project/data/assets/files');
+    expect(buildFilesUrl('org/project')).toBe('/p/org%2Fproject/data/assets/files');
+  });
+});
+
+describe('createAssetManagerActionExecutors', () => {
+  it('returns executors for all ten action types', () => {
+    const executors = createAssetManagerActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(10);
+    expect(executors[CREATE_EMAIL_TEMPLATE_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_BLOCK_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_CUSTOM_ROW_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_SNIPPET_ACTION_TYPE]).toBeDefined();
+    expect(executors[EDIT_SNIPPET_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPLOAD_FILE_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_FILE_ACTION_TYPE]).toBeDefined();
+    expect(executors[CLONE_TEMPLATE_ACTION_TYPE]).toBeDefined();
+    expect(executors[ARCHIVE_TEMPLATE_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor actionType matches its key', () => {
+    const executors = createAssetManagerActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createAssetManagerActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachAssetManagerService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachAssetManagerService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachAssetManagerService);
+    });
+
+    it('exposes all expected URLs', () => {
+      const service = new BloomreachAssetManagerService('kingdom-of-joakim');
+      expect(service.emailTemplatesUrl).toBe(
+        '/p/kingdom-of-joakim/data/assets/email-templates',
+      );
+      expect(service.weblayerTemplatesUrl).toBe(
+        '/p/kingdom-of-joakim/data/assets/weblayer-templates',
+      );
+      expect(service.blocksUrl).toBe('/p/kingdom-of-joakim/data/assets/blocks');
+      expect(service.customRowsUrl).toBe('/p/kingdom-of-joakim/data/assets/custom-rows');
+      expect(service.snippetsUrl).toBe('/p/kingdom-of-joakim/data/assets/snippets');
+      expect(service.filesUrl).toBe('/p/kingdom-of-joakim/data/assets/files');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachAssetManagerService('  test  ');
+      expect(service.emailTemplatesUrl).toBe('/p/test/data/assets/email-templates');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachAssetManagerService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('list methods', () => {
+    it('listEmailTemplates throws not-yet-implemented error', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listEmailTemplates()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listWeblayerTemplates throws not-yet-implemented error', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listWeblayerTemplates()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listBlocks throws not-yet-implemented error', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listBlocks()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listCustomRows throws not-yet-implemented error', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listCustomRows()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listSnippets throws not-yet-implemented error', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listSnippets()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listFiles throws not-yet-implemented error', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listFiles()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project for list methods when input is provided', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(service.listEmailTemplates({ project: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+      await expect(service.listWeblayerTemplates({ project: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+      await expect(service.listBlocks({ project: '' })).rejects.toThrow('must not be empty');
+      await expect(service.listCustomRows({ project: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+      await expect(service.listSnippets({ project: '' })).rejects.toThrow('must not be empty');
+      await expect(service.listFiles({ project: '' })).rejects.toThrow('must not be empty');
+    });
+
+    it('validates listFiles category when provided', async () => {
+      const service = new BloomreachAssetManagerService('test');
+      await expect(
+        service.listFiles({ project: 'test', category: 'video' }),
+      ).rejects.toThrow('category must be one of');
+    });
+  });
+
+  describe('prepareCreateEmailTemplate', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareCreateEmailTemplate({
+        project: 'test',
+        name: 'Order Confirmation',
+        builderType: 'html',
+        htmlContent: '<html></html>',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.create_email_template',
+          project: 'test',
+          name: 'Order Confirmation',
+          builderType: 'html',
+        }),
+      );
+    });
+
+    it('throws for invalid builder type', () => {
+      const service = new BloomreachAssetManagerService('test');
+      expect(() =>
+        service.prepareCreateEmailTemplate({
+          project: 'test',
+          name: 'Template',
+          builderType: 'visual-plus',
+        }),
+      ).toThrow('builderType must be one of');
+    });
+  });
+
+  describe('prepareCreateWeblayerTemplate', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareCreateWeblayerTemplate({
+        project: 'test',
+        name: 'Weblayer Hero',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.create_weblayer_template',
+          project: 'test',
+          name: 'Weblayer Hero',
+        }),
+      );
+    });
+  });
+
+  describe('prepareCreateBlock', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareCreateBlock({
+        project: 'test',
+        name: 'Footer Block',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.create_block',
+          project: 'test',
+          name: 'Footer Block',
+        }),
+      );
+    });
+  });
+
+  describe('prepareCreateCustomRow', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareCreateCustomRow({
+        project: 'test',
+        name: 'Two Column Row',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.create_custom_row',
+          project: 'test',
+          name: 'Two Column Row',
+        }),
+      );
+    });
+  });
+
+  describe('prepareCreateSnippet', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareCreateSnippet({
+        project: 'test',
+        name: 'Greeting Snippet',
+        language: 'jinja',
+        content: 'Hello {{ customer.first_name }}',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.create_snippet',
+          project: 'test',
+          name: 'Greeting Snippet',
+          language: 'jinja',
+        }),
+      );
+    });
+
+    it('throws for empty content', () => {
+      const service = new BloomreachAssetManagerService('test');
+      expect(() =>
+        service.prepareCreateSnippet({
+          project: 'test',
+          name: 'Snippet',
+          language: 'jinja',
+          content: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareEditSnippet', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareEditSnippet({
+        project: 'test',
+        snippetId: 'snippet-123',
+        name: 'Updated Name',
+        language: 'html',
+        content: '<div>Hello</div>',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.edit_snippet',
+          project: 'test',
+          snippetId: 'snippet-123',
+          name: 'Updated Name',
+          language: 'html',
+        }),
+      );
+    });
+
+    it('throws for empty snippetId', () => {
+      const service = new BloomreachAssetManagerService('test');
+      expect(() =>
+        service.prepareEditSnippet({
+          project: 'test',
+          snippetId: '   ',
+        }),
+      ).toThrow('Asset ID must not be empty');
+    });
+  });
+
+  describe('prepareUploadFile', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareUploadFile({
+        project: 'test',
+        name: 'logo.png',
+        mimeType: 'image/png',
+        category: 'image',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.upload_file',
+          project: 'test',
+          name: 'logo.png',
+          mimeType: 'image/png',
+          category: 'image',
+        }),
+      );
+    });
+
+    it('throws for invalid mime type', () => {
+      const service = new BloomreachAssetManagerService('test');
+      expect(() =>
+        service.prepareUploadFile({
+          project: 'test',
+          name: 'logo',
+          mimeType: 'image',
+        }),
+      ).toThrow('must include a "/"');
+    });
+  });
+
+  describe('prepareDeleteFile', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareDeleteFile({
+        project: 'test',
+        fileId: 'file-001',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.delete_file',
+          project: 'test',
+          fileId: 'file-001',
+        }),
+      );
+    });
+  });
+
+  describe('prepareCloneTemplate', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareCloneTemplate({
+        project: 'test',
+        templateId: 'tmpl-1',
+        assetType: 'email_template',
+        newName: 'Clone Name',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.clone_template',
+          project: 'test',
+          templateId: 'tmpl-1',
+          assetType: 'email_template',
+          newName: 'Clone Name',
+        }),
+      );
+    });
+
+    it('throws for non-cloneable asset type', () => {
+      const service = new BloomreachAssetManagerService('test');
+      expect(() =>
+        service.prepareCloneTemplate({
+          project: 'test',
+          templateId: 'tmpl-1',
+          assetType: 'snippet',
+        }),
+      ).toThrow('cloneable types');
+    });
+  });
+
+  describe('prepareArchiveTemplate', () => {
+    it('returns prepared action for valid input', () => {
+      const service = new BloomreachAssetManagerService('test');
+      const result = service.prepareArchiveTemplate({
+        project: 'test',
+        templateId: 'tmpl-2',
+        assetType: 'custom_row',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'asset_manager.archive_template',
+          project: 'test',
+          templateId: 'tmpl-2',
+          assetType: 'custom_row',
+        }),
+      );
+    });
+
+    it('throws for non-cloneable asset type', () => {
+      const service = new BloomreachAssetManagerService('test');
+      expect(() =>
+        service.prepareArchiveTemplate({
+          project: 'test',
+          templateId: 'tmpl-2',
+          assetType: 'file',
+        }),
+      ).toThrow('cloneable types');
+    });
+  });
+
+  describe('prepare methods shared validation', () => {
+    it('throws on empty project for prepare methods', () => {
+      const service = new BloomreachAssetManagerService('test');
+
+      expect(() =>
+        service.prepareCreateEmailTemplate({
+          project: '',
+          name: 'Template',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareCreateWeblayerTemplate({
+          project: '',
+          name: 'Template',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareCreateBlock({
+          project: '',
+          name: 'Block',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareCreateCustomRow({
+          project: '',
+          name: 'Row',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareCreateSnippet({
+          project: '',
+          name: 'Snippet',
+          language: 'jinja',
+          content: 'x',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareEditSnippet({
+          project: '',
+          snippetId: 'snippet-1',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareUploadFile({
+          project: '',
+          name: 'file',
+          mimeType: 'image/png',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareDeleteFile({
+          project: '',
+          fileId: 'file-1',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareCloneTemplate({
+          project: '',
+          templateId: 'tmpl-1',
+          assetType: 'email_template',
+        }),
+      ).toThrow('must not be empty');
+
+      expect(() =>
+        service.prepareArchiveTemplate({
+          project: '',
+          templateId: 'tmpl-1',
+          assetType: 'email_template',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachAssetManager.ts
+++ b/packages/core/src/bloomreachAssetManager.ts
@@ -1,0 +1,843 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const CREATE_EMAIL_TEMPLATE_ACTION_TYPE =
+  'asset_manager.create_email_template';
+export const CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE =
+  'asset_manager.create_weblayer_template';
+export const CREATE_BLOCK_ACTION_TYPE = 'asset_manager.create_block';
+export const CREATE_CUSTOM_ROW_ACTION_TYPE = 'asset_manager.create_custom_row';
+export const CREATE_SNIPPET_ACTION_TYPE = 'asset_manager.create_snippet';
+export const EDIT_SNIPPET_ACTION_TYPE = 'asset_manager.edit_snippet';
+export const UPLOAD_FILE_ACTION_TYPE = 'asset_manager.upload_file';
+export const DELETE_FILE_ACTION_TYPE = 'asset_manager.delete_file';
+export const CLONE_TEMPLATE_ACTION_TYPE = 'asset_manager.clone_template';
+export const ARCHIVE_TEMPLATE_ACTION_TYPE = 'asset_manager.archive_template';
+
+/** Rate limit window for asset manager operations (1 hour in ms). */
+export const ASSET_MANAGER_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const ASSET_MANAGER_CREATE_RATE_LIMIT = 10;
+export const ASSET_MANAGER_MODIFY_RATE_LIMIT = 20;
+
+export const ASSET_TYPES = [
+  'email_template',
+  'weblayer_template',
+  'block',
+  'custom_row',
+  'snippet',
+  'file',
+] as const;
+export type AssetType = (typeof ASSET_TYPES)[number];
+
+export const TEMPLATE_STATUSES = ['active', 'archived', 'draft'] as const;
+export type TemplateStatus = (typeof TEMPLATE_STATUSES)[number];
+
+export const FILE_CATEGORIES = ['image', 'document', 'font', 'other'] as const;
+export type FileCategory = (typeof FILE_CATEGORIES)[number];
+
+export const SNIPPET_LANGUAGES = ['jinja', 'html'] as const;
+export type SnippetLanguage = (typeof SNIPPET_LANGUAGES)[number];
+
+export const TEMPLATE_BUILDER_TYPES = ['visual', 'html'] as const;
+export type TemplateBuilderType = (typeof TEMPLATE_BUILDER_TYPES)[number];
+
+export interface BloomreachEmailTemplate {
+  id: string;
+  name: string;
+  status: TemplateStatus;
+  builderType?: TemplateBuilderType;
+  thumbnailUrl?: string;
+  htmlContent?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface BloomreachWeblayerTemplate {
+  id: string;
+  name: string;
+  status: TemplateStatus;
+  thumbnailUrl?: string;
+  htmlContent?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface BloomreachContentBlock {
+  id: string;
+  name: string;
+  status: TemplateStatus;
+  htmlContent?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface BloomreachCustomRow {
+  id: string;
+  name: string;
+  status: TemplateStatus;
+  htmlContent?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface BloomreachSnippet {
+  id: string;
+  name: string;
+  language: SnippetLanguage;
+  content: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface BloomreachFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  fileSize?: number;
+  category: FileCategory;
+  fileUrl: string;
+  uploadedAt?: string;
+  url: string;
+}
+
+export interface ListEmailTemplatesInput {
+  project: string;
+}
+
+export interface ListWeblayerTemplatesInput {
+  project: string;
+}
+
+export interface ListBlocksInput {
+  project: string;
+}
+
+export interface ListCustomRowsInput {
+  project: string;
+}
+
+export interface ListSnippetsInput {
+  project: string;
+}
+
+export interface ListFilesInput {
+  project: string;
+  category?: string;
+}
+
+export interface CreateEmailTemplateInput {
+  project: string;
+  name: string;
+  builderType?: string;
+  htmlContent?: string;
+  operatorNote?: string;
+}
+
+export interface CreateWeblayerTemplateInput {
+  project: string;
+  name: string;
+  htmlContent?: string;
+  operatorNote?: string;
+}
+
+export interface CreateBlockInput {
+  project: string;
+  name: string;
+  htmlContent?: string;
+  operatorNote?: string;
+}
+
+export interface CreateCustomRowInput {
+  project: string;
+  name: string;
+  htmlContent?: string;
+  operatorNote?: string;
+}
+
+export interface CreateSnippetInput {
+  project: string;
+  name: string;
+  language: string;
+  content: string;
+  operatorNote?: string;
+}
+
+export interface EditSnippetInput {
+  project: string;
+  snippetId: string;
+  name?: string;
+  language?: string;
+  content?: string;
+  operatorNote?: string;
+}
+
+export interface UploadFileInput {
+  project: string;
+  name: string;
+  mimeType: string;
+  fileSize?: number;
+  category?: string;
+  operatorNote?: string;
+}
+
+export interface DeleteFileInput {
+  project: string;
+  fileId: string;
+  operatorNote?: string;
+}
+
+export interface CloneTemplateInput {
+  project: string;
+  templateId: string;
+  assetType: string;
+  newName?: string;
+  operatorNote?: string;
+}
+
+export interface ArchiveTemplateInput {
+  project: string;
+  templateId: string;
+  assetType: string;
+  operatorNote?: string;
+}
+
+/** Staged action awaiting confirmation via two-phase commit. */
+export interface PreparedAssetManagerAction {
+  preparedActionId: string;
+  /** Cryptographic token required to confirm the action. */
+  confirmToken: string;
+  /** Timestamp (ms since epoch) when the token expires. */
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MIN_ASSET_NAME_LENGTH = 1;
+const MAX_ASSET_NAME_LENGTH = 200;
+const MAX_SNIPPET_CONTENT_LENGTH = 100_000;
+const CLONEABLE_ASSET_TYPES = [
+  'email_template',
+  'weblayer_template',
+  'block',
+  'custom_row',
+] as const;
+type CloneableAssetType = (typeof CLONEABLE_ASSET_TYPES)[number];
+
+/** @throws {Error} If name is empty or exceeds 200 characters. */
+export function validateAssetName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_ASSET_NAME_LENGTH) {
+    throw new Error('Asset name must not be empty.');
+  }
+  if (trimmed.length > MAX_ASSET_NAME_LENGTH) {
+    throw new Error(
+      `Asset name must not exceed ${MAX_ASSET_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If `type` is not a recognised asset type. */
+export function validateAssetType(type: string): AssetType {
+  if (!ASSET_TYPES.includes(type as AssetType)) {
+    throw new Error(`assetType must be one of: ${ASSET_TYPES.join(', ')} (got "${type}").`);
+  }
+  return type as AssetType;
+}
+
+/** @throws {Error} If `status` is not a recognised template status. */
+export function validateTemplateStatus(status: string): TemplateStatus {
+  if (!TEMPLATE_STATUSES.includes(status as TemplateStatus)) {
+    throw new Error(
+      `status must be one of: ${TEMPLATE_STATUSES.join(', ')} (got "${status}").`,
+    );
+  }
+  return status as TemplateStatus;
+}
+
+/** @throws {Error} If `category` is not a recognised file category. */
+export function validateFileCategory(category: string): FileCategory {
+  if (!FILE_CATEGORIES.includes(category as FileCategory)) {
+    throw new Error(
+      `category must be one of: ${FILE_CATEGORIES.join(', ')} (got "${category}").`,
+    );
+  }
+  return category as FileCategory;
+}
+
+/** @throws {Error} If `language` is not a recognised snippet language. */
+export function validateSnippetLanguage(language: string): SnippetLanguage {
+  if (!SNIPPET_LANGUAGES.includes(language as SnippetLanguage)) {
+    throw new Error(
+      `language must be one of: ${SNIPPET_LANGUAGES.join(', ')} (got "${language}").`,
+    );
+  }
+  return language as SnippetLanguage;
+}
+
+/** @throws {Error} If `type` is not a recognised builder type. */
+export function validateBuilderType(type: string): TemplateBuilderType {
+  if (!TEMPLATE_BUILDER_TYPES.includes(type as TemplateBuilderType)) {
+    throw new Error(
+      `builderType must be one of: ${TEMPLATE_BUILDER_TYPES.join(', ')} (got "${type}").`,
+    );
+  }
+  return type as TemplateBuilderType;
+}
+
+/** @throws {Error} If snippet content is empty or exceeds 100000 characters. */
+export function validateSnippetContent(content: string): string {
+  if (content.trim().length === 0) {
+    throw new Error('Snippet content must not be empty.');
+  }
+  if (content.length > MAX_SNIPPET_CONTENT_LENGTH) {
+    throw new Error(
+      `Snippet content must not exceed ${MAX_SNIPPET_CONTENT_LENGTH} characters (got ${content.length}).`,
+    );
+  }
+  return content;
+}
+
+/** @throws {Error} If mime type is empty or malformed. */
+export function validateMimeType(mimeType: string): string {
+  const trimmed = mimeType.trim();
+  if (trimmed.length === 0) {
+    throw new Error('MIME type must not be empty.');
+  }
+  if (!trimmed.includes('/')) {
+    throw new Error('MIME type must include a "/" separator.');
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If asset ID is empty. */
+export function validateAssetId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Asset ID must not be empty.');
+  }
+  return trimmed;
+}
+
+function validateCloneableAssetType(type: string): CloneableAssetType {
+  const assetType = validateAssetType(type);
+  if (!CLONEABLE_ASSET_TYPES.includes(assetType as CloneableAssetType)) {
+    throw new Error(
+      `assetType must be one of cloneable types: ${CLONEABLE_ASSET_TYPES.join(', ')} (got "${type}").`,
+    );
+  }
+  return assetType as CloneableAssetType;
+}
+
+export function buildEmailTemplatesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/assets/email-templates`;
+}
+
+export function buildWeblayerTemplatesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/assets/weblayer-templates`;
+}
+
+export function buildBlocksUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/assets/blocks`;
+}
+
+export function buildCustomRowsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/assets/custom-rows`;
+}
+
+export function buildSnippetsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/assets/snippets`;
+}
+
+export function buildFilesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/assets/files`;
+}
+
+/**
+ * Executor for a confirmed asset manager mutation.
+ * Execute methods require browser automation infrastructure (not yet built).
+ */
+export interface AssetManagerActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateEmailTemplateExecutor implements AssetManagerActionExecutor {
+  readonly actionType = CREATE_EMAIL_TEMPLATE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateEmailTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateWeblayerTemplateExecutor implements AssetManagerActionExecutor {
+  readonly actionType = CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateWeblayerTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateBlockExecutor implements AssetManagerActionExecutor {
+  readonly actionType = CREATE_BLOCK_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateBlockExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateCustomRowExecutor implements AssetManagerActionExecutor {
+  readonly actionType = CREATE_CUSTOM_ROW_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateCustomRowExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateSnippetExecutor implements AssetManagerActionExecutor {
+  readonly actionType = CREATE_SNIPPET_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateSnippetExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class EditSnippetExecutor implements AssetManagerActionExecutor {
+  readonly actionType = EDIT_SNIPPET_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'EditSnippetExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UploadFileExecutor implements AssetManagerActionExecutor {
+  readonly actionType = UPLOAD_FILE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UploadFileExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteFileExecutor implements AssetManagerActionExecutor {
+  readonly actionType = DELETE_FILE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteFileExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CloneTemplateExecutor implements AssetManagerActionExecutor {
+  readonly actionType = CLONE_TEMPLATE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CloneTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ArchiveTemplateExecutor implements AssetManagerActionExecutor {
+  readonly actionType = ARCHIVE_TEMPLATE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ArchiveTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createAssetManagerActionExecutors(): Record<
+  string,
+  AssetManagerActionExecutor
+> {
+  return {
+    [CREATE_EMAIL_TEMPLATE_ACTION_TYPE]: new CreateEmailTemplateExecutor(),
+    [CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE]: new CreateWeblayerTemplateExecutor(),
+    [CREATE_BLOCK_ACTION_TYPE]: new CreateBlockExecutor(),
+    [CREATE_CUSTOM_ROW_ACTION_TYPE]: new CreateCustomRowExecutor(),
+    [CREATE_SNIPPET_ACTION_TYPE]: new CreateSnippetExecutor(),
+    [EDIT_SNIPPET_ACTION_TYPE]: new EditSnippetExecutor(),
+    [UPLOAD_FILE_ACTION_TYPE]: new UploadFileExecutor(),
+    [DELETE_FILE_ACTION_TYPE]: new DeleteFileExecutor(),
+    [CLONE_TEMPLATE_ACTION_TYPE]: new CloneTemplateExecutor(),
+    [ARCHIVE_TEMPLATE_ACTION_TYPE]: new ArchiveTemplateExecutor(),
+  };
+}
+
+/**
+ * Manages Bloomreach Engagement asset manager content. Read methods return data directly.
+ * Mutation methods follow the two-phase commit pattern (prepare + confirm).
+ * Browser-dependent methods throw until Playwright infrastructure is available.
+ */
+export class BloomreachAssetManagerService {
+  private readonly emailTemplatesBaseUrl: string;
+  private readonly weblayerTemplatesBaseUrl: string;
+  private readonly blocksBaseUrl: string;
+  private readonly customRowsBaseUrl: string;
+  private readonly snippetsBaseUrl: string;
+  private readonly filesBaseUrl: string;
+
+  constructor(project: string) {
+    const validatedProject = validateProject(project);
+    this.emailTemplatesBaseUrl = buildEmailTemplatesUrl(validatedProject);
+    this.weblayerTemplatesBaseUrl = buildWeblayerTemplatesUrl(validatedProject);
+    this.blocksBaseUrl = buildBlocksUrl(validatedProject);
+    this.customRowsBaseUrl = buildCustomRowsUrl(validatedProject);
+    this.snippetsBaseUrl = buildSnippetsUrl(validatedProject);
+    this.filesBaseUrl = buildFilesUrl(validatedProject);
+  }
+
+  get emailTemplatesUrl(): string {
+    return this.emailTemplatesBaseUrl;
+  }
+
+  get weblayerTemplatesUrl(): string {
+    return this.weblayerTemplatesBaseUrl;
+  }
+
+  get blocksUrl(): string {
+    return this.blocksBaseUrl;
+  }
+
+  get customRowsUrl(): string {
+    return this.customRowsBaseUrl;
+  }
+
+  get snippetsUrl(): string {
+    return this.snippetsBaseUrl;
+  }
+
+  get filesUrl(): string {
+    return this.filesBaseUrl;
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listEmailTemplates(
+    input?: ListEmailTemplatesInput,
+  ): Promise<BloomreachEmailTemplate[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listEmailTemplates: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listWeblayerTemplates(
+    input?: ListWeblayerTemplatesInput,
+  ): Promise<BloomreachWeblayerTemplate[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listWeblayerTemplates: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listBlocks(input?: ListBlocksInput): Promise<BloomreachContentBlock[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listBlocks: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listCustomRows(input?: ListCustomRowsInput): Promise<BloomreachCustomRow[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listCustomRows: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listSnippets(input?: ListSnippetsInput): Promise<BloomreachSnippet[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listSnippets: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listFiles(input?: ListFilesInput): Promise<BloomreachFile[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+      if (input.category !== undefined) {
+        validateFileCategory(input.category);
+      }
+    }
+
+    throw new Error(
+      'listFiles: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateEmailTemplate(
+    input: CreateEmailTemplateInput,
+  ): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const name = validateAssetName(input.name);
+    const builderType =
+      input.builderType !== undefined
+        ? validateBuilderType(input.builderType)
+        : undefined;
+
+    const preview = {
+      action: CREATE_EMAIL_TEMPLATE_ACTION_TYPE,
+      project,
+      name,
+      builderType,
+      htmlContent: input.htmlContent,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateWeblayerTemplate(
+    input: CreateWeblayerTemplateInput,
+  ): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const name = validateAssetName(input.name);
+
+    const preview = {
+      action: CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE,
+      project,
+      name,
+      htmlContent: input.htmlContent,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateBlock(input: CreateBlockInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const name = validateAssetName(input.name);
+
+    const preview = {
+      action: CREATE_BLOCK_ACTION_TYPE,
+      project,
+      name,
+      htmlContent: input.htmlContent,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateCustomRow(input: CreateCustomRowInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const name = validateAssetName(input.name);
+
+    const preview = {
+      action: CREATE_CUSTOM_ROW_ACTION_TYPE,
+      project,
+      name,
+      htmlContent: input.htmlContent,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateSnippet(input: CreateSnippetInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const name = validateAssetName(input.name);
+    const language = validateSnippetLanguage(input.language);
+    const content = validateSnippetContent(input.content);
+
+    const preview = {
+      action: CREATE_SNIPPET_ACTION_TYPE,
+      project,
+      name,
+      language,
+      content,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareEditSnippet(input: EditSnippetInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const snippetId = validateAssetId(input.snippetId);
+    const name = input.name !== undefined ? validateAssetName(input.name) : undefined;
+    const language =
+      input.language !== undefined ? validateSnippetLanguage(input.language) : undefined;
+    const content =
+      input.content !== undefined ? validateSnippetContent(input.content) : undefined;
+
+    const preview = {
+      action: EDIT_SNIPPET_ACTION_TYPE,
+      project,
+      snippetId,
+      name,
+      language,
+      content,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareUploadFile(input: UploadFileInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const name = validateAssetName(input.name);
+    const mimeType = validateMimeType(input.mimeType);
+    const category =
+      input.category !== undefined ? validateFileCategory(input.category) : undefined;
+
+    const preview = {
+      action: UPLOAD_FILE_ACTION_TYPE,
+      project,
+      name,
+      mimeType,
+      fileSize: input.fileSize,
+      category,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareDeleteFile(input: DeleteFileInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const fileId = validateAssetId(input.fileId);
+
+    const preview = {
+      action: DELETE_FILE_ACTION_TYPE,
+      project,
+      fileId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCloneTemplate(input: CloneTemplateInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const templateId = validateAssetId(input.templateId);
+    const assetType = validateCloneableAssetType(input.assetType);
+    const newName =
+      input.newName !== undefined ? validateAssetName(input.newName) : undefined;
+
+    const preview = {
+      action: CLONE_TEMPLATE_ACTION_TYPE,
+      project,
+      templateId,
+      assetType,
+      newName,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareArchiveTemplate(input: ArchiveTemplateInput): PreparedAssetManagerAction {
+    const project = validateProject(input.project);
+    const templateId = validateAssetId(input.templateId);
+    const assetType = validateCloneableAssetType(input.assetType);
+
+    const preview = {
+      action: ARCHIVE_TEMPLATE_ACTION_TYPE,
+      project,
+      templateId,
+      assetType,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './bloomreachTrends.js';
 export * from './bloomreachCustomers.js';
 export * from './bloomreachGeoAnalyses.js';
 export * from './bloomreachVouchers.js';
+export * from './bloomreachAssetManager.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Adds the Asset Manager feature module for managing email templates, weblayer templates, content blocks, custom rows, snippets, and files in Bloomreach Engagement.

## Changes

### Core Module (`packages/core/src/bloomreachAssetManager.ts`)
- **6 asset type interfaces**: `BloomreachEmailTemplate`, `BloomreachWeblayerTemplate`, `BloomreachContentBlock`, `BloomreachCustomRow`, `BloomreachSnippet`, `BloomreachFile`
- **10 two-phase commit action types** with executor stubs: create (email template, weblayer template, block, custom row, snippet), edit snippet, upload/delete file, clone/archive template
- **Rate limit constants**: 1-hour window, 10 creates, 20 modifications
- **Validation functions**: asset names, IDs, types, statuses, MIME types, snippet content, builder types, file categories
- **URL builders** for all 6 asset paths (`/p/{project}/data/assets/...`)
- **`BloomreachAssetManagerService`** with read methods (stub) and prepare methods for all mutations
- Clone/archive restricted to template types only (email_template, weblayer_template, block, custom_row)

### Unit Tests (`packages/core/src/__tests__/bloomreachAssetManager.test.ts`)
- Comprehensive coverage of all constants, validators, URL builders, executors, and service methods
- Follows existing test patterns exactly

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- `bloomreach assets email-templates list|create`
- `bloomreach assets weblayer-templates list|create`
- `bloomreach assets blocks list|create`
- `bloomreach assets custom-rows list|create`
- `bloomreach assets snippets list|create|edit`
- `bloomreach assets files list|upload|delete`
- `bloomreach assets clone` / `bloomreach assets archive`

### Export
- Added to `packages/core/src/index.ts`

## Quality Gates
- ✅ typecheck (`tsc --build`) — clean
- ✅ lint (`eslint .`) — clean
- ✅ test (`vitest run`) — 32 files, 2770 tests passed
- ✅ build (`tsup`) — core + CLI built successfully

Closes #46
