### PR TITLE
feat: manage metrics (#49)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -12,6 +12,7 @@ import {
   BloomreachFlowsService,
   BloomreachFunnelsService,
   BloomreachGeoAnalysesService,
+  BloomreachMetricsService,
   BloomreachPerformanceService,
   BloomreachRetentionsService,
   BloomreachScenariosService,
@@ -29,6 +30,8 @@ import type {
   FunnelStep,
   FunnelFilter,
   GeoFilter,
+  MetricAggregation,
+  MetricFilter,
   SurveyQuestion,
   SurveyDisplayConditions,
   TagTriggerConditions,
@@ -4002,6 +4005,199 @@ tagManager
       } else {
         console.log('Tag deletion prepared.');
         console.log(`  Tag:     ${options.tagId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const metrics = program
+  .command('metrics')
+  .description('Manage custom computed metrics (Data & Assets > Metrics)');
+
+metrics
+  .command('list')
+  .description('List all custom computed metrics in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachMetricsService(options.project);
+      const result = await service.listMetrics({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No metrics found.');
+          return;
+        }
+        for (const metric of result) {
+          console.log(`  ${metric.name}`);
+          console.log(`    ID:          ${metric.id}`);
+          console.log(`    Aggregation: ${metric.aggregation.aggregationType}`);
+          console.log(`    URL:         ${metric.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+metrics
+  .command('create')
+  .description('Prepare creation of a custom metric (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Metric name')
+  .requiredOption('--event-name <eventName>', 'Event name for aggregation')
+  .requiredOption('--aggregation-type <type>', 'Aggregation type (sum, count, average, min, max, unique)')
+  .option('--property-name <prop>', 'Event property name for property-based aggregations')
+  .option('--description <desc>', 'Metric description')
+  .option('--filters <json>', 'JSON object of metric filters')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      eventName: string;
+      aggregationType: string;
+      propertyName?: string;
+      description?: string;
+      filters?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const filters = options.filters ? (JSON.parse(options.filters) as MetricFilter) : undefined;
+        const aggregation: MetricAggregation = {
+          eventName: options.eventName,
+          aggregationType: options.aggregationType,
+          propertyName: options.propertyName,
+        };
+
+        const service = new BloomreachMetricsService(options.project);
+        const result = service.prepareCreateMetric({
+          project: options.project,
+          name: options.name,
+          description: options.description,
+          aggregation,
+          filters,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Metric creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+metrics
+  .command('edit')
+  .description('Prepare editing a custom metric (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--metric-id <id>', 'Metric ID')
+  .option('--name <name>', 'New metric name')
+  .option('--event-name <eventName>', 'New event name for aggregation')
+  .option('--aggregation-type <type>', 'New aggregation type (sum, count, average, min, max, unique)')
+  .option('--property-name <prop>', 'New event property name for property-based aggregations')
+  .option('--description <desc>', 'New metric description')
+  .option('--filters <json>', 'JSON object of metric filters')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      metricId: string;
+      name?: string;
+      eventName?: string;
+      aggregationType?: string;
+      propertyName?: string;
+      description?: string;
+      filters?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        let aggregation: MetricAggregation | undefined;
+        if (options.eventName || options.aggregationType || options.propertyName) {
+          aggregation = {
+            eventName: options.eventName ?? '',
+            aggregationType: options.aggregationType ?? '',
+            propertyName: options.propertyName,
+          };
+        }
+        const filters = options.filters ? (JSON.parse(options.filters) as MetricFilter) : undefined;
+
+        const service = new BloomreachMetricsService(options.project);
+        const result = service.prepareEditMetric({
+          project: options.project,
+          metricId: options.metricId,
+          name: options.name,
+          description: options.description,
+          aggregation,
+          filters,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Metric edit prepared.');
+          console.log(`  Metric:  ${options.metricId}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+metrics
+  .command('delete')
+  .description('Prepare deletion of a custom metric (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--metric-id <id>', 'Metric ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; metricId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachMetricsService(options.project);
+      const result = service.prepareDeleteMetric({
+        project: options.project,
+        metricId: options.metricId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Metric deletion prepared.');
+        console.log(`  Metric:  ${options.metricId}`);
         console.log(`  Token:   ${result.confirmToken}`);
         console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
         console.log('');

--- a/packages/core/src/__tests__/bloomreachMetrics.test.ts
+++ b/packages/core/src/__tests__/bloomreachMetrics.test.ts
@@ -1,0 +1,990 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_METRIC_ACTION_TYPE,
+  EDIT_METRIC_ACTION_TYPE,
+  DELETE_METRIC_ACTION_TYPE,
+  METRIC_RATE_LIMIT_WINDOW_MS,
+  METRIC_CREATE_RATE_LIMIT,
+  METRIC_MODIFY_RATE_LIMIT,
+  METRIC_DELETE_RATE_LIMIT,
+  validateMetricName,
+  validateMetricId,
+  validateDescription,
+  validateAggregationType,
+  validateAggregation,
+  buildMetricsUrl,
+  createMetricActionExecutors,
+  BloomreachMetricsService,
+} from '../index.js';
+
+const validateMetricDescription = validateDescription;
+
+describe('action type constants', () => {
+  it('exports CREATE_METRIC_ACTION_TYPE', () => {
+    expect(CREATE_METRIC_ACTION_TYPE).toBe('metrics.create_metric');
+  });
+
+  it('exports EDIT_METRIC_ACTION_TYPE', () => {
+    expect(EDIT_METRIC_ACTION_TYPE).toBe('metrics.edit_metric');
+  });
+
+  it('exports DELETE_METRIC_ACTION_TYPE', () => {
+    expect(DELETE_METRIC_ACTION_TYPE).toBe('metrics.delete_metric');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports METRIC_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(METRIC_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports METRIC_CREATE_RATE_LIMIT', () => {
+    expect(METRIC_CREATE_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports METRIC_MODIFY_RATE_LIMIT', () => {
+    expect(METRIC_MODIFY_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports METRIC_DELETE_RATE_LIMIT', () => {
+    expect(METRIC_DELETE_RATE_LIMIT).toBe(10);
+  });
+});
+
+describe('validateMetricName', () => {
+  it('returns trimmed name for valid input', () => {
+    expect(validateMetricName('  Revenue Metric  ')).toBe('Revenue Metric');
+  });
+
+  it('returns trimmed name with tabs and newlines', () => {
+    expect(validateMetricName('\n\tCheckout Value\t\n')).toBe('Checkout Value');
+  });
+
+  it('accepts single-character name', () => {
+    expect(validateMetricName('A')).toBe('A');
+  });
+
+  it('accepts numeric name', () => {
+    expect(validateMetricName('123')).toBe('123');
+  });
+
+  it('accepts name with punctuation', () => {
+    expect(validateMetricName('Metric: Revenue v2')).toBe('Metric: Revenue v2');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateMetricName(name)).toBe(name);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateMetricName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateMetricName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateMetricName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateMetricName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateMetricId', () => {
+  it('returns trimmed metric ID for valid input', () => {
+    expect(validateMetricId('  metric-123  ')).toBe('metric-123');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateMetricId('metric-456')).toBe('metric-456');
+  });
+
+  it('returns ID containing slashes', () => {
+    expect(validateMetricId('metric/group/a')).toBe('metric/group/a');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateMetricId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateMetricId('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateMetricId('\n')).toThrow('must not be empty');
+  });
+});
+
+describe('validateDescription', () => {
+  it('returns trimmed description for valid input', () => {
+    expect(validateMetricDescription('  Useful metric description  ')).toBe(
+      'Useful metric description',
+    );
+  });
+
+  it('accepts description at max length', () => {
+    const description = 'x'.repeat(1000);
+    expect(validateMetricDescription(description)).toBe(description);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateMetricDescription('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateMetricDescription('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for description exceeding max length', () => {
+    const description = 'x'.repeat(1001);
+    expect(() => validateMetricDescription(description)).toThrow(
+      'must not exceed 1000 characters',
+    );
+  });
+});
+
+describe('validateAggregationType', () => {
+  it('accepts sum and returns lowercase', () => {
+    expect(validateAggregationType('sum')).toBe('sum');
+  });
+
+  it('accepts count', () => {
+    expect(validateAggregationType('count')).toBe('count');
+  });
+
+  it('accepts average', () => {
+    expect(validateAggregationType('average')).toBe('average');
+  });
+
+  it('accepts min', () => {
+    expect(validateAggregationType('min')).toBe('min');
+  });
+
+  it('accepts max', () => {
+    expect(validateAggregationType('max')).toBe('max');
+  });
+
+  it('accepts unique', () => {
+    expect(validateAggregationType('unique')).toBe('unique');
+  });
+
+  it('accepts uppercase input and returns lowercase', () => {
+    expect(validateAggregationType('SUM')).toBe('sum');
+  });
+
+  it('accepts input with leading and trailing whitespace', () => {
+    expect(validateAggregationType('  count  ')).toBe('count');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateAggregationType('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateAggregationType('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for invalid type', () => {
+    expect(() => validateAggregationType('median')).toThrow('must be one of');
+  });
+});
+
+describe('validateAggregation', () => {
+  it('accepts valid aggregation with count (no propertyName required)', () => {
+    expect(
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'count',
+      }),
+    ).toEqual({
+      eventName: 'purchase',
+      aggregationType: 'count',
+      propertyName: undefined,
+    });
+  });
+
+  it('accepts valid aggregation with unique (no propertyName required)', () => {
+    expect(
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'unique',
+      }),
+    ).toEqual({
+      eventName: 'purchase',
+      aggregationType: 'unique',
+      propertyName: undefined,
+    });
+  });
+
+  it('accepts valid aggregation with sum and propertyName', () => {
+    expect(
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'sum',
+        propertyName: 'revenue',
+      }),
+    ).toEqual({
+      eventName: 'purchase',
+      aggregationType: 'sum',
+      propertyName: 'revenue',
+    });
+  });
+
+  it('accepts valid aggregation with average and propertyName', () => {
+    expect(
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'average',
+        propertyName: 'basket_size',
+      }),
+    ).toEqual({
+      eventName: 'purchase',
+      aggregationType: 'average',
+      propertyName: 'basket_size',
+    });
+  });
+
+  it('accepts valid aggregation with min and propertyName', () => {
+    expect(
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'min',
+        propertyName: 'price',
+      }),
+    ).toEqual({
+      eventName: 'purchase',
+      aggregationType: 'min',
+      propertyName: 'price',
+    });
+  });
+
+  it('accepts valid aggregation with max and propertyName', () => {
+    expect(
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'max',
+        propertyName: 'price',
+      }),
+    ).toEqual({
+      eventName: 'purchase',
+      aggregationType: 'max',
+      propertyName: 'price',
+    });
+  });
+
+  it('throws for empty eventName', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: '',
+        aggregationType: 'count',
+      }),
+    ).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only eventName', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: '   ',
+        aggregationType: 'count',
+      }),
+    ).toThrow('must not be empty');
+  });
+
+  it('throws for invalid aggregationType', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'median',
+      }),
+    ).toThrow('must be one of');
+  });
+
+  it('throws for sum without propertyName', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'sum',
+      }),
+    ).toThrow('propertyName is required');
+  });
+
+  it('throws for average without propertyName', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'average',
+      }),
+    ).toThrow('propertyName is required');
+  });
+
+  it('throws for min without propertyName', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'min',
+      }),
+    ).toThrow('propertyName is required');
+  });
+
+  it('throws for max without propertyName', () => {
+    expect(() =>
+      validateAggregation({
+        eventName: 'purchase',
+        aggregationType: 'max',
+      }),
+    ).toThrow('propertyName is required');
+  });
+});
+
+describe('buildMetricsUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildMetricsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/data/metrics');
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildMetricsUrl('my project')).toBe('/p/my%20project/data/metrics');
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildMetricsUrl('org/project')).toBe('/p/org%2Fproject/data/metrics');
+  });
+
+  it('encodes unicode characters in project name', () => {
+    expect(buildMetricsUrl('projekt åäö')).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/data/metrics');
+  });
+
+  it('encodes hash character in project name', () => {
+    expect(buildMetricsUrl('my#project')).toBe('/p/my%23project/data/metrics');
+  });
+
+  it('keeps dashes unencoded in project name', () => {
+    expect(buildMetricsUrl('team-alpha')).toBe('/p/team-alpha/data/metrics');
+  });
+});
+
+describe('createMetricActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createMetricActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[CREATE_METRIC_ACTION_TYPE]).toBeDefined();
+    expect(executors[EDIT_METRIC_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_METRIC_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createMetricActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('create executor throws "not yet implemented" on execute', async () => {
+    const executors = createMetricActionExecutors();
+    await expect(executors[CREATE_METRIC_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('edit executor throws "not yet implemented" on execute', async () => {
+    const executors = createMetricActionExecutors();
+    await expect(executors[EDIT_METRIC_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('delete executor throws "not yet implemented" on execute', async () => {
+    const executors = createMetricActionExecutors();
+    await expect(executors[DELETE_METRIC_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+});
+
+describe('BloomreachMetricsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachMetricsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachMetricsService);
+    });
+
+    it('exposes the metrics URL', () => {
+      const service = new BloomreachMetricsService('kingdom-of-joakim');
+      expect(service.metricsUrl).toBe('/p/kingdom-of-joakim/data/metrics');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachMetricsService('  my-project  ');
+      expect(service.metricsUrl).toBe('/p/my-project/data/metrics');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachMetricsService('')).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      expect(() => new BloomreachMetricsService('   ')).toThrow('must not be empty');
+    });
+
+    it('encodes slashes in constructor project URL', () => {
+      const service = new BloomreachMetricsService('org/project');
+      expect(service.metricsUrl).toBe('/p/org%2Fproject/data/metrics');
+    });
+  });
+
+  describe('listMetrics', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(service.listMetrics()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(service.listMetrics({ project: '' })).rejects.toThrow('must not be empty');
+    });
+
+    it('validates whitespace-only project when input is provided', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(service.listMetrics({ project: '   ' })).rejects.toThrow('must not be empty');
+    });
+
+    it('throws not-yet-implemented error for valid project override', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(service.listMetrics({ project: 'kingdom-of-joakim' })).rejects.toThrow(
+        'not yet implemented',
+      );
+    });
+  });
+
+  describe('viewMetricResults', () => {
+    it('throws not-yet-implemented error with valid minimal input', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: '',
+          metricId: 'metric-1',
+        }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates metricId input when empty', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: '',
+        }),
+      ).rejects.toThrow('Metric ID must not be empty');
+    });
+
+    it('validates metricId input when whitespace-only', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: '   ',
+        }),
+      ).rejects.toThrow('Metric ID must not be empty');
+    });
+
+    it('accepts trimmed metricId and reaches not-yet-implemented', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: '  metric-99  ',
+        }),
+      ).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareCreateMetric', () => {
+    it('returns a prepared action with valid minimal input (count aggregation, no propertyName)', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: 'Orders Count',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'count',
+        },
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'metrics.create_metric',
+          project: 'test',
+          name: 'Orders Count',
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'count',
+            propertyName: undefined,
+          },
+        }),
+      );
+    });
+
+    it('returns a prepared action with valid input including propertyName (sum aggregation)', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: 'Revenue Sum',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'sum',
+          propertyName: 'order_value',
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'sum',
+            propertyName: 'order_value',
+          },
+        }),
+      );
+    });
+
+    it('includes description in preview when provided', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: 'Revenue Sum',
+        description: '  Total revenue per period  ',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'sum',
+          propertyName: 'order_value',
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          description: 'Total revenue per period',
+        }),
+      );
+    });
+
+    it('includes filters in preview when provided', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: 'US Revenue',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'sum',
+          propertyName: 'order_value',
+        },
+        filters: {
+          customerAttributes: { segment: 'vip' },
+          eventProperties: { currency: 'USD' },
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          filters: {
+            customerAttributes: { segment: 'vip' },
+            eventProperties: { currency: 'USD' },
+          },
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: 'Revenue Sum',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'sum',
+          propertyName: 'order_value',
+        },
+        operatorNote: 'Create metric for weekly review',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Create metric for weekly review',
+        }),
+      );
+    });
+
+    it('trims project and name in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: '  my-project  ',
+        name: '  Revenue Sum  ',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'sum',
+          propertyName: 'order_value',
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+          name: 'Revenue Sum',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: 'test',
+          name: '',
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'count',
+          },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only name', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: 'test',
+          name: '   ',
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'count',
+          },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: '',
+          name: 'Revenue Sum',
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'count',
+          },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for too-long name', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: 'test',
+          name: 'x'.repeat(201),
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'count',
+          },
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws for empty eventName in aggregation', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: 'test',
+          name: 'Revenue Sum',
+          aggregation: {
+            eventName: '',
+            aggregationType: 'count',
+          },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid aggregationType', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: 'test',
+          name: 'Revenue Sum',
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'median',
+          },
+        }),
+      ).toThrow('must be one of');
+    });
+
+    it('throws for sum aggregation without propertyName', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareCreateMetric({
+          project: 'test',
+          name: 'Revenue Sum',
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'sum',
+          },
+        }),
+      ).toThrow('propertyName is required');
+    });
+
+    it('accepts max-length name and still prepares action', () => {
+      const service = new BloomreachMetricsService('test');
+      const maxName = 'x'.repeat(200);
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: maxName,
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'count',
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: maxName,
+        }),
+      );
+    });
+  });
+
+  describe('prepareEditMetric', () => {
+    it('returns a prepared action with valid input (metricId only)', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: 'metric-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'metrics.edit_metric',
+          project: 'test',
+          metricId: 'metric-123',
+        }),
+      );
+    });
+
+    it('includes name in preview when provided', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: 'metric-123',
+        name: '  Revenue Total  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: 'Revenue Total',
+        }),
+      );
+    });
+
+    it('includes aggregation in preview when provided', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: 'metric-123',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'average',
+          propertyName: 'order_value',
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          aggregation: {
+            eventName: 'purchase',
+            aggregationType: 'average',
+            propertyName: 'order_value',
+          },
+        }),
+      );
+    });
+
+    it('includes description in preview when provided', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: 'metric-123',
+        description: '  Updated description  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          description: 'Updated description',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: 'metric-123',
+        operatorNote: 'Align metric naming',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Align metric naming',
+        }),
+      );
+    });
+
+    it('throws for empty metricId', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareEditMetric({
+          project: 'test',
+          metricId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only metricId', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareEditMetric({
+          project: 'test',
+          metricId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareEditMetric({
+          project: '',
+          metricId: 'metric-123',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareEditMetric({
+          project: '   ',
+          metricId: 'metric-123',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareDeleteMetric', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: 'metric-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'metrics.delete_metric',
+          project: 'test',
+          metricId: 'metric-900',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: 'metric-900',
+        operatorNote: 'Remove obsolete metric',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'Remove obsolete metric',
+        }),
+      );
+    });
+
+    it('throws for empty metricId', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareDeleteMetric({
+          project: 'test',
+          metricId: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only metricId', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareDeleteMetric({
+          project: 'test',
+          metricId: '   ',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareDeleteMetric({
+          project: '',
+          metricId: 'metric-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachMetricsService('test');
+      expect(() =>
+        service.prepareDeleteMetric({
+          project: '   ',
+          metricId: 'metric-900',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('accepts trimmed metricId and reaches prepared state', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: '  metric-900  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          metricId: 'metric-900',
+        }),
+      );
+    });
+  });
+});

--- a/packages/core/src/bloomreachMetrics.ts
+++ b/packages/core/src/bloomreachMetrics.ts
@@ -1,0 +1,354 @@
+import { validateProject } from './bloomreachDashboards.js';
+import { validateDateRange } from './bloomreachPerformance.js';
+import type { DateRangeFilter } from './bloomreachPerformance.js';
+
+export const CREATE_METRIC_ACTION_TYPE = 'metrics.create_metric';
+export const EDIT_METRIC_ACTION_TYPE = 'metrics.edit_metric';
+export const DELETE_METRIC_ACTION_TYPE = 'metrics.delete_metric';
+
+export const METRIC_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const METRIC_CREATE_RATE_LIMIT = 10;
+export const METRIC_MODIFY_RATE_LIMIT = 20;
+export const METRIC_DELETE_RATE_LIMIT = 10;
+
+export interface MetricAggregation {
+  eventName: string;
+  aggregationType: string;
+  propertyName?: string;
+}
+
+export interface MetricFilter {
+  customerAttributes?: Record<string, string>;
+  eventProperties?: Record<string, string>;
+}
+
+export interface BloomreachMetric {
+  id: string;
+  name: string;
+  description?: string;
+  aggregation: MetricAggregation;
+  filters?: MetricFilter;
+  createdAt?: string;
+  updatedAt?: string;
+  url: string;
+}
+
+export interface MetricResults {
+  metricId: string;
+  metricName: string;
+  startDate: string;
+  endDate: string;
+  value: number;
+  aggregationType: string;
+  filters?: MetricFilter;
+}
+
+export interface ListMetricsInput {
+  project: string;
+}
+
+export interface CreateMetricInput {
+  project: string;
+  name: string;
+  description?: string;
+  aggregation: MetricAggregation;
+  filters?: MetricFilter;
+  operatorNote?: string;
+}
+
+export interface EditMetricInput {
+  project: string;
+  metricId: string;
+  name?: string;
+  description?: string;
+  aggregation?: MetricAggregation;
+  filters?: MetricFilter;
+  operatorNote?: string;
+}
+
+export interface DeleteMetricInput {
+  project: string;
+  metricId: string;
+  operatorNote?: string;
+}
+
+export interface ViewMetricResultsInput {
+  project: string;
+  metricId: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface PreparedMetricAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_METRIC_NAME_LENGTH = 200;
+const MIN_METRIC_NAME_LENGTH = 1;
+const MAX_DESCRIPTION_LENGTH = 1000;
+const AGGREGATION_TYPES = new Set([
+  'sum',
+  'count',
+  'average',
+  'min',
+  'max',
+  'unique',
+]);
+const PROPERTY_REQUIRED_AGGREGATION_TYPES = new Set([
+  'sum',
+  'average',
+  'min',
+  'max',
+]);
+
+export function validateMetricName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_METRIC_NAME_LENGTH) {
+    throw new Error('Metric name must not be empty.');
+  }
+  if (trimmed.length > MAX_METRIC_NAME_LENGTH) {
+    throw new Error(
+      `Metric name must not exceed ${MAX_METRIC_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateMetricId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Metric ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateDescription(description: string): string {
+  const trimmed = description.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Description must not be empty.');
+  }
+  if (trimmed.length > MAX_DESCRIPTION_LENGTH) {
+    throw new Error(
+      `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateAggregationType(type: string): string {
+  const normalized = type.trim().toLowerCase();
+  if (normalized.length === 0) {
+    throw new Error('Aggregation type must not be empty.');
+  }
+  if (!AGGREGATION_TYPES.has(normalized)) {
+    throw new Error(
+      `Aggregation type must be one of: ${Array.from(AGGREGATION_TYPES).join(', ')} (got ${normalized}).`,
+    );
+  }
+  return normalized;
+}
+
+export function validateAggregation(
+  aggregation: MetricAggregation,
+): MetricAggregation {
+  const eventName = aggregation.eventName.trim();
+  if (eventName.length === 0) {
+    throw new Error('Aggregation eventName must not be empty.');
+  }
+
+  const aggregationType = validateAggregationType(aggregation.aggregationType);
+  const propertyName = aggregation.propertyName?.trim();
+
+  if (
+    PROPERTY_REQUIRED_AGGREGATION_TYPES.has(aggregationType) &&
+    (propertyName === undefined || propertyName.length === 0)
+  ) {
+    throw new Error(
+      `aggregation.propertyName is required for aggregationType ${aggregationType}.`,
+    );
+  }
+
+  if (propertyName !== undefined && propertyName.length === 0) {
+    throw new Error('Aggregation propertyName must not be empty when provided.');
+  }
+
+  return {
+    eventName,
+    aggregationType,
+    propertyName,
+  };
+}
+
+export function buildMetricsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/metrics`;
+}
+
+export interface MetricActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateMetricExecutor implements MetricActionExecutor {
+  readonly actionType = CREATE_METRIC_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateMetricExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class EditMetricExecutor implements MetricActionExecutor {
+  readonly actionType = EDIT_METRIC_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'EditMetricExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteMetricExecutor implements MetricActionExecutor {
+  readonly actionType = DELETE_METRIC_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteMetricExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createMetricActionExecutors(): Record<string, MetricActionExecutor> {
+  return {
+    [CREATE_METRIC_ACTION_TYPE]: new CreateMetricExecutor(),
+    [EDIT_METRIC_ACTION_TYPE]: new EditMetricExecutor(),
+    [DELETE_METRIC_ACTION_TYPE]: new DeleteMetricExecutor(),
+  };
+}
+
+export class BloomreachMetricsService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildMetricsUrl(validateProject(project));
+  }
+
+  get metricsUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listMetrics(input?: ListMetricsInput): Promise<BloomreachMetric[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listMetrics: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewMetricResults(input: ViewMetricResultsInput): Promise<MetricResults> {
+    validateProject(input.project);
+    validateMetricId(input.metricId);
+
+    if (input.startDate !== undefined || input.endDate !== undefined) {
+      const dateRange: DateRangeFilter = {
+        startDate: input.startDate,
+        endDate: input.endDate,
+      };
+      validateDateRange(dateRange);
+    }
+
+    throw new Error(
+      'viewMetricResults: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateMetric(input: CreateMetricInput): PreparedMetricAction {
+    const project = validateProject(input.project);
+    const name = validateMetricName(input.name);
+    const description =
+      input.description === undefined
+        ? undefined
+        : validateDescription(input.description);
+    const aggregation = validateAggregation(input.aggregation);
+
+    const preview = {
+      action: CREATE_METRIC_ACTION_TYPE,
+      project,
+      name,
+      description,
+      aggregation,
+      filters: input.filters,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareEditMetric(input: EditMetricInput): PreparedMetricAction {
+    const project = validateProject(input.project);
+    const metricId = validateMetricId(input.metricId);
+    const name =
+      input.name === undefined ? undefined : validateMetricName(input.name);
+    const description =
+      input.description === undefined
+        ? undefined
+        : validateDescription(input.description);
+    const aggregation =
+      input.aggregation === undefined
+        ? undefined
+        : validateAggregation(input.aggregation);
+
+    const preview = {
+      action: EDIT_METRIC_ACTION_TYPE,
+      project,
+      metricId,
+      name,
+      description,
+      aggregation,
+      filters: input.filters,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteMetric(input: DeleteMetricInput): PreparedMetricAction {
+    const project = validateProject(input.project);
+    const metricId = validateMetricId(input.metricId);
+
+    const preview = {
+      action: DELETE_METRIC_ACTION_TYPE,
+      project,
+      metricId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './bloomreachVouchers.js';
 export * from './bloomreachAssetManager.js';
 export * from './bloomreachTagManager.js';
 export * from './bloomreachDataManager.js';
+export * from './bloomreachMetrics.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary
Add the Metrics feature module for managing custom computed metrics under **Data & Assets > Metrics** (`/p/{project}/data/metrics`).

## Changes

### Core Module (`packages/core/src/bloomreachMetrics.ts`)
- Action type constants: `metrics.create_metric`, `metrics.edit_metric`, `metrics.delete_metric`
- Rate limit constants (1hr window): create=10, modify=20, delete=10
- Data interfaces: `BloomreachMetric`, `MetricAggregation`, `MetricFilter`, `MetricResults`
- Input interfaces: `ListMetricsInput`, `CreateMetricInput`, `EditMetricInput`, `DeleteMetricInput`, `ViewMetricResultsInput`
- Validation functions: metric name, metric ID, description, aggregation type, aggregation (with propertyName requirement enforcement for sum/average/min/max)
- URL builder: `buildMetricsUrl(project)` → `/p/{project}/data/metrics`
- Action executor stubs (Create, Edit, Delete) with factory function
- `BloomreachMetricsService` class with list, view results, and two-phase commit prepare methods

### Tests (`packages/core/src/__tests__/bloomreachMetrics.test.ts`)
- Comprehensive unit tests covering all validators, URL builder, executor factory, and service class methods
- Follows established Vitest patterns from existing test files

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- `bloomreach metrics list` — List all metrics
- `bloomreach metrics create` — Prepare metric creation (two-phase commit)
- `bloomreach metrics edit` — Prepare metric edit (two-phase commit)
- `bloomreach metrics delete` — Prepare metric deletion (two-phase commit)

### Barrel Export (`packages/core/src/index.ts`)
- Added `export * from './bloomreachMetrics.js'`

## Quality Gates
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 3484 tests pass (38 test files)
- [x] `npm run build` — both core and CLI build successfully

Closes #49
