### PR TITLE
feat #51: add data exports feature module with CLI commands

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -3,12 +3,13 @@
 import { Command } from 'commander';
 import {
   BloomreachAssetManagerService,
-  BloomreachClient,
   BloomreachCampaignCalendarService,
+  BloomreachClient,
   BloomreachCustomersService,
   BloomreachDataManagerService,
   BloomreachDashboardsService,
   BloomreachEmailCampaignsService,
+  BloomreachExportsService,
   BloomreachFlowsService,
   BloomreachFunnelsService,
   BloomreachGeoAnalysesService,
@@ -23,22 +24,25 @@ import {
 } from '@bloomreach-buddy/core';
 import type {
   CustomerIds,
-  EmailCampaignSchedule,
+  DataSelection,
   EmailCampaignABTestConfig,
+  EmailCampaignSchedule,
+  EventPropertyDefinition,
+  ExportDestination,
+  ExportSchedule,
   FlowEvent,
   FlowFilter,
-  FunnelStep,
   FunnelFilter,
+  FunnelStep,
   GeoFilter,
   MetricAggregation,
   MetricFilter,
-  SurveyQuestion,
-  SurveyDisplayConditions,
-  TagTriggerConditions,
-  RetentionFilter,
-  TrendFilter,
   RedemptionRules,
-  EventPropertyDefinition,
+  RetentionFilter,
+  SurveyDisplayConditions,
+  SurveyQuestion,
+  TagTriggerConditions,
+  TrendFilter,
 } from '@bloomreach-buddy/core';
 
 function printJson(value: unknown): void {
@@ -4803,6 +4807,270 @@ dataManager
       } else {
         console.log('Data Manager save prepared.');
         console.log(`  Project: ${options.project}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const exportsCmd = program
+  .command('exports')
+  .description('Manage Bloomreach exports (list, status, history, create, run, schedule, delete)');
+
+exportsCmd
+  .command('list')
+  .description('List all configured exports')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachExportsService(options.project);
+      const result = await service.listExports({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No exports found.');
+          return;
+        }
+        for (const exportItem of result) {
+          console.log(`  ${exportItem.name}`);
+          console.log(`    Type:   ${exportItem.exportType}`);
+          console.log(`    Status: ${exportItem.status}`);
+          console.log(`    URL:    ${exportItem.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+exportsCmd
+  .command('status')
+  .description('View export status')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--export-id <id>', 'Export ID')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; exportId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachExportsService(options.project);
+      const result = await service.viewExportStatus({
+        project: options.project,
+        exportId: options.exportId,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Export status for ${options.exportId}`);
+        console.log(`  Status:      ${result.status}`);
+        console.log(`  Started:     ${result.startedAt ?? 'N/A'}`);
+        console.log(`  Completed:   ${result.completedAt ?? 'N/A'}`);
+        console.log(`  File:        ${result.fileLocation ?? 'N/A'}`);
+        console.log(`  RecordCount: ${result.recordCount ?? 'N/A'}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+exportsCmd
+  .command('history')
+  .description('View export history')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--export-id <id>', 'Export ID')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; exportId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachExportsService(options.project);
+      const result = await service.viewExportHistory({
+        project: options.project,
+        exportId: options.exportId,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No export history found.');
+          return;
+        }
+        console.log(`Export history for ${options.exportId}`);
+        for (const entry of result) {
+          console.log(`  ${entry.id}`);
+          console.log(`    Status:      ${entry.status}`);
+          console.log(`    Started:     ${entry.startedAt ?? 'N/A'}`);
+          console.log(`    Completed:   ${entry.completedAt ?? 'N/A'}`);
+          console.log(`    File:        ${entry.fileLocation ?? 'N/A'}`);
+          console.log(`    RecordCount: ${entry.recordCount ?? 'N/A'}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+exportsCmd
+  .command('create')
+  .description('Prepare creation of a new export (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Export name')
+  .requiredOption('--export-type <type>', 'Export type (customers, events)')
+  .requiredOption('--data-selection <json>', 'JSON object: {"attributes":["a"],"events":["b"],"segments":["c"]}')
+  .requiredOption('--destination <json>', 'JSON object: {"type":"sftp","host":"...","path":"..."}')
+  .option('--schedule <json>', 'JSON object: {"frequency":"daily","time":"09:00","timezone":"UTC"}')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      exportType: string;
+      dataSelection: string;
+      destination: string;
+      schedule?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const dataSelection = JSON.parse(options.dataSelection) as DataSelection;
+        const destination = JSON.parse(options.destination) as ExportDestination;
+        const schedule = options.schedule
+          ? (JSON.parse(options.schedule) as ExportSchedule)
+          : undefined;
+
+        const service = new BloomreachExportsService(options.project);
+        const result = service.prepareCreateExport({
+          project: options.project,
+          name: options.name,
+          exportType: options.exportType,
+          dataSelection,
+          destination,
+          schedule,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Export creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+exportsCmd
+  .command('run')
+  .description('Prepare triggering an immediate export (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--export-id <id>', 'Export ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; exportId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachExportsService(options.project);
+      const result = service.prepareRunExport({
+        project: options.project,
+        exportId: options.exportId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Export run prepared.');
+        console.log(`  Export:  ${options.exportId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+exportsCmd
+  .command('schedule')
+  .description('Prepare configuring a recurring schedule (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--export-id <id>', 'Export ID')
+  .requiredOption('--schedule <json>', 'JSON object: {"frequency":"weekly","daysOfWeek":[1,3,5],"time":"08:00","timezone":"UTC"}')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; exportId: string; schedule: string; note?: string; json?: boolean }) => {
+      try {
+        const schedule = JSON.parse(options.schedule) as ExportSchedule;
+
+        const service = new BloomreachExportsService(options.project);
+        const result = service.prepareScheduleExport({
+          project: options.project,
+          exportId: options.exportId,
+          schedule,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Export schedule prepared.');
+          console.log(`  Export:  ${options.exportId}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+exportsCmd
+  .command('delete')
+  .description('Prepare deletion of an export (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--export-id <id>', 'Export ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; exportId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachExportsService(options.project);
+      const result = service.prepareDeleteExport({
+        project: options.project,
+        exportId: options.exportId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Export deletion prepared.');
+        console.log(`  Export:  ${options.exportId}`);
         console.log(`  Token:   ${result.confirmToken}`);
         console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
         console.log('');

--- a/packages/core/src/__tests__/bloomreachExports.test.ts
+++ b/packages/core/src/__tests__/bloomreachExports.test.ts
@@ -1,0 +1,838 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_EXPORT_ACTION_TYPE,
+  RUN_EXPORT_ACTION_TYPE,
+  SCHEDULE_EXPORT_ACTION_TYPE,
+  DELETE_EXPORT_ACTION_TYPE,
+  EXPORT_RATE_LIMIT_WINDOW_MS,
+  EXPORT_CREATE_RATE_LIMIT,
+  EXPORT_RUN_RATE_LIMIT,
+  EXPORT_SCHEDULE_RATE_LIMIT,
+  EXPORT_DELETE_RATE_LIMIT,
+  buildExportsUrl,
+  buildExportDetailUrl,
+  createExportActionExecutors,
+  BloomreachExportsService,
+  type CreateExportInput,
+} from '../index.js';
+
+function createValidCreateExportInput(overrides: Partial<CreateExportInput> = {}): CreateExportInput {
+  return {
+    project: 'test-project',
+    name: 'Customer Export',
+    exportType: 'customers',
+    dataSelection: {
+      attributes: ['email'],
+    },
+    destination: {
+      type: 'sftp',
+      host: 'sftp.example.com',
+      path: '/exports/customers.csv',
+    },
+    ...overrides,
+  };
+}
+
+describe('action type constants', () => {
+  it('exports CREATE_EXPORT_ACTION_TYPE', () => {
+    expect(CREATE_EXPORT_ACTION_TYPE).toBe('exports.create_export');
+  });
+
+  it('exports RUN_EXPORT_ACTION_TYPE', () => {
+    expect(RUN_EXPORT_ACTION_TYPE).toBe('exports.run_export');
+  });
+
+  it('exports SCHEDULE_EXPORT_ACTION_TYPE', () => {
+    expect(SCHEDULE_EXPORT_ACTION_TYPE).toBe('exports.schedule_export');
+  });
+
+  it('exports DELETE_EXPORT_ACTION_TYPE', () => {
+    expect(DELETE_EXPORT_ACTION_TYPE).toBe('exports.delete_export');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports EXPORT_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(EXPORT_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports EXPORT_CREATE_RATE_LIMIT', () => {
+    expect(EXPORT_CREATE_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports EXPORT_RUN_RATE_LIMIT', () => {
+    expect(EXPORT_RUN_RATE_LIMIT).toBe(60);
+  });
+
+  it('exports EXPORT_SCHEDULE_RATE_LIMIT', () => {
+    expect(EXPORT_SCHEDULE_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports EXPORT_DELETE_RATE_LIMIT', () => {
+    expect(EXPORT_DELETE_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('validateExportName', () => {
+  it('valid input returns trimmed value', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput({ name: '  Customer Export  ' }));
+    expect(result.preview).toEqual(expect.objectContaining({ name: 'Customer Export' }));
+  });
+
+  it('throws for empty string', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareCreateExport(createValidCreateExportInput({ name: '' }))).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareCreateExport(createValidCreateExportInput({ name: '   ' }))).toThrow('must not be empty');
+  });
+
+  it('throws for too-long input', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareCreateExport(createValidCreateExportInput({ name: 'x'.repeat(201) }))).toThrow(
+      'must not exceed 200 characters',
+    );
+  });
+
+  it('accepts 200 characters', () => {
+    const service = new BloomreachExportsService('test');
+    const value = 'x'.repeat(200);
+    const result = service.prepareCreateExport(createValidCreateExportInput({ name: value }));
+    expect(result.preview).toEqual(expect.objectContaining({ name: value }));
+  });
+});
+
+describe('validateExportType', () => {
+  it('accepts customers', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput({ exportType: 'customers' }));
+    expect(result.preview).toEqual(expect.objectContaining({ exportType: 'customers' }));
+  });
+
+  it('accepts events', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput({ exportType: 'events' }));
+    expect(result.preview).toEqual(expect.objectContaining({ exportType: 'events' }));
+  });
+
+  it('normalizes value to lowercase', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput({ exportType: 'CUSTOMERS' }));
+    expect(result.preview).toEqual(expect.objectContaining({ exportType: 'customers' }));
+  });
+
+  it('throws for invalid enum value', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareCreateExport(createValidCreateExportInput({ exportType: 'profiles' }))).toThrow(
+      'must be one of',
+    );
+  });
+});
+
+describe('validateDestinationType', () => {
+  it('accepts sftp', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput());
+    expect(result.preview).toEqual(expect.objectContaining({ destination: expect.objectContaining({ type: 'sftp' }) }));
+  });
+
+  it('accepts s3', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(
+      createValidCreateExportInput({
+        destination: { type: 's3', bucket: 'my-bucket', path: '/exports/customers.csv' },
+      }),
+    );
+    expect(result.preview).toEqual(expect.objectContaining({ destination: expect.objectContaining({ type: 's3' }) }));
+  });
+
+  it('accepts email', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(
+      createValidCreateExportInput({ destination: { type: 'email', email: 'ops@example.com' } }),
+    );
+    expect(result.preview).toEqual(expect.objectContaining({ destination: expect.objectContaining({ type: 'email' }) }));
+  });
+
+  it('accepts webhook', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(
+      createValidCreateExportInput({ destination: { type: 'webhook', webhookUrl: 'https://api.example.com/export-hook' } }),
+    );
+    expect(result.preview).toEqual(
+      expect.objectContaining({ destination: expect.objectContaining({ type: 'webhook' }) }),
+    );
+  });
+
+  it('throws for invalid enum value', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareCreateExport(
+        createValidCreateExportInput({
+          destination: { type: 'ftp', host: 'ftp.example.com', path: '/exports/customers.csv' },
+        }),
+      ),
+    ).toThrow('must be one of');
+  });
+});
+
+describe('validateExportId', () => {
+  it('valid input returns trimmed value', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareRunExport({ project: 'test', exportId: '  exp-123  ' });
+    expect(result.preview).toEqual(expect.objectContaining({ exportId: 'exp-123' }));
+  });
+
+  it('throws for empty string', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareRunExport({ project: 'test', exportId: '' })).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareRunExport({ project: 'test', exportId: '   ' })).toThrow('must not be empty');
+  });
+
+  it('throws for too-long input', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareRunExport({ project: 'test', exportId: 'x'.repeat(201) })).toThrow(
+      'must not exceed 200 characters',
+    );
+  });
+
+  it('accepts 200 characters', () => {
+    const service = new BloomreachExportsService('test');
+    const value = 'x'.repeat(200);
+    const result = service.prepareRunExport({ project: 'test', exportId: value });
+    expect(result.preview).toEqual(expect.objectContaining({ exportId: value }));
+  });
+});
+
+describe('validateDataSelection', () => {
+  it('accepts attributes only', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(
+      createValidCreateExportInput({ dataSelection: { attributes: ['email', 'first_name'] } }),
+    );
+    expect(result.preview).toEqual(
+      expect.objectContaining({ dataSelection: expect.objectContaining({ attributes: ['email', 'first_name'] }) }),
+    );
+  });
+
+  it('accepts events only', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput({ dataSelection: { events: ['purchase'] } }));
+    expect(result.preview).toEqual(
+      expect.objectContaining({ dataSelection: expect.objectContaining({ events: ['purchase'] }) }),
+    );
+  });
+
+  it('accepts segments only', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(createValidCreateExportInput({ dataSelection: { segments: ['vip'] } }));
+    expect(result.preview).toEqual(
+      expect.objectContaining({ dataSelection: expect.objectContaining({ segments: ['vip'] }) }),
+    );
+  });
+
+  it('accepts all three lists', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(
+      createValidCreateExportInput({
+        dataSelection: {
+          attributes: ['email'],
+          events: ['purchase'],
+          segments: ['vip'],
+        },
+      }),
+    );
+    expect(result.preview).toEqual(
+      expect.objectContaining({
+        dataSelection: {
+          attributes: ['email'],
+          events: ['purchase'],
+          segments: ['vip'],
+        },
+      }),
+    );
+  });
+
+  it('throws when all arrays are empty', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareCreateExport(
+        createValidCreateExportInput({ dataSelection: { attributes: [], events: [], segments: [] } }),
+      ),
+    ).toThrow('must include at least one non-empty list');
+  });
+
+  it('throws when all lists are undefined', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareCreateExport(createValidCreateExportInput({ dataSelection: {} }))).toThrow(
+      'must include at least one non-empty list',
+    );
+  });
+});
+
+describe('validateDestination', () => {
+  it('validates sftp requires host and path', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareCreateExport(createValidCreateExportInput({ destination: { type: 'sftp', host: 'sftp.example.com' } })),
+    ).toThrow('requires host and path');
+  });
+
+  it('validates s3 requires bucket and path', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareCreateExport(createValidCreateExportInput({ destination: { type: 's3', bucket: 'my-bucket' } })),
+    ).toThrow('requires bucket and path');
+  });
+
+  it('validates email requires email', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() => service.prepareCreateExport(createValidCreateExportInput({ destination: { type: 'email' } }))).toThrow(
+      'requires email',
+    );
+  });
+
+  it('validates webhook requires webhookUrl', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareCreateExport(createValidCreateExportInput({ destination: { type: 'webhook' } })),
+    ).toThrow('requires webhookUrl');
+  });
+
+  it('validates port range 1-65535', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareCreateExport(
+      createValidCreateExportInput({
+        destination: {
+          type: 'sftp',
+          host: 'sftp.example.com',
+          port: 22,
+          path: '/exports/customers.csv',
+          username: 'integration-user',
+        },
+      }),
+    );
+    expect(result.preview).toEqual(
+      expect.objectContaining({ destination: expect.objectContaining({ type: 'sftp', port: 22 }) }),
+    );
+  });
+
+  it('throws for invalid port', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareCreateExport(
+        createValidCreateExportInput({
+          destination: {
+            type: 'sftp',
+            host: 'sftp.example.com',
+            port: 70000,
+            path: '/exports/customers.csv',
+          },
+        }),
+      ),
+    ).toThrow('must be an integer between 1 and 65535');
+  });
+});
+
+describe('validateSchedule', () => {
+  it('validates daily schedule', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareScheduleExport({
+      project: 'test',
+      exportId: 'exp-1',
+      schedule: { frequency: 'daily', time: '09:30', timezone: 'UTC' },
+    });
+    expect(result.preview).toEqual(
+      expect.objectContaining({ schedule: expect.objectContaining({ frequency: 'daily', time: '09:30', timezone: 'UTC' }) }),
+    );
+  });
+
+  it('validates weekly schedule requires daysOfWeek', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareScheduleExport({
+        project: 'test',
+        exportId: 'exp-1',
+        schedule: { frequency: 'weekly', time: '09:30', timezone: 'UTC' },
+      }),
+    ).toThrow('Weekly schedules require daysOfWeek');
+  });
+
+  it('validates monthly schedule requires dayOfMonth', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareScheduleExport({
+        project: 'test',
+        exportId: 'exp-1',
+        schedule: { frequency: 'monthly', time: '09:30', timezone: 'UTC' },
+      }),
+    ).toThrow('Monthly schedules require dayOfMonth');
+  });
+
+  it('validates time format HH:MM', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareScheduleExport({
+      project: 'test',
+      exportId: 'exp-1',
+      schedule: { frequency: 'weekly', daysOfWeek: [1, 3], time: '23:59', timezone: 'UTC' },
+    });
+    expect(result.preview).toEqual(
+      expect.objectContaining({ schedule: expect.objectContaining({ time: '23:59' }) }),
+    );
+  });
+
+  it('throws for invalid time format', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareScheduleExport({
+        project: 'test',
+        exportId: 'exp-1',
+        schedule: { frequency: 'daily', time: '9:30', timezone: 'UTC' },
+      }),
+    ).toThrow('must use HH:MM format');
+  });
+
+  it('validates daysOfWeek values from 0 to 6', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareScheduleExport({
+      project: 'test',
+      exportId: 'exp-1',
+      schedule: { frequency: 'weekly', daysOfWeek: [0, 6], time: '10:00', timezone: 'UTC' },
+    });
+    expect(result.preview).toEqual(
+      expect.objectContaining({ schedule: expect.objectContaining({ daysOfWeek: [0, 6] }) }),
+    );
+  });
+
+  it('throws for invalid day of week', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareScheduleExport({
+        project: 'test',
+        exportId: 'exp-1',
+        schedule: { frequency: 'weekly', daysOfWeek: [7], time: '10:00', timezone: 'UTC' },
+      }),
+    ).toThrow('must be an integer from 0 to 6');
+  });
+
+  it('validates dayOfMonth range 1 to 31', () => {
+    const service = new BloomreachExportsService('test');
+    const result = service.prepareScheduleExport({
+      project: 'test',
+      exportId: 'exp-1',
+      schedule: { frequency: 'monthly', dayOfMonth: 31, time: '10:00', timezone: 'UTC' },
+    });
+    expect(result.preview).toEqual(
+      expect.objectContaining({ schedule: expect.objectContaining({ dayOfMonth: 31 }) }),
+    );
+  });
+
+  it('throws for invalid day of month', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareScheduleExport({
+        project: 'test',
+        exportId: 'exp-1',
+        schedule: { frequency: 'monthly', dayOfMonth: 0, time: '10:00', timezone: 'UTC' },
+      }),
+    ).toThrow('must be an integer from 1 to 31');
+  });
+
+  it('validates timezone is required', () => {
+    const service = new BloomreachExportsService('test');
+    expect(() =>
+      service.prepareScheduleExport({
+        project: 'test',
+        exportId: 'exp-1',
+        schedule: { frequency: 'daily', time: '10:00', timezone: '   ' },
+      }),
+    ).toThrow('must not be empty');
+  });
+});
+
+describe('buildExportsUrl', () => {
+  it('builds URL for simple project', () => {
+    expect(buildExportsUrl('my-project')).toBe('/p/my-project/data/exports');
+  });
+
+  it('encodes spaces', () => {
+    expect(buildExportsUrl('my project')).toBe('/p/my%20project/data/exports');
+  });
+
+  it('encodes slashes', () => {
+    expect(buildExportsUrl('org/project')).toBe('/p/org%2Fproject/data/exports');
+  });
+});
+
+describe('buildExportDetailUrl', () => {
+  it('builds URL with project and export ID', () => {
+    expect(buildExportDetailUrl('my-project', 'exp-123')).toBe('/p/my-project/data/exports/exp-123');
+  });
+
+  it('encodes spaces in project and export ID', () => {
+    expect(buildExportDetailUrl('my project', 'exp 123')).toBe('/p/my%20project/data/exports/exp%20123');
+  });
+});
+
+describe('createExportActionExecutors', () => {
+  it('returns executors for all 4 action types', () => {
+    const executors = createExportActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(4);
+    expect(executors[CREATE_EXPORT_ACTION_TYPE]).toBeDefined();
+    expect(executors[RUN_EXPORT_ACTION_TYPE]).toBeDefined();
+    expect(executors[SCHEDULE_EXPORT_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_EXPORT_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has actionType matching its key', () => {
+    const executors = createExportActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('each executor throws not yet implemented on execute', async () => {
+    const executors = createExportActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachExportsService', () => {
+  describe('constructor', () => {
+    it('creates instance with valid project', () => {
+      const service = new BloomreachExportsService('my-project');
+      expect(service).toBeInstanceOf(BloomreachExportsService);
+    });
+
+    it('exposes exportsUrl getter with correct path', () => {
+      const service = new BloomreachExportsService('my-project');
+      expect(service.exportsUrl).toBe('/p/my-project/data/exports');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachExportsService('  my-project  ');
+      expect(service.exportsUrl).toBe('/p/my-project/data/exports');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachExportsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listExports', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.listExports()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input provided', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.listExports({ project: '' })).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('viewExportStatus', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.viewExportStatus({ project: 'test', exportId: 'exp-1' })).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.viewExportStatus({ project: '', exportId: 'exp-1' })).rejects.toThrow('must not be empty');
+    });
+
+    it('validates exportId', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.viewExportStatus({ project: 'test', exportId: '' })).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('viewExportHistory', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.viewExportHistory({ project: 'test', exportId: 'exp-1' })).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.viewExportHistory({ project: '', exportId: 'exp-1' })).rejects.toThrow('must not be empty');
+    });
+
+    it('validates exportId', async () => {
+      const service = new BloomreachExportsService('test');
+      await expect(service.viewExportHistory({ project: 'test', exportId: '' })).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareCreateExport', () => {
+    it('returns prepared action with valid input, preview includes all fields', () => {
+      const service = new BloomreachExportsService('test');
+      const result = service.prepareCreateExport({
+        project: 'test',
+        name: '  Customer Segment Export  ',
+        exportType: 'EVENTS',
+        dataSelection: {
+          attributes: [' email ', ' first_name '],
+          events: [' purchase '],
+          segments: [' vip '],
+        },
+        destination: {
+          type: 's3',
+          bucket: '  my-bucket  ',
+          path: '  /exports/daily.csv  ',
+          region: '  us-east-1  ',
+          accessKeyId: '  key-123  ',
+          secretAccessKey: '  secret-123  ',
+          fileNameTemplate: '  customers-{{date}}.csv  ',
+        },
+        schedule: {
+          frequency: 'weekly',
+          daysOfWeek: [1, 3, 5],
+          time: '08:15',
+          timezone: '  UTC  ',
+        },
+        operatorNote: '  Run every business day  ',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'exports.create_export',
+          project: 'test',
+          name: 'Customer Segment Export',
+          exportType: 'events',
+          dataSelection: {
+            attributes: ['email', 'first_name'],
+            events: ['purchase'],
+            segments: ['vip'],
+          },
+          destination: {
+            type: 's3',
+            host: undefined,
+            port: undefined,
+            username: undefined,
+            password: undefined,
+            path: '/exports/daily.csv',
+            bucket: 'my-bucket',
+            region: 'us-east-1',
+            accessKeyId: 'key-123',
+            secretAccessKey: 'secret-123',
+            email: undefined,
+            webhookUrl: undefined,
+            fileNameTemplate: 'customers-{{date}}.csv',
+          },
+          schedule: {
+            frequency: 'weekly',
+            daysOfWeek: [1, 3, 5],
+            dayOfMonth: undefined,
+            time: '08:15',
+            timezone: 'UTC',
+          },
+          operatorNote: 'Run every business day',
+        }),
+      );
+    });
+
+    it('throws for empty export name', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareCreateExport(createValidCreateExportInput({ name: '' }))).toThrow('must not be empty');
+    });
+
+    it('throws for invalid export type', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareCreateExport(createValidCreateExportInput({ exportType: 'profiles' }))).toThrow(
+        'must be one of',
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareCreateExport(createValidCreateExportInput({ project: '' }))).toThrow('must not be empty');
+    });
+
+    it('validates dataSelection', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareCreateExport(createValidCreateExportInput({ dataSelection: { events: [] } }))).toThrow(
+        'must include at least one non-empty list',
+      );
+    });
+
+    it('validates destination', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() =>
+        service.prepareCreateExport(
+          createValidCreateExportInput({ destination: { type: 'webhook', webhookUrl: '   ' } }),
+        ),
+      ).toThrow('must not be empty');
+    });
+
+    it('validates optional schedule', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() =>
+        service.prepareCreateExport(
+          createValidCreateExportInput({
+            schedule: { frequency: 'weekly', time: '10:00', timezone: 'UTC' },
+          }),
+        ),
+      ).toThrow('Weekly schedules require daysOfWeek');
+    });
+  });
+
+  describe('prepareRunExport', () => {
+    it('returns prepared action with valid input', () => {
+      const service = new BloomreachExportsService('test');
+      const result = service.prepareRunExport({
+        project: 'test',
+        exportId: '  exp-123  ',
+        operatorNote: '  Run now  ',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'exports.run_export',
+          project: 'test',
+          exportId: 'exp-123',
+          operatorNote: 'Run now',
+        }),
+      );
+    });
+
+    it('throws for empty export ID', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareRunExport({ project: 'test', exportId: '' })).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareRunExport({ project: '', exportId: 'exp-123' })).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareScheduleExport', () => {
+    it('returns prepared action with valid input including schedule', () => {
+      const service = new BloomreachExportsService('test');
+      const result = service.prepareScheduleExport({
+        project: 'test',
+        exportId: '  exp-456  ',
+        schedule: {
+          frequency: 'monthly',
+          dayOfMonth: 15,
+          time: '11:45',
+          timezone: '  Europe/Prague  ',
+        },
+        operatorNote: '  Monthly refresh  ',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'exports.schedule_export',
+          project: 'test',
+          exportId: 'exp-456',
+          schedule: {
+            frequency: 'monthly',
+            daysOfWeek: undefined,
+            dayOfMonth: 15,
+            time: '11:45',
+            timezone: 'Europe/Prague',
+          },
+          operatorNote: 'Monthly refresh',
+        }),
+      );
+    });
+
+    it('throws for empty export ID', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() =>
+        service.prepareScheduleExport({
+          project: 'test',
+          exportId: '',
+          schedule: { frequency: 'daily', time: '09:00', timezone: 'UTC' },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() =>
+        service.prepareScheduleExport({
+          project: '',
+          exportId: 'exp-1',
+          schedule: { frequency: 'daily', time: '09:00', timezone: 'UTC' },
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid schedule frequency', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() =>
+        service.prepareScheduleExport({
+          project: 'test',
+          exportId: 'exp-1',
+          schedule: { frequency: 'hourly', time: '09:00', timezone: 'UTC' },
+        }),
+      ).toThrow('must be one of');
+    });
+
+    it('validates time format', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() =>
+        service.prepareScheduleExport({
+          project: 'test',
+          exportId: 'exp-1',
+          schedule: { frequency: 'daily', time: '24:61', timezone: 'UTC' },
+        }),
+      ).toThrow('must use 24-hour HH:MM values');
+    });
+  });
+
+  describe('prepareDeleteExport', () => {
+    it('returns prepared action with valid input', () => {
+      const service = new BloomreachExportsService('test');
+      const result = service.prepareDeleteExport({
+        project: 'test',
+        exportId: '  exp-789  ',
+        operatorNote: '  Remove stale export  ',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'exports.delete_export',
+          project: 'test',
+          exportId: 'exp-789',
+          operatorNote: 'Remove stale export',
+        }),
+      );
+    });
+
+    it('throws for empty export ID', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareDeleteExport({ project: 'test', exportId: '' })).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachExportsService('test');
+      expect(() => service.prepareDeleteExport({ project: '', exportId: 'exp-789' })).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachExports.ts
+++ b/packages/core/src/bloomreachExports.ts
@@ -1,0 +1,599 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const CREATE_EXPORT_ACTION_TYPE = 'exports.create_export';
+export const RUN_EXPORT_ACTION_TYPE = 'exports.run_export';
+export const SCHEDULE_EXPORT_ACTION_TYPE = 'exports.schedule_export';
+export const DELETE_EXPORT_ACTION_TYPE = 'exports.delete_export';
+
+export const EXPORT_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const EXPORT_CREATE_RATE_LIMIT = 20;
+export const EXPORT_RUN_RATE_LIMIT = 60;
+export const EXPORT_SCHEDULE_RATE_LIMIT = 20;
+export const EXPORT_DELETE_RATE_LIMIT = 20;
+
+export interface DataSelection {
+  attributes?: string[];
+  events?: string[];
+  segments?: string[];
+}
+
+export interface ExportDestination {
+  type: string;
+  host?: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  path?: string;
+  bucket?: string;
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  email?: string;
+  webhookUrl?: string;
+  fileNameTemplate?: string;
+}
+
+export interface ExportSchedule {
+  frequency: string;
+  daysOfWeek?: number[];
+  dayOfMonth?: number;
+  time: string;
+  timezone: string;
+}
+
+export interface BloomreachExport {
+  id: string;
+  name: string;
+  exportType: string;
+  dataSelection: DataSelection;
+  destination: ExportDestination;
+  schedule?: ExportSchedule;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+}
+
+export interface ExportStatus {
+  exportId: string;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+  fileLocation?: string;
+  recordCount?: number;
+  errorMessage?: string;
+}
+
+export interface ExportHistoryEntry {
+  id: string;
+  exportId: string;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+  fileLocation?: string;
+  recordCount?: number;
+}
+
+export interface ListExportsInput {
+  project: string;
+}
+
+export interface ViewExportStatusInput {
+  project: string;
+  exportId: string;
+}
+
+export interface ViewExportHistoryInput {
+  project: string;
+  exportId: string;
+}
+
+export interface CreateExportInput {
+  project: string;
+  name: string;
+  exportType: string;
+  dataSelection: DataSelection;
+  destination: ExportDestination;
+  schedule?: ExportSchedule;
+  operatorNote?: string;
+}
+
+export interface RunExportInput {
+  project: string;
+  exportId: string;
+  operatorNote?: string;
+}
+
+export interface ScheduleExportInput {
+  project: string;
+  exportId: string;
+  schedule: ExportSchedule;
+  operatorNote?: string;
+}
+
+export interface DeleteExportInput {
+  project: string;
+  exportId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedExportAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_EXPORT_NAME_LENGTH = 200;
+const MAX_DESCRIPTION_LENGTH = 1000;
+const MAX_EXPORT_ID_LENGTH = 200;
+
+const EXPORT_TYPES = new Set(['customers', 'events']);
+const DESTINATION_TYPES = new Set(['sftp', 's3', 'email', 'webhook']);
+const SCHEDULE_FREQUENCIES = new Set(['daily', 'weekly', 'monthly']);
+function validateRequiredTrimmed(value: string, fieldName: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${fieldName} must not be empty.`);
+  }
+  return trimmed;
+}
+
+function validateExportName(name: string): string {
+  const trimmed = validateRequiredTrimmed(name, 'Export name');
+  if (trimmed.length > MAX_EXPORT_NAME_LENGTH) {
+    throw new Error(
+      `Export name must not exceed ${MAX_EXPORT_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+function validateExportType(exportType: string): string {
+  const normalized = validateRequiredTrimmed(exportType, 'Export type').toLowerCase();
+  if (!EXPORT_TYPES.has(normalized)) {
+    throw new Error(
+      `Export type must be one of: ${Array.from(EXPORT_TYPES).join(', ')} (got ${normalized}).`,
+    );
+  }
+  return normalized;
+}
+
+function validateDestinationType(destinationType: string): string {
+  const normalized = validateRequiredTrimmed(destinationType, 'Destination type').toLowerCase();
+  if (!DESTINATION_TYPES.has(normalized)) {
+    throw new Error(
+      `Destination type must be one of: ${Array.from(DESTINATION_TYPES).join(', ')} (got ${normalized}).`,
+    );
+  }
+  return normalized;
+}
+
+function validateExportId(exportId: string): string {
+  const trimmed = validateRequiredTrimmed(exportId, 'Export ID');
+  if (trimmed.length > MAX_EXPORT_ID_LENGTH) {
+    throw new Error(
+      `Export ID must not exceed ${MAX_EXPORT_ID_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+function validateScheduleFrequency(frequency: string): string {
+  const normalized = validateRequiredTrimmed(frequency, 'Schedule frequency').toLowerCase();
+  if (!SCHEDULE_FREQUENCIES.has(normalized)) {
+    throw new Error(
+      `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`,
+    );
+  }
+  return normalized;
+}
+
+function validateOptionalString(
+  value: string | undefined,
+  fieldName: string,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmed = validateRequiredTrimmed(value, fieldName);
+  if (trimmed.length > maxLength) {
+    throw new Error(`${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
+  }
+
+  return trimmed;
+}
+
+function validateStringArray(values: string[] | undefined, fieldName: string): string[] | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(values)) {
+    throw new Error(`${fieldName} must be an array.`);
+  }
+
+  const normalized = values.map((value, index) => {
+    if (typeof value !== 'string') {
+      throw new Error(`${fieldName}[${index}] must be a string.`);
+    }
+    return validateRequiredTrimmed(value, `${fieldName}[${index}]`);
+  });
+
+  return normalized;
+}
+
+function validateDataSelection(dataSelection: DataSelection): DataSelection {
+  const attributes = validateStringArray(dataSelection.attributes, 'dataSelection.attributes');
+  const events = validateStringArray(dataSelection.events, 'dataSelection.events');
+  const segments = validateStringArray(dataSelection.segments, 'dataSelection.segments');
+
+  const hasSelections =
+    (attributes !== undefined && attributes.length > 0) ||
+    (events !== undefined && events.length > 0) ||
+    (segments !== undefined && segments.length > 0);
+
+  if (!hasSelections) {
+    throw new Error(
+      'Data selection must include at least one non-empty list: attributes, events, or segments.',
+    );
+  }
+
+  return {
+    attributes,
+    events,
+    segments,
+  };
+}
+
+function validateDestination(destination: ExportDestination): ExportDestination {
+  const type = validateDestinationType(destination.type);
+  const host = validateOptionalString(destination.host, 'Destination host', MAX_EXPORT_NAME_LENGTH);
+  const username = validateOptionalString(
+    destination.username,
+    'Destination username',
+    MAX_EXPORT_NAME_LENGTH,
+  );
+  const password = validateOptionalString(
+    destination.password,
+    'Destination password',
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const path = validateOptionalString(destination.path, 'Destination path', MAX_DESCRIPTION_LENGTH);
+  const bucket = validateOptionalString(
+    destination.bucket,
+    'Destination bucket',
+    MAX_EXPORT_NAME_LENGTH,
+  );
+  const region = validateOptionalString(
+    destination.region,
+    'Destination region',
+    MAX_EXPORT_NAME_LENGTH,
+  );
+  const accessKeyId = validateOptionalString(
+    destination.accessKeyId,
+    'Destination accessKeyId',
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const secretAccessKey = validateOptionalString(
+    destination.secretAccessKey,
+    'Destination secretAccessKey',
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const email = validateOptionalString(destination.email, 'Destination email', MAX_DESCRIPTION_LENGTH);
+  const webhookUrl = validateOptionalString(
+    destination.webhookUrl,
+    'Destination webhookUrl',
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const fileNameTemplate = validateOptionalString(
+    destination.fileNameTemplate,
+    'Destination fileNameTemplate',
+    MAX_EXPORT_NAME_LENGTH,
+  );
+
+  if (destination.port !== undefined) {
+    if (!Number.isInteger(destination.port) || destination.port < 1 || destination.port > 65535) {
+      throw new Error('Destination port must be an integer between 1 and 65535.');
+    }
+  }
+
+  if (type === 'sftp' && (host === undefined || path === undefined)) {
+    throw new Error('SFTP destination requires host and path.');
+  }
+
+  if (type === 's3' && (bucket === undefined || path === undefined)) {
+    throw new Error('S3 destination requires bucket and path.');
+  }
+
+  if (type === 'email' && email === undefined) {
+    throw new Error('Email destination requires email.');
+  }
+
+  if (type === 'webhook' && webhookUrl === undefined) {
+    throw new Error('Webhook destination requires webhookUrl.');
+  }
+
+  return {
+    type,
+    host,
+    port: destination.port,
+    username,
+    password,
+    path,
+    bucket,
+    region,
+    accessKeyId,
+    secretAccessKey,
+    email,
+    webhookUrl,
+    fileNameTemplate,
+  };
+}
+
+function validateTimeFormat(time: string): string {
+  const trimmed = validateRequiredTrimmed(time, 'Schedule time');
+  const match = /^(\d{2}):(\d{2})$/.exec(trimmed);
+  if (match === null) {
+    throw new Error('Schedule time must use HH:MM format.');
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    throw new Error('Schedule time must use 24-hour HH:MM values (00-23 and 00-59).');
+  }
+
+  return trimmed;
+}
+
+function validateSchedule(schedule: ExportSchedule): ExportSchedule {
+  const frequency = validateScheduleFrequency(schedule.frequency);
+  const time = validateTimeFormat(schedule.time);
+  const timezone = validateRequiredTrimmed(schedule.timezone, 'Schedule timezone');
+
+  const daysOfWeek = schedule.daysOfWeek;
+  if (daysOfWeek !== undefined) {
+    if (!Array.isArray(daysOfWeek) || daysOfWeek.length === 0) {
+      throw new Error('Schedule daysOfWeek must be a non-empty array when provided.');
+    }
+
+    daysOfWeek.forEach((day, index) => {
+      if (!Number.isInteger(day) || day < 0 || day > 6) {
+        throw new Error(`Schedule daysOfWeek[${index}] must be an integer from 0 to 6.`);
+      }
+    });
+  }
+
+  const dayOfMonth = schedule.dayOfMonth;
+  if (dayOfMonth !== undefined) {
+    if (!Number.isInteger(dayOfMonth) || dayOfMonth < 1 || dayOfMonth > 31) {
+      throw new Error('Schedule dayOfMonth must be an integer from 1 to 31.');
+    }
+  }
+
+  if (frequency === 'weekly' && daysOfWeek === undefined) {
+    throw new Error('Weekly schedules require daysOfWeek.');
+  }
+
+  if (frequency === 'monthly' && dayOfMonth === undefined) {
+    throw new Error('Monthly schedules require dayOfMonth.');
+  }
+
+  return {
+    frequency,
+    daysOfWeek,
+    dayOfMonth,
+    time,
+    timezone,
+  };
+}
+
+function createPreparedAction(preview: Record<string, unknown>): PreparedExportAction {
+  return {
+    preparedActionId: `pa_${Date.now()}`,
+    confirmToken: `ct_stub_${Date.now()}`,
+    expiresAtMs: Date.now() + 30 * 60 * 1000,
+    preview,
+  };
+}
+
+export function buildExportsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/data/exports`;
+}
+
+export function buildExportDetailUrl(project: string, exportId: string): string {
+  return `/p/${encodeURIComponent(project)}/data/exports/${encodeURIComponent(exportId)}`;
+}
+
+export interface ExportActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateExportExecutor implements ExportActionExecutor {
+  readonly actionType = CREATE_EXPORT_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateExportExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class RunExportExecutor implements ExportActionExecutor {
+  readonly actionType = RUN_EXPORT_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'RunExportExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ScheduleExportExecutor implements ExportActionExecutor {
+  readonly actionType = SCHEDULE_EXPORT_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ScheduleExportExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteExportExecutor implements ExportActionExecutor {
+  readonly actionType = DELETE_EXPORT_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteExportExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createExportActionExecutors(): Record<string, ExportActionExecutor> {
+  return {
+    [CREATE_EXPORT_ACTION_TYPE]: new CreateExportExecutor(),
+    [RUN_EXPORT_ACTION_TYPE]: new RunExportExecutor(),
+    [SCHEDULE_EXPORT_ACTION_TYPE]: new ScheduleExportExecutor(),
+    [DELETE_EXPORT_ACTION_TYPE]: new DeleteExportExecutor(),
+  };
+}
+
+export class BloomreachExportsService {
+  private readonly exportsBaseUrl: string;
+
+  constructor(project: string) {
+    const validatedProject = validateProject(project);
+    this.exportsBaseUrl = buildExportsUrl(validatedProject);
+  }
+
+  get exportsUrl(): string {
+    return this.exportsBaseUrl;
+  }
+
+  async listExports(input?: ListExportsInput): Promise<BloomreachExport[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listExports: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewExportStatus(input: ViewExportStatusInput): Promise<ExportStatus> {
+    validateProject(input.project);
+    validateExportId(input.exportId);
+
+    throw new Error(
+      'viewExportStatus: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewExportHistory(input: ViewExportHistoryInput): Promise<ExportHistoryEntry[]> {
+    validateProject(input.project);
+    validateExportId(input.exportId);
+
+    throw new Error(
+      'viewExportHistory: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateExport(input: CreateExportInput): PreparedExportAction {
+    const project = validateProject(input.project);
+    const name = validateExportName(input.name);
+    const exportType = validateExportType(input.exportType);
+    const dataSelection = validateDataSelection(input.dataSelection);
+    const destination = validateDestination(input.destination);
+    const schedule =
+      input.schedule === undefined ? undefined : validateSchedule(input.schedule);
+    const operatorNote = validateOptionalString(
+      input.operatorNote,
+      'Operator note',
+      MAX_DESCRIPTION_LENGTH,
+    );
+
+    const preview = {
+      action: CREATE_EXPORT_ACTION_TYPE,
+      project,
+      name,
+      exportType,
+      dataSelection,
+      destination,
+      schedule,
+      operatorNote,
+    };
+
+    return createPreparedAction(preview);
+  }
+
+  prepareRunExport(input: RunExportInput): PreparedExportAction {
+    const project = validateProject(input.project);
+    const exportId = validateExportId(input.exportId);
+    const operatorNote = validateOptionalString(
+      input.operatorNote,
+      'Operator note',
+      MAX_DESCRIPTION_LENGTH,
+    );
+
+    const preview = {
+      action: RUN_EXPORT_ACTION_TYPE,
+      project,
+      exportId,
+      operatorNote,
+    };
+
+    return createPreparedAction(preview);
+  }
+
+  prepareScheduleExport(input: ScheduleExportInput): PreparedExportAction {
+    const project = validateProject(input.project);
+    const exportId = validateExportId(input.exportId);
+    const schedule = validateSchedule(input.schedule);
+    const operatorNote = validateOptionalString(
+      input.operatorNote,
+      'Operator note',
+      MAX_DESCRIPTION_LENGTH,
+    );
+
+    const preview = {
+      action: SCHEDULE_EXPORT_ACTION_TYPE,
+      project,
+      exportId,
+      schedule,
+      operatorNote,
+    };
+
+    return createPreparedAction(preview);
+  }
+
+  prepareDeleteExport(input: DeleteExportInput): PreparedExportAction {
+    const project = validateProject(input.project);
+    const exportId = validateExportId(input.exportId);
+    const operatorNote = validateOptionalString(
+      input.operatorNote,
+      'Operator note',
+      MAX_DESCRIPTION_LENGTH,
+    );
+
+    const preview = {
+      action: DELETE_EXPORT_ACTION_TYPE,
+      project,
+      exportId,
+      operatorNote,
+    };
+
+    return createPreparedAction(preview);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export * from './bloomreachAssetManager.js';
 export * from './bloomreachTagManager.js';
 export * from './bloomreachDataManager.js';
 export * from './bloomreachMetrics.js';
+export * from './bloomreachExports.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Adds the data exports feature module for managing scheduled data exports from Bloomreach (issue #51).

## Changes

### Core Module (`packages/core/src/bloomreachExports.ts` — 600 lines)
- Action type constants: `exports.create_export`, `exports.run_export`, `exports.schedule_export`, `exports.delete_export`
- Rate limit constants (1-hour window, per-action limits)
- Entity interfaces: `BloomreachExport`, `ExportStatus`, `ExportHistoryEntry`, `DataSelection`, `ExportDestination`, `ExportSchedule`
- Input interfaces for all 7 operations (list, view status, view history, create, run, schedule, delete)
- Comprehensive validation layer:
  - Export name, type (`customers`/`events`), ID
  - Destination type (`sftp`/`s3`/`email`/`webhook`) with per-type required field validation
  - Schedule validation (frequency, HH:MM time format, daysOfWeek 0-6, dayOfMonth 1-31, timezone)
  - Data selection (at least one of attributes/events/segments must be non-empty)
- URL builders: `buildExportsUrl()`, `buildExportDetailUrl()`
- Action executor stubs (awaiting browser automation infrastructure)
- `BloomreachExportsService` with list, view, and 4 prepare methods (two-phase commit pattern)

### Unit Tests (`packages/core/src/__tests__/bloomreachExports.test.ts` — 88 tests)
- Full coverage of constants, URL builders, executor factory, service construction
- Validation testing for all input paths (happy + error)
- Tests for all prepare methods and read-only service methods

### CLI Commands (`packages/cli/src/bin/bloomreach.ts` — 268 lines added)
- `bloomreach exports list` — List all configured exports
- `bloomreach exports status` — View export run status
- `bloomreach exports history` — View export history
- `bloomreach exports create` — Prepare new export (two-phase commit)
- `bloomreach exports run` — Prepare immediate export trigger
- `bloomreach exports schedule` — Configure recurring schedule
- `bloomreach exports delete` — Remove export configuration

### Re-export (`packages/core/src/index.ts`)
- Added `export * from './bloomreachExports.js'`

## Quality Gates
- ✅ typecheck (`tsc --build`)
- ✅ lint (`eslint .`)
- ✅ test (3660 tests pass, 40 test files)
- ✅ build (core + CLI)

Closes #51
