### PR TITLE
feat: Browse and Deploy Use Cases (#54)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -16,6 +16,7 @@ import {
   BloomreachFlowsService,
   BloomreachIntegrationsService,
   BloomreachInitiativesService,
+  BloomreachUseCasesService,
   BloomreachProjectSettingsService,
   BloomreachFunnelsService,
   BloomreachGeoAnalysesService,
@@ -10132,6 +10133,286 @@ imports
           console.log(`  Import: ${options.importId}`);
           console.log(`  Token:  ${result.confirmToken}`);
           console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const useCases = program
+  .command('use-cases')
+  .description('Browse and deploy Bloomreach Use Case Center templates');
+
+useCases
+  .command('list')
+  .description('List all available use case templates')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--category <category>', 'Filter by goal category (awareness, acquisition, retention, optimization)')
+  .option('--tag <tag>', 'Filter by tag (new, essentials, popular)')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; category?: string; tag?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachUseCasesService(options.project);
+        const input: { project: string; category?: string; tag?: string } = {
+          project: options.project,
+        };
+        if (options.category) input.category = options.category;
+        if (options.tag) input.tag = options.tag;
+
+        const result = await service.listUseCases(input);
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          if (result.length === 0) {
+            console.log('No use cases found.');
+            return;
+          }
+          for (const useCase of result) {
+            console.log(`  ${useCase.name}`);
+            console.log(`    Category: ${useCase.goalCategory}`);
+            console.log(`    Tags:     ${useCase.tags.join(', ')}`);
+            if (useCase.readinessStatus) {
+              console.log(`    Ready:    ${useCase.readinessStatus}`);
+            }
+            console.log(`    ID:       ${useCase.id}`);
+            console.log(`    URL:      ${useCase.url}`);
+          }
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+useCases
+  .command('search')
+  .description('Search use case templates by keyword')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--query <query>', 'Search keyword')
+  .option('--category <category>', 'Filter by goal category (awareness, acquisition, retention, optimization)')
+  .option('--tag <tag>', 'Filter by tag (new, essentials, popular)')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      query: string;
+      category?: string;
+      tag?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachUseCasesService(options.project);
+        const result = await service.searchUseCases({
+          project: options.project,
+          query: options.query,
+          category: options.category,
+          tag: options.tag,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          if (result.length === 0) {
+            console.log('No use cases match the search.');
+            return;
+          }
+          for (const useCase of result) {
+            console.log(`  ${useCase.name}`);
+            console.log(`    Category: ${useCase.goalCategory}`);
+            console.log(`    Tags:     ${useCase.tags.join(', ')}`);
+            if (useCase.readinessStatus) {
+              console.log(`    Ready:    ${useCase.readinessStatus}`);
+            }
+            console.log(`    ID:       ${useCase.id}`);
+            console.log(`    URL:      ${useCase.url}`);
+          }
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+useCases
+  .command('view')
+  .description('View details of a specific use case template')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--use-case-id <id>', 'Use case ID')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; useCaseId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachUseCasesService(options.project);
+      const result = await service.viewUseCase({
+        project: options.project,
+        useCaseId: options.useCaseId,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Use Case: ${result.name}`);
+        console.log(`  Category:     ${result.goalCategory}`);
+        console.log(`  Tags:         ${result.tags.join(', ')}`);
+        console.log(`  Description:  ${result.description}`);
+        if (result.longDescription) {
+          console.log(`  Details:      ${result.longDescription}`);
+        }
+        if (result.requiredIntegrations.length > 0) {
+          console.log(`  Integrations: ${result.requiredIntegrations.join(', ')}`);
+        }
+        if (result.channelsUsed.length > 0) {
+          console.log(`  Channels:     ${result.channelsUsed.join(', ')}`);
+        }
+        if (result.readinessStatus) {
+          console.log(`  Readiness:    ${result.readinessStatus}`);
+        }
+        console.log(`  URL:          ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+useCases
+  .command('project-list')
+  .description('List use cases deployed in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachUseCasesService(options.project);
+      const result = await service.listProjectUseCases({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No use cases deployed in this project.');
+          return;
+        }
+        for (const useCase of result) {
+          console.log(`  ${useCase.name}`);
+          console.log(`    Category: ${useCase.goalCategory}`);
+          if (useCase.status) {
+            console.log(`    Status:   ${useCase.status}`);
+          }
+          if (useCase.deployedAt) {
+            console.log(`    Deployed: ${useCase.deployedAt}`);
+          }
+          console.log(`    ID:       ${useCase.id}`);
+          console.log(`    URL:      ${useCase.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+useCases
+  .command('deploy')
+  .description('Prepare deployment of a use case template (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--use-case-id <id>', 'Use case ID to deploy')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; useCaseId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachUseCasesService(options.project);
+        const result = service.prepareDeployUseCase({
+          project: options.project,
+          useCaseId: options.useCaseId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Use case deployment prepared.');
+          console.log(`  Use Case: ${options.useCaseId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+useCases
+  .command('favorite')
+  .description('Prepare favoriting a use case (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--use-case-id <id>', 'Use case ID to favorite')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; useCaseId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachUseCasesService(options.project);
+        const result = service.prepareFavoriteUseCase({
+          project: options.project,
+          useCaseId: options.useCaseId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Use case favorite prepared.');
+          console.log(`  Use Case: ${options.useCaseId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+useCases
+  .command('unfavorite')
+  .description('Prepare unfavoriting a use case (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--use-case-id <id>', 'Use case ID to unfavorite')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; useCaseId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachUseCasesService(options.project);
+        const result = service.prepareUnfavoriteUseCase({
+          project: options.project,
+          useCaseId: options.useCaseId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Use case unfavorite prepared.');
+          console.log(`  Use Case: ${options.useCaseId}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
           console.log('To confirm, run:');
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);

--- a/packages/core/src/__tests__/bloomreachUseCases.test.ts
+++ b/packages/core/src/__tests__/bloomreachUseCases.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEPLOY_USE_CASE_ACTION_TYPE,
+  FAVORITE_USE_CASE_ACTION_TYPE,
+  UNFAVORITE_USE_CASE_ACTION_TYPE,
+  USE_CASE_RATE_LIMIT_WINDOW_MS,
+  USE_CASE_DEPLOY_RATE_LIMIT,
+  USE_CASE_FAVORITE_RATE_LIMIT,
+  USE_CASE_GOAL_CATEGORIES,
+  USE_CASE_TAGS,
+  validateUseCaseId,
+  validateUseCaseSearchQuery,
+  validateGoalCategory,
+  validateUseCaseTag,
+  buildUseCasesUrl,
+  createUseCaseActionExecutors,
+  BloomreachUseCasesService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports DEPLOY_USE_CASE_ACTION_TYPE', () => {
+    expect(DEPLOY_USE_CASE_ACTION_TYPE).toBe('use_cases.deploy');
+  });
+
+  it('exports FAVORITE_USE_CASE_ACTION_TYPE', () => {
+    expect(FAVORITE_USE_CASE_ACTION_TYPE).toBe('use_cases.favorite');
+  });
+
+  it('exports UNFAVORITE_USE_CASE_ACTION_TYPE', () => {
+    expect(UNFAVORITE_USE_CASE_ACTION_TYPE).toBe('use_cases.unfavorite');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports USE_CASE_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(USE_CASE_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports USE_CASE_DEPLOY_RATE_LIMIT', () => {
+    expect(USE_CASE_DEPLOY_RATE_LIMIT).toBe(5);
+  });
+
+  it('exports USE_CASE_FAVORITE_RATE_LIMIT', () => {
+    expect(USE_CASE_FAVORITE_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('USE_CASE_GOAL_CATEGORIES', () => {
+  it('contains 4 categories', () => {
+    expect(USE_CASE_GOAL_CATEGORIES).toHaveLength(4);
+  });
+
+  it('contains expected categories in order', () => {
+    expect(USE_CASE_GOAL_CATEGORIES).toEqual([
+      'awareness',
+      'acquisition',
+      'retention',
+      'optimization',
+    ]);
+  });
+});
+
+describe('USE_CASE_TAGS', () => {
+  it('contains 3 tags', () => {
+    expect(USE_CASE_TAGS).toHaveLength(3);
+  });
+
+  it('contains expected tags in order', () => {
+    expect(USE_CASE_TAGS).toEqual(['new', 'essentials', 'popular']);
+  });
+});
+
+describe('validateUseCaseId', () => {
+  it('returns trimmed ID for valid input', () => {
+    expect(validateUseCaseId('  use-case-123  ')).toBe('use-case-123');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateUseCaseId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateUseCaseId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns same value when already trimmed', () => {
+    expect(validateUseCaseId('use-case-456')).toBe('use-case-456');
+  });
+});
+
+describe('validateUseCaseSearchQuery', () => {
+  it('returns trimmed query for valid input', () => {
+    expect(validateUseCaseSearchQuery('  personalization  ')).toBe('personalization');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateUseCaseSearchQuery('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateUseCaseSearchQuery('   ')).toThrow('must not be empty');
+  });
+});
+
+describe('validateGoalCategory', () => {
+  it('accepts awareness', () => {
+    expect(validateGoalCategory('awareness')).toBe('awareness');
+  });
+
+  it('accepts acquisition', () => {
+    expect(validateGoalCategory('acquisition')).toBe('acquisition');
+  });
+
+  it('accepts retention', () => {
+    expect(validateGoalCategory('retention')).toBe('retention');
+  });
+
+  it('accepts optimization', () => {
+    expect(validateGoalCategory('optimization')).toBe('optimization');
+  });
+
+  it('throws for unknown category', () => {
+    expect(() => validateGoalCategory('activation')).toThrow('category must be one of');
+  });
+
+  it('throws for empty category', () => {
+    expect(() => validateGoalCategory('')).toThrow('category must be one of');
+  });
+});
+
+describe('validateUseCaseTag', () => {
+  it('accepts new', () => {
+    expect(validateUseCaseTag('new')).toBe('new');
+  });
+
+  it('accepts essentials', () => {
+    expect(validateUseCaseTag('essentials')).toBe('essentials');
+  });
+
+  it('accepts popular', () => {
+    expect(validateUseCaseTag('popular')).toBe('popular');
+  });
+
+  it('throws for unknown tag', () => {
+    expect(() => validateUseCaseTag('trending')).toThrow('tag must be one of');
+  });
+
+  it('throws for empty tag', () => {
+    expect(() => validateUseCaseTag('')).toThrow('tag must be one of');
+  });
+});
+
+describe('buildUseCasesUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildUseCasesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/use-case-center/use-case-center',
+    );
+  });
+
+  it('encodes spaces in project name', () => {
+    expect(buildUseCasesUrl('my project')).toBe('/p/my%20project/use-case-center/use-case-center');
+  });
+
+  it('encodes slashes in project name', () => {
+    expect(buildUseCasesUrl('org/project')).toBe('/p/org%2Fproject/use-case-center/use-case-center');
+  });
+});
+
+describe('createUseCaseActionExecutors', () => {
+  it('returns executors for all three action types', () => {
+    const executors = createUseCaseActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(3);
+    expect(executors[DEPLOY_USE_CASE_ACTION_TYPE]).toBeDefined();
+    expect(executors[FAVORITE_USE_CASE_ACTION_TYPE]).toBeDefined();
+    expect(executors[UNFAVORITE_USE_CASE_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching its key', () => {
+    const executors = createUseCaseActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createUseCaseActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachUseCasesService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachUseCasesService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachUseCasesService);
+    });
+
+    it('exposes the use cases URL', () => {
+      const service = new BloomreachUseCasesService('kingdom-of-joakim');
+      expect(service.useCasesUrl).toBe('/p/kingdom-of-joakim/use-case-center/use-case-center');
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachUseCasesService('  my-project  ');
+      expect(service.useCasesUrl).toBe('/p/my-project/use-case-center/use-case-center');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachUseCasesService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listUseCases', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(service.listUseCases()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates category when provided', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.listUseCases({ project: 'test', category: 'activation' }),
+      ).rejects.toThrow('category must be one of');
+    });
+
+    it('validates tag when provided', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.listUseCases({ project: 'test', tag: 'trending' }),
+      ).rejects.toThrow('tag must be one of');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.listUseCases({ project: '', category: 'awareness', tag: 'new' }),
+      ).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('searchUseCases', () => {
+    it('throws not-yet-implemented error with valid input', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.searchUseCases({ project: 'test', query: 'cart abandonment' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.searchUseCases({ project: '', query: 'cart abandonment' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates query (empty throws)', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(service.searchUseCases({ project: 'test', query: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates category when provided', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.searchUseCases({
+          project: 'test',
+          query: 'cart abandonment',
+          category: 'activation',
+        }),
+      ).rejects.toThrow('category must be one of');
+    });
+
+    it('validates tag when provided', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.searchUseCases({
+          project: 'test',
+          query: 'cart abandonment',
+          tag: 'trending',
+        }),
+      ).rejects.toThrow('tag must be one of');
+    });
+  });
+
+  describe('viewUseCase', () => {
+    it('throws not-yet-implemented error with valid input', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.viewUseCase({ project: 'test', useCaseId: 'use-case-1' }),
+      ).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project input', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(
+        service.viewUseCase({ project: '', useCaseId: 'use-case-1' }),
+      ).rejects.toThrow('must not be empty');
+    });
+
+    it('validates useCaseId input with empty string', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(service.viewUseCase({ project: 'test', useCaseId: '' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('validates useCaseId input with whitespace', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(service.viewUseCase({ project: 'test', useCaseId: '   ' })).rejects.toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('listProjectUseCases', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(service.listProjectUseCases()).rejects.toThrow('not yet implemented');
+    });
+
+    it('validates project when input is provided', async () => {
+      const service = new BloomreachUseCasesService('test');
+      await expect(service.listProjectUseCases({ project: '' })).rejects.toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareDeployUseCase', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachUseCasesService('test');
+      const result = service.prepareDeployUseCase({
+        project: 'test',
+        useCaseId: 'use-case-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'use_cases.deploy',
+          project: 'test',
+          useCaseId: 'use-case-123',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachUseCasesService('test');
+      const result = service.prepareDeployUseCase({
+        project: 'test',
+        useCaseId: 'use-case-123',
+        operatorNote: 'Deploy after QA signoff',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Deploy after QA signoff' }),
+      );
+    });
+
+    it('throws for empty useCaseId', () => {
+      const service = new BloomreachUseCasesService('test');
+      expect(() =>
+        service.prepareDeployUseCase({ project: 'test', useCaseId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachUseCasesService('test');
+      expect(() =>
+        service.prepareDeployUseCase({ project: '', useCaseId: 'use-case-123' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareFavoriteUseCase', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachUseCasesService('test');
+      const result = service.prepareFavoriteUseCase({
+        project: 'test',
+        useCaseId: 'use-case-456',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'use_cases.favorite',
+          project: 'test',
+          useCaseId: 'use-case-456',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachUseCasesService('test');
+      const result = service.prepareFavoriteUseCase({
+        project: 'test',
+        useCaseId: 'use-case-456',
+        operatorNote: 'Favorite for launch team',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Favorite for launch team' }),
+      );
+    });
+
+    it('throws for empty useCaseId', () => {
+      const service = new BloomreachUseCasesService('test');
+      expect(() =>
+        service.prepareFavoriteUseCase({ project: 'test', useCaseId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachUseCasesService('test');
+      expect(() =>
+        service.prepareFavoriteUseCase({ project: '', useCaseId: 'use-case-456' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUnfavoriteUseCase', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachUseCasesService('test');
+      const result = service.prepareUnfavoriteUseCase({
+        project: 'test',
+        useCaseId: 'use-case-789',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'use_cases.unfavorite',
+          project: 'test',
+          useCaseId: 'use-case-789',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachUseCasesService('test');
+      const result = service.prepareUnfavoriteUseCase({
+        project: 'test',
+        useCaseId: 'use-case-789',
+        operatorNote: 'Unfavorite stale item',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Unfavorite stale item' }),
+      );
+    });
+
+    it('throws for empty useCaseId', () => {
+      const service = new BloomreachUseCasesService('test');
+      expect(() =>
+        service.prepareUnfavoriteUseCase({ project: 'test', useCaseId: '' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachUseCasesService('test');
+      expect(() =>
+        service.prepareUnfavoriteUseCase({ project: '', useCaseId: 'use-case-789' }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachUseCases.ts
+++ b/packages/core/src/bloomreachUseCases.ts
@@ -1,0 +1,295 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const DEPLOY_USE_CASE_ACTION_TYPE = 'use_cases.deploy';
+export const FAVORITE_USE_CASE_ACTION_TYPE = 'use_cases.favorite';
+export const UNFAVORITE_USE_CASE_ACTION_TYPE = 'use_cases.unfavorite';
+
+export const USE_CASE_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const USE_CASE_DEPLOY_RATE_LIMIT = 5;
+export const USE_CASE_FAVORITE_RATE_LIMIT = 20;
+
+export const USE_CASE_GOAL_CATEGORIES = [
+  'awareness',
+  'acquisition',
+  'retention',
+  'optimization',
+] as const;
+export type UseCaseGoalCategory = (typeof USE_CASE_GOAL_CATEGORIES)[number];
+
+export const USE_CASE_TAGS = ['new', 'essentials', 'popular'] as const;
+export type UseCaseTag = (typeof USE_CASE_TAGS)[number];
+
+export interface BloomreachUseCase {
+  id: string;
+  name: string;
+  description: string;
+  goalCategory: UseCaseGoalCategory;
+  tags: UseCaseTag[];
+  readinessStatus?: string;
+  url: string;
+}
+
+export interface UseCaseDetails extends BloomreachUseCase {
+  requiredIntegrations: string[];
+  channelsUsed: string[];
+  longDescription?: string;
+  previewImageUrl?: string;
+}
+
+export interface ProjectUseCase extends BloomreachUseCase {
+  deployedAt?: string;
+  status?: string;
+}
+
+export interface ListUseCasesInput {
+  project: string;
+  category?: string;
+  tag?: string;
+}
+
+export interface SearchUseCasesInput {
+  project: string;
+  query: string;
+  category?: string;
+  tag?: string;
+}
+
+export interface ViewUseCaseInput {
+  project: string;
+  useCaseId: string;
+}
+
+export interface ListProjectUseCasesInput {
+  project: string;
+}
+
+export interface DeployUseCaseInput {
+  project: string;
+  useCaseId: string;
+  operatorNote?: string;
+}
+
+export interface FavoriteUseCaseInput {
+  project: string;
+  useCaseId: string;
+  operatorNote?: string;
+}
+
+export interface UnfavoriteUseCaseInput {
+  project: string;
+  useCaseId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedUseCaseAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+export function validateUseCaseId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Use case ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateUseCaseSearchQuery(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Search query must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateGoalCategory(category: string): UseCaseGoalCategory {
+  if (!USE_CASE_GOAL_CATEGORIES.includes(category as UseCaseGoalCategory)) {
+    throw new Error(
+      `category must be one of: ${USE_CASE_GOAL_CATEGORIES.join(', ')} (got "${category}").`,
+    );
+  }
+  return category as UseCaseGoalCategory;
+}
+
+export function validateUseCaseTag(tag: string): UseCaseTag {
+  if (!USE_CASE_TAGS.includes(tag as UseCaseTag)) {
+    throw new Error(`tag must be one of: ${USE_CASE_TAGS.join(', ')} (got "${tag}").`);
+  }
+  return tag as UseCaseTag;
+}
+
+export function buildUseCasesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/use-case-center/use-case-center`;
+}
+
+export interface UseCaseActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class DeployUseCaseExecutor implements UseCaseActionExecutor {
+  readonly actionType = DEPLOY_USE_CASE_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeployUseCaseExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class FavoriteUseCaseExecutor implements UseCaseActionExecutor {
+  readonly actionType = FAVORITE_USE_CASE_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'FavoriteUseCaseExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UnfavoriteUseCaseExecutor implements UseCaseActionExecutor {
+  readonly actionType = UNFAVORITE_USE_CASE_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UnfavoriteUseCaseExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createUseCaseActionExecutors(): Record<string, UseCaseActionExecutor> {
+  return {
+    [DEPLOY_USE_CASE_ACTION_TYPE]: new DeployUseCaseExecutor(),
+    [FAVORITE_USE_CASE_ACTION_TYPE]: new FavoriteUseCaseExecutor(),
+    [UNFAVORITE_USE_CASE_ACTION_TYPE]: new UnfavoriteUseCaseExecutor(),
+  };
+}
+
+export class BloomreachUseCasesService {
+  private readonly baseUrl: string;
+
+  constructor(project: string) {
+    this.baseUrl = buildUseCasesUrl(validateProject(project));
+  }
+
+  get useCasesUrl(): string {
+    return this.baseUrl;
+  }
+
+  async listUseCases(input?: ListUseCasesInput): Promise<BloomreachUseCase[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+      if (input.category !== undefined) {
+        validateGoalCategory(input.category);
+      }
+      if (input.tag !== undefined) {
+        validateUseCaseTag(input.tag);
+      }
+    }
+
+    throw new Error(
+      'listUseCases: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async searchUseCases(input: SearchUseCasesInput): Promise<BloomreachUseCase[]> {
+    validateProject(input.project);
+    validateUseCaseSearchQuery(input.query);
+    if (input.category !== undefined) {
+      validateGoalCategory(input.category);
+    }
+    if (input.tag !== undefined) {
+      validateUseCaseTag(input.tag);
+    }
+
+    throw new Error(
+      'searchUseCases: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewUseCase(input: ViewUseCaseInput): Promise<UseCaseDetails> {
+    validateProject(input.project);
+    validateUseCaseId(input.useCaseId);
+
+    throw new Error(
+      'viewUseCase: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listProjectUseCases(
+    input?: ListProjectUseCasesInput,
+  ): Promise<ProjectUseCase[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listProjectUseCases: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareDeployUseCase(input: DeployUseCaseInput): PreparedUseCaseAction {
+    const project = validateProject(input.project);
+    const useCaseId = validateUseCaseId(input.useCaseId);
+
+    const preview = {
+      action: DEPLOY_USE_CASE_ACTION_TYPE,
+      project,
+      useCaseId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareFavoriteUseCase(input: FavoriteUseCaseInput): PreparedUseCaseAction {
+    const project = validateProject(input.project);
+    const useCaseId = validateUseCaseId(input.useCaseId);
+
+    const preview = {
+      action: FAVORITE_USE_CASE_ACTION_TYPE,
+      project,
+      useCaseId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUnfavoriteUseCase(input: UnfavoriteUseCaseInput): PreparedUseCaseAction {
+    const project = validateProject(input.project);
+    const useCaseId = validateUseCaseId(input.useCaseId);
+
+    const preview = {
+      action: UNFAVORITE_USE_CASE_ACTION_TYPE,
+      project,
+      useCaseId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from './bloomreachChannelSettings.js';
 export * from './bloomreachSecuritySettings.js';
 export * from './bloomreachEvaluationSettings.js';
 export * from './bloomreachWeblayers.js';
+export * from './bloomreachUseCases.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Adds the **Use Case Center** feature module for browsing, searching, deploying, and bookmarking Bloomreach use case templates.

Closes #54

## Changes

### New: `packages/core/src/bloomreachUseCases.ts`
- Goal category taxonomy: `awareness`, `acquisition`, `retention`, `optimization`
- Tag taxonomy: `new`, `essentials`, `popular`
- Interfaces: `BloomreachUseCase`, `UseCaseDetails`, `ProjectUseCase`
- Input validation: `validateUseCaseId`, `validateUseCaseSearchQuery`, `validateGoalCategory`, `validateUseCaseTag`
- URL builder: `/p/{project}/use-case-center/use-case-center`
- Service class `BloomreachUseCasesService` with:
  - Read methods: `listUseCases`, `searchUseCases`, `viewUseCase`, `listProjectUseCases`
  - Two-phase commit mutations: `prepareDeployUseCase`, `prepareFavoriteUseCase`, `prepareUnfavoriteUseCase`
- Action executors: `DeployUseCaseExecutor`, `FavoriteUseCaseExecutor`, `UnfavoriteUseCaseExecutor` (stub implementations awaiting browser automation infrastructure)
- Rate limit constants for deploy and favorite operations

### New: `packages/core/src/__tests__/bloomreachUseCases.test.ts`
- Comprehensive unit tests covering all constants, validators, URL builder, executor factory, and service methods
- Follows the exact same test structure as existing feature modules

### Modified: `packages/core/src/index.ts`
- Added barrel export for `bloomreachUseCases`

### Modified: `packages/cli/src/bin/bloomreach.ts`
- Added `use-cases` command group with subcommands:
  - `list` — Browse all templates with optional category/tag filter
  - `search` — Search by keyword with optional filters
  - `view` — View detailed use case information
  - `project-list` — List deployed use cases
  - `deploy` — Deploy a template (two-phase commit)
  - `favorite` / `unfavorite` — Bookmark management (two-phase commit)

## Quality Gates

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 3942 tests passed (44 files)
- ✅ `npm run build` — both packages built successfully
