### PR TITLE
feat: add Tag Manager feature module (#47)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -15,6 +15,7 @@ import {
   BloomreachRetentionsService,
   BloomreachScenariosService,
   BloomreachSurveysService,
+  BloomreachTagManagerService,
   BloomreachTrendsService,
   BloomreachVouchersService,
 } from '@bloomreach-buddy/core';
@@ -29,6 +30,7 @@ import type {
   GeoFilter,
   SurveyQuestion,
   SurveyDisplayConditions,
+  TagTriggerConditions,
   RetentionFilter,
   TrendFilter,
   RedemptionRules,
@@ -3705,5 +3707,309 @@ assets
       }
     },
   );
+
+const tagManager = program
+  .command('tag-manager')
+  .description('Manage Bloomreach Tag Manager JavaScript tags');
+
+tagManager
+  .command('list')
+  .description('List all managed JavaScript tags')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--status <status>', 'Filter by status (enabled, disabled)')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; status?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachTagManagerService(options.project);
+      const result = await service.listTags({
+        project: options.project,
+        status: options.status,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No managed tags found.');
+          return;
+        }
+
+        for (const tag of result) {
+          console.log(`  ${tag.name}`);
+          console.log(`    Status:   ${tag.status}`);
+          if (tag.priority !== undefined) {
+            console.log(`    Priority: ${tag.priority}`);
+          }
+          console.log(`    ID:       ${tag.id}`);
+          console.log(`    URL:      ${tag.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+tagManager
+  .command('view')
+  .description('View details of a specific managed tag')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tag-id <id>', 'Tag ID')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; tagId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachTagManagerService(options.project);
+      const result = await service.viewTag({
+        project: options.project,
+        tagId: options.tagId,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Tag: ${result.name}`);
+        console.log(`  Status:   ${result.status}`);
+        if (result.priority !== undefined) {
+          console.log(`  Priority: ${result.priority}`);
+        }
+        console.log(`  JS code:  ${result.jsCode.slice(0, 200)}`);
+        console.log(`  Trigger:  ${JSON.stringify(result.triggerConditions)}`);
+        console.log(`  URL:      ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+tagManager
+  .command('create')
+  .description('Prepare creation of a new managed JavaScript tag (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Tag name')
+  .requiredOption('--js-code <code>', 'JavaScript code for the tag')
+  .option('--page-url <url>', 'Page URL pattern for trigger condition')
+  .option('--events <csv>', 'Trigger event names (comma-separated)')
+  .option('--customer-attributes <json>', 'Customer attribute conditions as JSON object')
+  .option('--priority <n>', 'Execution priority (positive integer, lower = higher)')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      jsCode: string;
+      pageUrl?: string;
+      events?: string;
+      customerAttributes?: string;
+      priority?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        let triggerConditions: TagTriggerConditions | undefined;
+        if (options.pageUrl || options.events || options.customerAttributes) {
+          triggerConditions = {
+            pageUrl: options.pageUrl,
+            events: options.events ? options.events.split(',').map((e) => e.trim()) : undefined,
+            customerAttributes: options.customerAttributes
+              ? (JSON.parse(options.customerAttributes) as Record<string, string>)
+              : undefined,
+          };
+        }
+
+        const service = new BloomreachTagManagerService(options.project);
+        const result = service.prepareCreateTag({
+          project: options.project,
+          name: options.name,
+          jsCode: options.jsCode,
+          triggerConditions,
+          priority: options.priority ? parseInt(options.priority, 10) : undefined,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Tag creation prepared.');
+          console.log(`  Tag:     ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+tagManager
+  .command('enable')
+  .description('Prepare enabling a managed tag (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tag-id <id>', 'Tag ID to enable')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; tagId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachTagManagerService(options.project);
+      const result = service.prepareEnableTag({
+        project: options.project,
+        tagId: options.tagId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Tag enable prepared.');
+        console.log(`  Tag:     ${options.tagId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+tagManager
+  .command('disable')
+  .description('Prepare disabling a managed tag (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tag-id <id>', 'Tag ID to disable')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; tagId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachTagManagerService(options.project);
+      const result = service.prepareDisableTag({
+        project: options.project,
+        tagId: options.tagId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Tag disable prepared.');
+        console.log(`  Tag:     ${options.tagId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+tagManager
+  .command('edit')
+  .description('Prepare editing a managed tag (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tag-id <id>', 'Tag ID to edit')
+  .option('--name <name>', 'New tag name')
+  .option('--js-code <code>', 'New JavaScript code')
+  .option('--page-url <url>', 'New page URL pattern for trigger condition')
+  .option('--events <csv>', 'New trigger event names (comma-separated)')
+  .option('--customer-attributes <json>', 'New customer attribute conditions as JSON object')
+  .option('--priority <n>', 'New execution priority')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      tagId: string;
+      name?: string;
+      jsCode?: string;
+      pageUrl?: string;
+      events?: string;
+      customerAttributes?: string;
+      priority?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        let triggerConditions: TagTriggerConditions | undefined;
+        if (options.pageUrl || options.events || options.customerAttributes) {
+          triggerConditions = {
+            pageUrl: options.pageUrl,
+            events: options.events ? options.events.split(',').map((e) => e.trim()) : undefined,
+            customerAttributes: options.customerAttributes
+              ? (JSON.parse(options.customerAttributes) as Record<string, string>)
+              : undefined,
+          };
+        }
+
+        const service = new BloomreachTagManagerService(options.project);
+        const result = service.prepareEditTag({
+          project: options.project,
+          tagId: options.tagId,
+          name: options.name,
+          jsCode: options.jsCode,
+          triggerConditions,
+          priority: options.priority ? parseInt(options.priority, 10) : undefined,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Tag edit prepared.');
+          console.log(`  Tag:     ${options.tagId}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+tagManager
+  .command('delete')
+  .description('Prepare deletion of a managed tag (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tag-id <id>', 'Tag ID to delete')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; tagId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachTagManagerService(options.project);
+      const result = service.prepareDeleteTag({
+        project: options.project,
+        tagId: options.tagId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Tag deletion prepared.');
+        console.log(`  Tag:     ${options.tagId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/packages/core/src/__tests__/bloomreachTagManager.test.ts
+++ b/packages/core/src/__tests__/bloomreachTagManager.test.ts
@@ -1,0 +1,735 @@
+import { describe, it, expect } from 'vitest';
+import * as core from '../index.js';
+
+interface ServiceTriggerConditions {
+  pageUrl?: string;
+  events?: string[];
+  customerAttributes?: Record<string, string>;
+}
+
+interface ServicePreparedAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: unknown;
+}
+
+interface TagManagerServiceInstance {
+  managedTagsUrl: string;
+  listTags(input?: { project?: string; status?: string }): Promise<unknown>;
+  viewTag(input: { project: string; tagId: string }): Promise<unknown>;
+  prepareCreateTag(input: {
+    project: string;
+    name: string;
+    jsCode: string;
+    status?: string;
+    triggerConditions?: ServiceTriggerConditions;
+    priority?: number;
+    operatorNote?: string;
+  }): ServicePreparedAction;
+  prepareEnableTag(input: { project: string; tagId: string; operatorNote?: string }): ServicePreparedAction;
+  prepareDisableTag(input: {
+    project: string;
+    tagId: string;
+    operatorNote?: string;
+  }): ServicePreparedAction;
+  prepareEditTag(input: {
+    project: string;
+    tagId: string;
+    name?: string;
+    jsCode?: string;
+    priority?: number;
+    operatorNote?: string;
+  }): ServicePreparedAction;
+  prepareDeleteTag(input: { project: string; tagId: string; operatorNote?: string }): ServicePreparedAction;
+}
+
+type TagManagerServiceConstructor = new (project: string) => TagManagerServiceInstance;
+type TagActionExecutor = { actionType: string; execute(input: Record<string, unknown>): Promise<unknown> };
+const exported = core as unknown as Record<string, unknown>;
+
+const CREATE_TAG_ACTION_TYPE = exported['CREATE_TAG_ACTION_TYPE'] as string;
+const ENABLE_TAG_ACTION_TYPE = exported['ENABLE_TAG_ACTION_TYPE'] as string;
+const DISABLE_TAG_ACTION_TYPE = exported['DISABLE_TAG_ACTION_TYPE'] as string;
+const EDIT_TAG_ACTION_TYPE = exported['EDIT_TAG_ACTION_TYPE'] as string;
+const DELETE_TAG_ACTION_TYPE = exported['DELETE_TAG_ACTION_TYPE'] as string;
+const TAG_MANAGER_RATE_LIMIT_WINDOW_MS = exported['TAG_MANAGER_RATE_LIMIT_WINDOW_MS'] as number;
+const TAG_CREATE_RATE_LIMIT = exported['TAG_CREATE_RATE_LIMIT'] as number;
+const TAG_MODIFY_RATE_LIMIT = exported['TAG_MODIFY_RATE_LIMIT'] as number;
+const TAG_DELETE_RATE_LIMIT = exported['TAG_DELETE_RATE_LIMIT'] as number;
+const validateTagName = exported['validateTagName'] as (name: string) => string;
+const validateTagId = exported['validateTagId'] as (tagId: string) => string;
+const validateJsCode = exported['validateJsCode'] as (code: string) => string;
+const validateTagStatus = exported['validateTagStatus'] as (status: string) => string;
+const validatePageUrl = exported['validatePageUrl'] as (url: string) => string;
+const validateEvents = exported['validateEvents'] as (events: string[]) => string[];
+const validateCustomerAttributes = exported['validateCustomerAttributes'] as (
+  attrs: Record<string, string>,
+) => Record<string, string>;
+const validateTriggerConditions = exported['validateTriggerConditions'] as (
+  conditions: ServiceTriggerConditions,
+) => ServiceTriggerConditions;
+const validatePriority = exported['validatePriority'] as (priority: number) => number;
+const buildManagedTagsUrl = exported['buildManagedTagsUrl'] as (project: string) => string;
+const createTagManagerActionExecutors = exported['createTagManagerActionExecutors'] as () => Record<
+  string,
+  TagActionExecutor
+>;
+const BloomreachTagManagerService = exported[
+  'BloomreachTagManagerService'
+] as TagManagerServiceConstructor;
+
+describe('action type constants', () => {
+  it('exports CREATE_TAG_ACTION_TYPE', () => {
+    expect(CREATE_TAG_ACTION_TYPE).toBe('tag_manager.create_tag');
+  });
+
+  it('exports ENABLE_TAG_ACTION_TYPE', () => {
+    expect(ENABLE_TAG_ACTION_TYPE).toBe('tag_manager.enable_tag');
+  });
+
+  it('exports DISABLE_TAG_ACTION_TYPE', () => {
+    expect(DISABLE_TAG_ACTION_TYPE).toBe('tag_manager.disable_tag');
+  });
+
+  it('exports EDIT_TAG_ACTION_TYPE', () => {
+    expect(EDIT_TAG_ACTION_TYPE).toBe('tag_manager.edit_tag');
+  });
+
+  it('exports DELETE_TAG_ACTION_TYPE', () => {
+    expect(DELETE_TAG_ACTION_TYPE).toBe('tag_manager.delete_tag');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports TAG_MANAGER_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(TAG_MANAGER_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports TAG_CREATE_RATE_LIMIT', () => {
+    expect(TAG_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports TAG_MODIFY_RATE_LIMIT', () => {
+    expect(TAG_MODIFY_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports TAG_DELETE_RATE_LIMIT', () => {
+    expect(TAG_DELETE_RATE_LIMIT).toBe(10);
+  });
+});
+
+describe('validateTagName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateTagName('  Product Viewed  ')).toBe('Product Viewed');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateTagName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateTagName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding 200 characters', () => {
+    expect(() => validateTagName('x'.repeat(201))).toThrow('must not exceed 200 characters');
+  });
+
+  it('accepts name at exactly 200 characters', () => {
+    expect(validateTagName('x'.repeat(200))).toBe('x'.repeat(200));
+  });
+});
+
+describe('validateTagId', () => {
+  it('returns trimmed ID for valid input', () => {
+    expect(validateTagId('  tag-123  ')).toBe('tag-123');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateTagId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateTagId('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for ID exceeding 500 characters', () => {
+    expect(() => validateTagId('x'.repeat(501))).toThrow('must not exceed 500 characters');
+  });
+});
+
+describe('validateJsCode', () => {
+  it('returns untrimmed code for valid input', () => {
+    const code = '  function run() { return true; }  ';
+    expect(validateJsCode(code)).toBe(code);
+  });
+
+  it('throws for empty code string', () => {
+    expect(() => validateJsCode('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only code string', () => {
+    expect(() => validateJsCode('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for code exceeding 100000 characters', () => {
+    expect(() => validateJsCode('x'.repeat(100_001))).toThrow('must not exceed 100000 characters');
+  });
+});
+
+describe('validateTagStatus', () => {
+  it('accepts enabled status', () => {
+    expect(validateTagStatus('enabled')).toBe('enabled');
+  });
+
+  it('accepts disabled status', () => {
+    expect(validateTagStatus('disabled')).toBe('disabled');
+  });
+
+  it('throws for invalid status', () => {
+    expect(() => validateTagStatus('paused')).toThrow('must be one of');
+  });
+});
+
+describe('validatePageUrl', () => {
+  it('returns trimmed URL for valid input', () => {
+    expect(validatePageUrl('  /checkout  ')).toBe('/checkout');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validatePageUrl('')).toThrow('must not be empty');
+  });
+
+  it('throws for URL exceeding 2000 characters', () => {
+    expect(() => validatePageUrl('x'.repeat(2001))).toThrow('must not exceed 2000 characters');
+  });
+});
+
+describe('validateEvents', () => {
+  it('returns trimmed events for valid input', () => {
+    expect(validateEvents(['  page_view  ', '  checkout_started  '])).toEqual([
+      'page_view',
+      'checkout_started',
+    ]);
+  });
+
+  it('throws for empty array', () => {
+    expect(() => validateEvents([])).toThrow('Events must not be empty');
+  });
+
+  it('throws for empty event string', () => {
+    expect(() => validateEvents(['viewed', ''])).toThrow('must not be empty');
+  });
+
+  it('throws for event list exceeding 50 entries', () => {
+    const events = Array.from({ length: 51 }, (_, i) => `event-${i}`);
+    expect(() => validateEvents(events)).toThrow('must not exceed 50');
+  });
+
+  it('throws for event exceeding 200 characters', () => {
+    expect(() => validateEvents(['x'.repeat(201)])).toThrow('must not exceed 200 characters');
+  });
+
+  it('throws for duplicate events', () => {
+    expect(() => validateEvents(['purchase', 'purchase'])).toThrow('must be unique');
+  });
+});
+
+describe('validateCustomerAttributes', () => {
+  it('returns trimmed customer attributes for valid input', () => {
+    expect(
+      validateCustomerAttributes({
+        '  tier  ': '  premium  ',
+        ' region ': ' eu ',
+      }),
+    ).toEqual({ tier: 'premium', region: 'eu' });
+  });
+
+  it('throws for empty object', () => {
+    expect(() => validateCustomerAttributes({})).toThrow('Customer attributes must not be empty');
+  });
+
+  it('throws for attributes exceeding 20 entries', () => {
+    const attrs = Object.fromEntries(Array.from({ length: 21 }, (_, i) => [`key-${i}`, `value-${i}`]));
+    expect(() => validateCustomerAttributes(attrs)).toThrow('must not exceed 20');
+  });
+
+  it('throws for empty key', () => {
+    expect(() => validateCustomerAttributes({ '   ': 'value' })).toThrow('must not be empty');
+  });
+
+  it('throws for empty value', () => {
+    expect(() => validateCustomerAttributes({ key: '   ' })).toThrow('must not be empty');
+  });
+
+  it('throws for key exceeding 200 characters', () => {
+    expect(() => validateCustomerAttributes({ ['x'.repeat(201)]: 'value' })).toThrow(
+      'must not exceed 200 characters',
+    );
+  });
+
+  it('throws for value exceeding 500 characters', () => {
+    expect(() => validateCustomerAttributes({ key: 'x'.repeat(501) })).toThrow(
+      'must not exceed 500 characters',
+    );
+  });
+});
+
+describe('validateTriggerConditions', () => {
+  it('returns empty object when provided', () => {
+    expect(validateTriggerConditions({})).toEqual({});
+  });
+
+  it('validates pageUrl when present', () => {
+    expect(() => validateTriggerConditions({ pageUrl: '' })).toThrow('must not be empty');
+  });
+
+  it('validates events when present', () => {
+    expect(() => validateTriggerConditions({ events: [] })).toThrow('Events must not be empty');
+  });
+
+  it('validates customerAttributes when present', () => {
+    expect(() => validateTriggerConditions({ customerAttributes: {} })).toThrow(
+      'Customer attributes must not be empty',
+    );
+  });
+});
+
+describe('validatePriority', () => {
+  it('returns priority for valid input', () => {
+    expect(validatePriority(100)).toBe(100);
+  });
+
+  it('throws for 0', () => {
+    expect(() => validatePriority(0)).toThrow('positive integer');
+  });
+
+  it('throws for negative number', () => {
+    expect(() => validatePriority(-1)).toThrow('positive integer');
+  });
+
+  it('throws for non-integer', () => {
+    expect(() => validatePriority(1.5)).toThrow('positive integer');
+  });
+
+  it('throws for value exceeding 1000', () => {
+    expect(() => validatePriority(1001)).toThrow('must not exceed 1000');
+  });
+
+  it('accepts value at exactly 1000', () => {
+    expect(validatePriority(1000)).toBe(1000);
+  });
+});
+
+describe('buildManagedTagsUrl', () => {
+  it('builds URL for simple project name', () => {
+    expect(buildManagedTagsUrl('my-project')).toBe('/p/my-project/data/managed-tags');
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildManagedTagsUrl('my project')).toBe('/p/my%20project/data/managed-tags');
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildManagedTagsUrl('org/project')).toBe('/p/org%2Fproject/data/managed-tags');
+  });
+});
+
+describe('createTagManagerActionExecutors', () => {
+  it('returns executors for all 5 action types', () => {
+    const executors = createTagManagerActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(5);
+    expect(executors[CREATE_TAG_ACTION_TYPE]).toBeDefined();
+    expect(executors[ENABLE_TAG_ACTION_TYPE]).toBeDefined();
+    expect(executors[DISABLE_TAG_ACTION_TYPE]).toBeDefined();
+    expect(executors[EDIT_TAG_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_TAG_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has actionType matching its key', () => {
+    const executors = createTagManagerActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw not yet implemented on execute', async () => {
+    const executors = createTagManagerActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachTagManagerService', () => {
+  describe('constructor', () => {
+    it('creates instance with valid project', () => {
+      const service = new BloomreachTagManagerService('my-project');
+      expect(service).toBeInstanceOf(BloomreachTagManagerService);
+    });
+
+    it('exposes managedTagsUrl', () => {
+      const service = new BloomreachTagManagerService('my-project');
+      expect(service.managedTagsUrl).toBe('/p/my-project/data/managed-tags');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachTagManagerService('  my-project  ');
+      expect(service.managedTagsUrl).toBe('/p/my-project/data/managed-tags');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachTagManagerService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listTags', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachTagManagerService('test');
+      await expect(service.listTags()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates status when input is provided', async () => {
+      const service = new BloomreachTagManagerService('test');
+      await expect(service.listTags({ project: 'test', status: 'paused' })).rejects.toThrow(
+        'must be one of',
+      );
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachTagManagerService('test');
+      await expect(service.listTags({ project: '', status: 'enabled' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('viewTag', () => {
+    it('throws not-yet-implemented error with valid input', async () => {
+      const service = new BloomreachTagManagerService('test');
+      await expect(service.viewTag({ project: 'test', tagId: 'tag-1' })).rejects.toThrow(
+        'not yet implemented',
+      );
+    });
+
+    it('validates tagId', async () => {
+      const service = new BloomreachTagManagerService('test');
+      await expect(service.viewTag({ project: 'test', tagId: '   ' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates project', async () => {
+      const service = new BloomreachTagManagerService('test');
+      await expect(service.viewTag({ project: '', tagId: 'tag-1' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateTag', () => {
+    it('returns prepared action with all fields', () => {
+      const service = new BloomreachTagManagerService('test');
+      const result = service.prepareCreateTag({
+        project: 'test',
+        name: '  Checkout Tag  ',
+        jsCode: '  window.__track = true;  ',
+        triggerConditions: {
+          pageUrl: '  /checkout  ',
+          events: ['  checkout_started  '],
+          customerAttributes: { '  tier  ': '  premium  ' },
+        },
+        priority: 10,
+        operatorNote: 'Create checkout tracking tag',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'tag_manager.create_tag',
+          project: 'test',
+          name: 'Checkout Tag',
+          jsCode: '  window.__track = true;  ',
+          triggerConditions: {
+            pageUrl: '/checkout',
+            events: ['checkout_started'],
+            customerAttributes: { tier: 'premium' },
+          },
+          priority: 10,
+          operatorNote: 'Create checkout tracking tag',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareCreateTag({
+          project: 'test',
+          name: '',
+          jsCode: 'window.__track = true;',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty jsCode', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareCreateTag({
+          project: 'test',
+          name: 'Checkout Tag',
+          jsCode: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid priority', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareCreateTag({
+          project: 'test',
+          name: 'Checkout Tag',
+          jsCode: 'window.__track = true;',
+          priority: 0,
+        }),
+      ).toThrow('positive integer');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareCreateTag({
+          project: '',
+          name: 'Checkout Tag',
+          jsCode: 'window.__track = true;',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('validates trigger conditions', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareCreateTag({
+          project: 'test',
+          name: 'Checkout Tag',
+          jsCode: 'window.__track = true;',
+          triggerConditions: { events: [] },
+        }),
+      ).toThrow('Events must not be empty');
+    });
+  });
+
+  describe('prepareEnableTag', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachTagManagerService('test');
+      const result = service.prepareEnableTag({
+        project: 'test',
+        tagId: '  tag-100  ',
+        operatorNote: 'Enable for rollout',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'tag_manager.enable_tag',
+          project: 'test',
+          tagId: 'tag-100',
+          operatorNote: 'Enable for rollout',
+        }),
+      );
+    });
+
+    it('throws for empty tagId', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEnableTag({
+          project: 'test',
+          tagId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEnableTag({
+          project: '',
+          tagId: 'tag-100',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareDisableTag', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachTagManagerService('test');
+      const result = service.prepareDisableTag({
+        project: 'test',
+        tagId: '  tag-200  ',
+        operatorNote: 'Disable for maintenance',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'tag_manager.disable_tag',
+          project: 'test',
+          tagId: 'tag-200',
+          operatorNote: 'Disable for maintenance',
+        }),
+      );
+    });
+
+    it('throws for empty tagId', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareDisableTag({
+          project: 'test',
+          tagId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareDisableTag({
+          project: '',
+          tagId: 'tag-200',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareEditTag', () => {
+    it('returns prepared action and validates optional fields', () => {
+      const service = new BloomreachTagManagerService('test');
+      const result = service.prepareEditTag({
+        project: 'test',
+        tagId: '  tag-300  ',
+        name: '  Updated Tag  ',
+        jsCode: '  console.log("updated");  ',
+        priority: 20,
+        operatorNote: 'Update tag details',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'tag_manager.edit_tag',
+          project: 'test',
+          tagId: 'tag-300',
+          name: 'Updated Tag',
+          jsCode: '  console.log("updated");  ',
+          priority: 20,
+          operatorNote: 'Update tag details',
+        }),
+      );
+    });
+
+    it('throws for empty tagId', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEditTag({
+          project: 'test',
+          tagId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEditTag({
+          project: '',
+          tagId: 'tag-300',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('validates optional name', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEditTag({
+          project: 'test',
+          tagId: 'tag-300',
+          name: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('validates optional jsCode', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEditTag({
+          project: 'test',
+          tagId: 'tag-300',
+          jsCode: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('validates optional priority', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareEditTag({
+          project: 'test',
+          tagId: 'tag-300',
+          priority: 1001,
+        }),
+      ).toThrow('must not exceed 1000');
+    });
+  });
+
+  describe('prepareDeleteTag', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachTagManagerService('test');
+      const result = service.prepareDeleteTag({
+        project: 'test',
+        tagId: '  tag-400  ',
+        operatorNote: 'Remove stale tag',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'tag_manager.delete_tag',
+          project: 'test',
+          tagId: 'tag-400',
+          operatorNote: 'Remove stale tag',
+        }),
+      );
+    });
+
+    it('throws for empty tagId', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareDeleteTag({
+          project: 'test',
+          tagId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachTagManagerService('test');
+      expect(() =>
+        service.prepareDeleteTag({
+          project: '',
+          tagId: 'tag-400',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachTagManager.ts
+++ b/packages/core/src/bloomreachTagManager.ts
@@ -1,0 +1,537 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+/** Action type for creating a managed tag. */
+export const CREATE_TAG_ACTION_TYPE = 'tag_manager.create_tag';
+/** Action type for enabling a managed tag. */
+export const ENABLE_TAG_ACTION_TYPE = 'tag_manager.enable_tag';
+/** Action type for disabling a managed tag. */
+export const DISABLE_TAG_ACTION_TYPE = 'tag_manager.disable_tag';
+/** Action type for editing a managed tag. */
+export const EDIT_TAG_ACTION_TYPE = 'tag_manager.edit_tag';
+/** Action type for deleting a managed tag. */
+export const DELETE_TAG_ACTION_TYPE = 'tag_manager.delete_tag';
+
+/** Rate limit window for tag manager operations (1 hour in ms). */
+export const TAG_MANAGER_RATE_LIMIT_WINDOW_MS = 3_600_000;
+/** Maximum tag creations per rate limit window. */
+export const TAG_CREATE_RATE_LIMIT = 10;
+/** Maximum tag modifications per rate limit window. */
+export const TAG_MODIFY_RATE_LIMIT = 20;
+/** Maximum tag deletions per rate limit window. */
+export const TAG_DELETE_RATE_LIMIT = 10;
+
+/** Allowed managed tag statuses. */
+export const TAG_STATUSES = ['enabled', 'disabled'] as const;
+/** Union type of allowed managed tag statuses. */
+export type TagStatus = (typeof TAG_STATUSES)[number];
+
+/** Trigger conditions used to determine when a managed tag should run. */
+export interface TagTriggerConditions {
+  /** URL pattern for page matching (glob or regex). */
+  pageUrl?: string;
+  /** Event names that trigger the tag. */
+  events?: string[];
+  /** Customer attribute conditions (key-value pairs). */
+  customerAttributes?: Record<string, string>;
+}
+
+/** Managed tag metadata as represented in Bloomreach. */
+export interface BloomreachManagedTag {
+  id: string;
+  name: string;
+  status: TagStatus;
+  jsCode: string;
+  triggerConditions?: TagTriggerConditions;
+  /** Priority/order for tag execution (lower = higher priority). */
+  priority?: number;
+  /** ISO-8601 creation timestamp (if available). */
+  createdAt?: string;
+  /** ISO-8601 last-modified timestamp (if available). */
+  updatedAt?: string;
+  /** Full URL path to the tag configuration. */
+  url: string;
+}
+
+/** Input for listing managed tags. */
+export interface ListTagsInput {
+  project: string;
+  status?: string;
+}
+
+/** Input for viewing a single managed tag. */
+export interface ViewTagInput {
+  project: string;
+  tagId: string;
+}
+
+/** Input for staging managed tag creation. */
+export interface CreateTagInput {
+  project: string;
+  name: string;
+  jsCode: string;
+  triggerConditions?: TagTriggerConditions;
+  priority?: number;
+  operatorNote?: string;
+}
+
+/** Input for staging managed tag enabling. */
+export interface EnableTagInput {
+  project: string;
+  tagId: string;
+  operatorNote?: string;
+}
+
+/** Input for staging managed tag disabling. */
+export interface DisableTagInput {
+  project: string;
+  tagId: string;
+  operatorNote?: string;
+}
+
+/** Input for staging managed tag edits. */
+export interface EditTagInput {
+  project: string;
+  tagId: string;
+  name?: string;
+  jsCode?: string;
+  triggerConditions?: TagTriggerConditions;
+  priority?: number;
+  operatorNote?: string;
+}
+
+/** Input for staging managed tag deletion. */
+export interface DeleteTagInput {
+  project: string;
+  tagId: string;
+  operatorNote?: string;
+}
+
+/** Staged action awaiting confirmation via two-phase commit. */
+export interface PreparedTagManagerAction {
+  preparedActionId: string;
+  /** Cryptographic token required to confirm the action. */
+  confirmToken: string;
+  /** Timestamp (ms since epoch) when the token expires. */
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MIN_TAG_NAME_LENGTH = 1;
+const MAX_TAG_NAME_LENGTH = 200;
+const MAX_TAG_ID_LENGTH = 500;
+const MAX_JS_CODE_LENGTH = 100_000;
+const MAX_PAGE_URL_LENGTH = 2000;
+const MAX_EVENTS_COUNT = 50;
+const MAX_EVENT_NAME_LENGTH = 200;
+const MAX_CUSTOMER_ATTRIBUTES_COUNT = 20;
+const MAX_ATTRIBUTE_KEY_LENGTH = 200;
+const MAX_ATTRIBUTE_VALUE_LENGTH = 500;
+const MAX_PRIORITY = 1000;
+
+/** @throws {Error} If tag name is empty or exceeds 200 characters. */
+export function validateTagName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_TAG_NAME_LENGTH) {
+    throw new Error('Tag name must not be empty.');
+  }
+  if (trimmed.length > MAX_TAG_NAME_LENGTH) {
+    throw new Error(
+      `Tag name must not exceed ${MAX_TAG_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If tag ID is empty or exceeds 500 characters. */
+export function validateTagId(tagId: string): string {
+  const trimmed = tagId.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Tag ID must not be empty.');
+  }
+  if (trimmed.length > MAX_TAG_ID_LENGTH) {
+    throw new Error(
+      `Tag ID must not exceed ${MAX_TAG_ID_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If JS code is empty or exceeds 100000 characters. */
+export function validateJsCode(code: string): string {
+  if (code.trim().length === 0) {
+    throw new Error('JS code must not be empty.');
+  }
+  if (code.length > MAX_JS_CODE_LENGTH) {
+    throw new Error(
+      `JS code must not exceed ${MAX_JS_CODE_LENGTH} characters (got ${code.length}).`,
+    );
+  }
+  return code;
+}
+
+/** @throws {Error} If status is not a recognised tag status. */
+export function validateTagStatus(status: string): TagStatus {
+  const trimmed = status.trim();
+  if (!TAG_STATUSES.includes(trimmed as TagStatus)) {
+    throw new Error(`status must be one of: ${TAG_STATUSES.join(', ')} (got "${status}").`);
+  }
+  return trimmed as TagStatus;
+}
+
+/** @throws {Error} If URL is empty or exceeds 2000 characters. */
+export function validatePageUrl(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Page URL must not be empty.');
+  }
+  if (trimmed.length > MAX_PAGE_URL_LENGTH) {
+    throw new Error(
+      `Page URL must not exceed ${MAX_PAGE_URL_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+/** @throws {Error} If events are empty, too many, invalid, or not unique. */
+export function validateEvents(events: string[]): string[] {
+  if (events.length === 0) {
+    throw new Error('Events must not be empty.');
+  }
+  if (events.length > MAX_EVENTS_COUNT) {
+    throw new Error(`Events must not exceed ${MAX_EVENTS_COUNT} items (got ${events.length}).`);
+  }
+
+  const validated: string[] = [];
+  for (const eventName of events) {
+    const trimmed = eventName.trim();
+    if (trimmed.length === 0) {
+      throw new Error('Event name must not be empty.');
+    }
+    if (trimmed.length > MAX_EVENT_NAME_LENGTH) {
+      throw new Error(
+        `Event name must not exceed ${MAX_EVENT_NAME_LENGTH} characters (got ${trimmed.length}).`,
+      );
+    }
+    validated.push(trimmed);
+  }
+
+  const unique = new Set(validated);
+  if (unique.size !== validated.length) {
+    throw new Error('Event names must be unique.');
+  }
+
+  return validated;
+}
+
+/** @throws {Error} If attributes are empty, too many, or contain invalid key/value pairs. */
+export function validateCustomerAttributes(
+  attrs: Record<string, string>,
+): Record<string, string> {
+  const entries = Object.entries(attrs);
+  if (entries.length === 0) {
+    throw new Error('Customer attributes must not be empty.');
+  }
+  if (entries.length > MAX_CUSTOMER_ATTRIBUTES_COUNT) {
+    throw new Error(
+      `Customer attributes must not exceed ${MAX_CUSTOMER_ATTRIBUTES_COUNT} entries (got ${entries.length}).`,
+    );
+  }
+
+  const validated: Record<string, string> = {};
+  for (const [key, value] of entries) {
+    const trimmedKey = key.trim();
+    if (trimmedKey.length === 0) {
+      throw new Error('Customer attribute key must not be empty.');
+    }
+    if (trimmedKey.length > MAX_ATTRIBUTE_KEY_LENGTH) {
+      throw new Error(
+        `Customer attribute key must not exceed ${MAX_ATTRIBUTE_KEY_LENGTH} characters (got ${trimmedKey.length}).`,
+      );
+    }
+
+    const trimmedValue = value.trim();
+    if (trimmedValue.length === 0) {
+      throw new Error('Customer attribute value must not be empty.');
+    }
+    if (trimmedValue.length > MAX_ATTRIBUTE_VALUE_LENGTH) {
+      throw new Error(
+        `Customer attribute value must not exceed ${MAX_ATTRIBUTE_VALUE_LENGTH} characters (got ${trimmedValue.length}).`,
+      );
+    }
+
+    validated[trimmedKey] = trimmedValue;
+  }
+
+  return validated;
+}
+
+/** @throws {Error} If trigger conditions contain invalid values. */
+export function validateTriggerConditions(
+  conditions: TagTriggerConditions,
+): TagTriggerConditions {
+  const validated: TagTriggerConditions = {};
+
+  if (conditions.pageUrl !== undefined) {
+    validated.pageUrl = validatePageUrl(conditions.pageUrl);
+  }
+
+  if (conditions.events !== undefined) {
+    validated.events = validateEvents(conditions.events);
+  }
+
+  if (conditions.customerAttributes !== undefined) {
+    validated.customerAttributes = validateCustomerAttributes(
+      conditions.customerAttributes,
+    );
+  }
+
+  return validated;
+}
+
+/** @throws {Error} If priority is not a positive integer or exceeds 1000. */
+export function validatePriority(priority: number): number {
+  if (!Number.isInteger(priority) || priority < 1) {
+    throw new Error('Priority must be a positive integer.');
+  }
+  if (priority > MAX_PRIORITY) {
+    throw new Error(`Priority must not exceed ${MAX_PRIORITY} (got ${priority}).`);
+  }
+  return priority;
+}
+
+/** Builds the managed tags page URL for a project. */
+export function buildManagedTagsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/managed-tags`;
+}
+
+/**
+ * Executor for a confirmed tag manager mutation.
+ * Execute methods require browser automation infrastructure (not yet built).
+ */
+export interface TagManagerActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateTagExecutor implements TagManagerActionExecutor {
+  readonly actionType = CREATE_TAG_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateTagExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class EnableTagExecutor implements TagManagerActionExecutor {
+  readonly actionType = ENABLE_TAG_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'EnableTagExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DisableTagExecutor implements TagManagerActionExecutor {
+  readonly actionType = DISABLE_TAG_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DisableTagExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class EditTagExecutor implements TagManagerActionExecutor {
+  readonly actionType = EDIT_TAG_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'EditTagExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteTagExecutor implements TagManagerActionExecutor {
+  readonly actionType = DELETE_TAG_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteTagExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+/** Creates all tag manager action executors keyed by action type. */
+export function createTagManagerActionExecutors(): Record<string, TagManagerActionExecutor> {
+  return {
+    [CREATE_TAG_ACTION_TYPE]: new CreateTagExecutor(),
+    [ENABLE_TAG_ACTION_TYPE]: new EnableTagExecutor(),
+    [DISABLE_TAG_ACTION_TYPE]: new DisableTagExecutor(),
+    [EDIT_TAG_ACTION_TYPE]: new EditTagExecutor(),
+    [DELETE_TAG_ACTION_TYPE]: new DeleteTagExecutor(),
+  };
+}
+
+/**
+ * Manages Bloomreach Engagement managed tags. Read methods return data directly.
+ * Mutation methods follow the two-phase commit pattern (prepare + confirm).
+ * Browser-dependent methods throw until Playwright infrastructure is available.
+ */
+export class BloomreachTagManagerService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildManagedTagsUrl(validateProject(project));
+  }
+
+  /** URL to the managed tags page for this service project. */
+  get managedTagsUrl(): string {
+    return this.baseUrl;
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async listTags(input?: ListTagsInput): Promise<BloomreachManagedTag[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+      if (input.status !== undefined) {
+        validateTagStatus(input.status);
+      }
+    }
+
+    throw new Error(
+      'listTags: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} Browser automation not yet available. */
+  async viewTag(input: ViewTagInput): Promise<BloomreachManagedTag> {
+    validateProject(input.project);
+    validateTagId(input.tagId);
+
+    throw new Error(
+      'viewTag: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareCreateTag(input: CreateTagInput): PreparedTagManagerAction {
+    const project = validateProject(input.project);
+    const name = validateTagName(input.name);
+    const jsCode = validateJsCode(input.jsCode);
+    const triggerConditions =
+      input.triggerConditions !== undefined
+        ? validateTriggerConditions(input.triggerConditions)
+        : undefined;
+    const priority = input.priority !== undefined ? validatePriority(input.priority) : undefined;
+
+    const preview = {
+      action: CREATE_TAG_ACTION_TYPE,
+      project,
+      name,
+      jsCode,
+      triggerConditions,
+      priority,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareEnableTag(input: EnableTagInput): PreparedTagManagerAction {
+    const project = validateProject(input.project);
+    const tagId = validateTagId(input.tagId);
+
+    const preview = {
+      action: ENABLE_TAG_ACTION_TYPE,
+      project,
+      tagId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareDisableTag(input: DisableTagInput): PreparedTagManagerAction {
+    const project = validateProject(input.project);
+    const tagId = validateTagId(input.tagId);
+
+    const preview = {
+      action: DISABLE_TAG_ACTION_TYPE,
+      project,
+      tagId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareEditTag(input: EditTagInput): PreparedTagManagerAction {
+    const project = validateProject(input.project);
+    const tagId = validateTagId(input.tagId);
+    const name = input.name !== undefined ? validateTagName(input.name) : undefined;
+    const jsCode = input.jsCode !== undefined ? validateJsCode(input.jsCode) : undefined;
+    const triggerConditions =
+      input.triggerConditions !== undefined
+        ? validateTriggerConditions(input.triggerConditions)
+        : undefined;
+    const priority = input.priority !== undefined ? validatePriority(input.priority) : undefined;
+
+    const preview = {
+      action: EDIT_TAG_ACTION_TYPE,
+      project,
+      tagId,
+      name,
+      jsCode,
+      triggerConditions,
+      priority,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  /** @throws {Error} If input validation fails. */
+  prepareDeleteTag(input: DeleteTagInput): PreparedTagManagerAction {
+    const project = validateProject(input.project);
+    const tagId = validateTagId(input.tagId);
+
+    const preview = {
+      action: DELETE_TAG_ACTION_TYPE,
+      project,
+      tagId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './bloomreachCustomers.js';
 export * from './bloomreachGeoAnalyses.js';
 export * from './bloomreachVouchers.js';
 export * from './bloomreachAssetManager.js';
+export * from './bloomreachTagManager.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Implements the Tag Manager feature module (issue #47) for managing JavaScript tags injected via the Bloomreach Tag Manager.

## Changes

### Core Module (`packages/core/src/bloomreachTagManager.ts`)
- **5 action types**: `create_tag`, `enable_tag`, `disable_tag`, `edit_tag`, `delete_tag`
- **Rate limits**: 10 creates/hr, 20 modifies/hr, 10 deletes/hr
- **Data model**: `BloomreachManagedTag` with JS code, trigger conditions (page URL, events, customer attributes), priority/order
- **10 validators**: tag name, tag ID, JS code, tag status, page URL, events, customer attributes, trigger conditions, priority
- **5 action executors** (stubs pending browser automation infrastructure)
- **`BloomreachTagManagerService`** with read methods (`listTags`, `viewTag`) and two-phase commit prepare methods for all mutations

### Unit Tests (`packages/core/src/__tests__/bloomreachTagManager.test.ts`)
- **88 tests** covering all constants, validators, URL builder, executor factory, and service methods
- Edge cases: empty/whitespace strings, boundary values, uniqueness constraints

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- **`tag-manager` command group** with 7 subcommands:
  - `list` — List all managed tags with optional status filter
  - `view` — View tag details
  - `create` — Prepare tag creation with JS code, trigger conditions, priority
  - `enable` / `disable` — Toggle tag activation
  - `edit` — Modify tag configuration
  - `delete` — Remove a tag
- All mutation commands follow two-phase commit (prepare → confirm)

### Core Export (`packages/core/src/index.ts`)
- Re-exports all Tag Manager types and service

## Quality Gates
- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 1473/1473 tests pass (88 new)
- ✅ `npm run build` — clean

Closes #47
