### PR TITLE
feat: manage access & API keys (#56)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import {
+  BloomreachAccessManagementService,
   BloomreachAssetManagerService,
   BloomreachCampaignCalendarService,
   BloomreachCampaignSettingsService,
@@ -10413,6 +10414,264 @@ useCases
           console.log(`  Use Case: ${options.useCaseId}`);
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const access = program
+  .command('access')
+  .description('Manage project access, team members, and API keys');
+
+access
+  .command('list-members')
+  .description('List all team members in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAccessManagementService(options.project);
+      const result = await service.listTeamMembers({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No team members found.');
+          return;
+        }
+        for (const member of result) {
+          console.log(`  ${member.email}`);
+          if (member.name) {
+            console.log(`    Name:   ${member.name}`);
+          }
+          console.log(`    Role:   ${member.role}`);
+          console.log(`    Status: ${member.status}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+access
+  .command('invite')
+  .description('Prepare inviting a team member (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--email <email>', 'Team member email address')
+  .requiredOption('--role <role>', 'Team member role')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      email: string;
+      role: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAccessManagementService(options.project);
+        const result = service.prepareInviteTeamMember({
+          project: options.project,
+          email: options.email,
+          role: options.role,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Team member invitation prepared.');
+          console.log(`  Email:   ${options.email}`);
+          console.log(`  Role:    ${options.role}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+access
+  .command('update-role')
+  .description('Prepare updating a team member role (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--member-id <id>', 'Team member ID')
+  .requiredOption('--role <role>', 'Updated team member role')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      memberId: string;
+      role: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachAccessManagementService(options.project);
+        const result = service.prepareUpdateMemberRole({
+          project: options.project,
+          memberId: options.memberId,
+          role: options.role,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Team member role update prepared.');
+          console.log(`  Member ID: ${options.memberId}`);
+          console.log(`  Role:      ${options.role}`);
+          console.log(`  Token:     ${result.confirmToken}`);
+          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+access
+  .command('remove-member')
+  .description('Prepare removing a team member (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--member-id <id>', 'Team member ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; memberId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachAccessManagementService(options.project);
+        const result = service.prepareRemoveTeamMember({
+          project: options.project,
+          memberId: options.memberId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Team member removal prepared.');
+          console.log(`  Member ID: ${options.memberId}`);
+          console.log(`  Token:     ${result.confirmToken}`);
+          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+access
+  .command('list-api-keys')
+  .description('List all API keys in the project')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAccessManagementService(options.project);
+      const result = await service.listApiKeys({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No API keys found.');
+          return;
+        }
+        for (const apiKey of result) {
+          console.log(`  ${apiKey.name}`);
+          console.log(`    Public Key: ${apiKey.publicKey}`);
+          console.log(`    Status:     ${apiKey.status}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+access
+  .command('create-api-key')
+  .description('Prepare creating an API key (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'API key name')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; name: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachAccessManagementService(options.project);
+        const result = service.prepareCreateApiKey({
+          project: options.project,
+          name: options.name,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('API key creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+access
+  .command('delete-api-key')
+  .description('Prepare deleting an API key (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--api-key-id <id>', 'API key ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; apiKeyId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachAccessManagementService(options.project);
+        const result = service.prepareDeleteApiKey({
+          project: options.project,
+          apiKeyId: options.apiKeyId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('API key deletion prepared.');
+          console.log(`  API key ID: ${options.apiKeyId}`);
+          console.log(`  Token:      ${result.confirmToken}`);
+          console.log(`  Expires:    ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
           console.log('To confirm, run:');
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);

--- a/packages/core/src/__tests__/bloomreachAccessManagement.test.ts
+++ b/packages/core/src/__tests__/bloomreachAccessManagement.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect } from 'vitest';
+import {
+  INVITE_TEAM_MEMBER_ACTION_TYPE,
+  UPDATE_MEMBER_ROLE_ACTION_TYPE,
+  REMOVE_TEAM_MEMBER_ACTION_TYPE,
+  CREATE_API_KEY_ACTION_TYPE,
+  DELETE_API_KEY_ACTION_TYPE,
+  ACCESS_RATE_LIMIT_WINDOW_MS,
+  ACCESS_INVITE_RATE_LIMIT,
+  ACCESS_MODIFY_RATE_LIMIT,
+  ACCESS_API_KEY_RATE_LIMIT,
+  TEAM_MEMBER_ROLES,
+  validateEmail,
+  validateMemberRole,
+  validateMemberId,
+  validateApiKeyName,
+  validateApiKeyId,
+  buildProjectTeamUrl,
+  buildApiKeysUrl,
+  createAccessActionExecutors,
+  BloomreachAccessManagementService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports INVITE_TEAM_MEMBER_ACTION_TYPE', () => {
+    expect(INVITE_TEAM_MEMBER_ACTION_TYPE).toBe('access.invite_team_member');
+  });
+
+  it('exports UPDATE_MEMBER_ROLE_ACTION_TYPE', () => {
+    expect(UPDATE_MEMBER_ROLE_ACTION_TYPE).toBe('access.update_member_role');
+  });
+
+  it('exports REMOVE_TEAM_MEMBER_ACTION_TYPE', () => {
+    expect(REMOVE_TEAM_MEMBER_ACTION_TYPE).toBe('access.remove_team_member');
+  });
+
+  it('exports CREATE_API_KEY_ACTION_TYPE', () => {
+    expect(CREATE_API_KEY_ACTION_TYPE).toBe('access.create_api_key');
+  });
+
+  it('exports DELETE_API_KEY_ACTION_TYPE', () => {
+    expect(DELETE_API_KEY_ACTION_TYPE).toBe('access.delete_api_key');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports ACCESS_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(ACCESS_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports ACCESS_INVITE_RATE_LIMIT', () => {
+    expect(ACCESS_INVITE_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports ACCESS_MODIFY_RATE_LIMIT', () => {
+    expect(ACCESS_MODIFY_RATE_LIMIT).toBe(30);
+  });
+
+  it('exports ACCESS_API_KEY_RATE_LIMIT', () => {
+    expect(ACCESS_API_KEY_RATE_LIMIT).toBe(10);
+  });
+});
+
+describe('TEAM_MEMBER_ROLES', () => {
+  it('contains expected roles', () => {
+    expect(TEAM_MEMBER_ROLES).toEqual(['admin', 'manager', 'analyst', 'editor', 'viewer']);
+  });
+});
+
+describe('validateEmail', () => {
+  it('returns valid email', () => {
+    expect(validateEmail('person@example.com')).toBe('person@example.com');
+  });
+
+  it('trims email', () => {
+    expect(validateEmail('  person@example.com  ')).toBe('person@example.com');
+  });
+
+  it('throws for empty email', () => {
+    expect(() => validateEmail('')).toThrow('must not be empty');
+  });
+
+  it('throws for no at-sign', () => {
+    expect(() => validateEmail('person.example.com')).toThrow('must contain "@"');
+  });
+
+  it('throws for at-sign at start', () => {
+    expect(() => validateEmail('@example.com')).toThrow('must contain "@"');
+  });
+
+  it('throws for at-sign at end', () => {
+    expect(() => validateEmail('person@')).toThrow('must contain "@"');
+  });
+});
+
+describe('validateMemberRole', () => {
+  it('returns valid role', () => {
+    expect(validateMemberRole('admin')).toBe('admin');
+  });
+
+  it('throws for invalid role', () => {
+    expect(() => validateMemberRole('owner')).toThrow('must be one of');
+  });
+});
+
+describe('validateMemberId', () => {
+  it('returns valid ID', () => {
+    expect(validateMemberId('member-123')).toBe('member-123');
+  });
+
+  it('trims ID', () => {
+    expect(validateMemberId('  member-123  ')).toBe('member-123');
+  });
+
+  it('throws for empty ID', () => {
+    expect(() => validateMemberId('')).toThrow('must not be empty');
+  });
+});
+
+describe('validateApiKeyName', () => {
+  it('returns valid name', () => {
+    expect(validateApiKeyName('Server-to-Server')).toBe('Server-to-Server');
+  });
+
+  it('trims name', () => {
+    expect(validateApiKeyName('  Private API Key  ')).toBe('Private API Key');
+  });
+
+  it('accepts minimum length name', () => {
+    expect(validateApiKeyName('a')).toBe('a');
+  });
+
+  it('accepts max length name', () => {
+    const name = 'x'.repeat(200);
+    expect(validateApiKeyName(name)).toBe(name);
+  });
+
+  it('throws for empty name', () => {
+    expect(() => validateApiKeyName('')).toThrow('must not be empty');
+  });
+
+  it('throws for too long name', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateApiKeyName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateApiKeyId', () => {
+  it('returns valid ID', () => {
+    expect(validateApiKeyId('key-123')).toBe('key-123');
+  });
+
+  it('trims ID', () => {
+    expect(validateApiKeyId('  key-123  ')).toBe('key-123');
+  });
+
+  it('throws for empty ID', () => {
+    expect(() => validateApiKeyId('')).toThrow('must not be empty');
+  });
+});
+
+describe('buildProjectTeamUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildProjectTeamUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/project-team-v2',
+    );
+  });
+
+  it('encodes special characters in project name', () => {
+    expect(buildProjectTeamUrl('my project')).toBe('/p/my%20project/project-settings/project-team-v2');
+  });
+});
+
+describe('buildApiKeysUrl', () => {
+  it('builds URL for a simple project name', () => {
+    expect(buildApiKeysUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/project-settings/api');
+  });
+
+  it('encodes special characters in project name', () => {
+    expect(buildApiKeysUrl('my project')).toBe('/p/my%20project/project-settings/api');
+  });
+});
+
+describe('createAccessActionExecutors', () => {
+  it('returns executors for all five action types', () => {
+    const executors = createAccessActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(5);
+    expect(executors[INVITE_TEAM_MEMBER_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_MEMBER_ROLE_ACTION_TYPE]).toBeDefined();
+    expect(executors[REMOVE_TEAM_MEMBER_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_API_KEY_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_API_KEY_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property', () => {
+    const executors = createAccessActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createAccessActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachAccessManagementService', () => {
+  describe('constructor', () => {
+    it('creates instance', () => {
+      const service = new BloomreachAccessManagementService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachAccessManagementService);
+    });
+
+    it('exposes URLs', () => {
+      const service = new BloomreachAccessManagementService('kingdom-of-joakim');
+      expect(service.projectTeamUrl).toBe('/p/kingdom-of-joakim/project-settings/project-team-v2');
+      expect(service.apiKeysUrl).toBe('/p/kingdom-of-joakim/project-settings/api');
+    });
+
+    it('trims project', () => {
+      const service = new BloomreachAccessManagementService('  my-project  ');
+      expect(service.projectTeamUrl).toBe('/p/my-project/project-settings/project-team-v2');
+      expect(service.apiKeysUrl).toBe('/p/my-project/project-settings/api');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachAccessManagementService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('listTeamMembers', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listTeamMembers()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('listApiKeys', () => {
+    it('throws not-yet-implemented error', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listApiKeys()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareInviteTeamMember', () => {
+    it('returns prepared action with valid input', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareInviteTeamMember({
+        project: 'test',
+        email: 'member@example.com',
+        role: 'manager',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'access.invite_team_member',
+          project: 'test',
+          email: 'member@example.com',
+          role: 'manager',
+        }),
+      );
+    });
+
+    it('throws for empty email', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareInviteTeamMember({ project: 'test', email: '', role: 'admin' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid email', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareInviteTeamMember({
+          project: 'test',
+          email: 'invalid-email',
+          role: 'admin',
+        }),
+      ).toThrow('must contain "@"');
+    });
+
+    it('throws for invalid role', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareInviteTeamMember({
+          project: 'test',
+          email: 'member@example.com',
+          role: 'owner',
+        }),
+      ).toThrow('must be one of');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareInviteTeamMember({
+          project: '',
+          email: 'member@example.com',
+          role: 'admin',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateMemberRole', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareUpdateMemberRole({
+        project: 'test',
+        memberId: 'mem-123',
+        role: 'editor',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'access.update_member_role',
+          project: 'test',
+          memberId: 'mem-123',
+          role: 'editor',
+        }),
+      );
+    });
+
+    it('throws for empty memberId', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareUpdateMemberRole({ project: 'test', memberId: '', role: 'editor' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid role', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareUpdateMemberRole({
+          project: 'test',
+          memberId: 'mem-123',
+          role: 'owner',
+        }),
+      ).toThrow('must be one of');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareUpdateMemberRole({ project: '', memberId: 'mem-123', role: 'editor' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareRemoveTeamMember', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareRemoveTeamMember({
+        project: 'test',
+        memberId: 'mem-456',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'access.remove_team_member',
+          project: 'test',
+          memberId: 'mem-456',
+        }),
+      );
+    });
+
+    it('throws for empty memberId', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() => service.prepareRemoveTeamMember({ project: 'test', memberId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() => service.prepareRemoveTeamMember({ project: '', memberId: 'mem-456' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateApiKey', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareCreateApiKey({
+        project: 'test',
+        name: 'My API Key',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'access.create_api_key',
+          project: 'test',
+          name: 'My API Key',
+        }),
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() => service.prepareCreateApiKey({ project: 'test', name: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for too long name', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() =>
+        service.prepareCreateApiKey({
+          project: 'test',
+          name: 'x'.repeat(201),
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() => service.prepareCreateApiKey({ project: '', name: 'My API Key' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareDeleteApiKey', () => {
+    it('returns prepared action', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareDeleteApiKey({
+        project: 'test',
+        apiKeyId: 'key-456',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'access.delete_api_key',
+          project: 'test',
+          apiKeyId: 'key-456',
+        }),
+      );
+    });
+
+    it('throws for empty apiKeyId', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() => service.prepareDeleteApiKey({ project: 'test', apiKeyId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachAccessManagementService('test');
+      expect(() => service.prepareDeleteApiKey({ project: '', apiKeyId: 'key-456' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+});

--- a/packages/core/src/bloomreachAccessManagement.ts
+++ b/packages/core/src/bloomreachAccessManagement.ts
@@ -1,0 +1,359 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+export const INVITE_TEAM_MEMBER_ACTION_TYPE = 'access.invite_team_member';
+export const UPDATE_MEMBER_ROLE_ACTION_TYPE = 'access.update_member_role';
+export const REMOVE_TEAM_MEMBER_ACTION_TYPE = 'access.remove_team_member';
+export const CREATE_API_KEY_ACTION_TYPE = 'access.create_api_key';
+export const DELETE_API_KEY_ACTION_TYPE = 'access.delete_api_key';
+
+export const ACCESS_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const ACCESS_INVITE_RATE_LIMIT = 20;
+export const ACCESS_MODIFY_RATE_LIMIT = 30;
+export const ACCESS_API_KEY_RATE_LIMIT = 10;
+
+export const TEAM_MEMBER_ROLES = ['admin', 'manager', 'analyst', 'editor', 'viewer'] as const;
+export type TeamMemberRole = (typeof TEAM_MEMBER_ROLES)[number];
+
+export interface BloomreachTeamMember {
+  id: string;
+  email: string;
+  name?: string;
+  role: TeamMemberRole;
+  status: string;
+  joinedAt?: string;
+  lastActiveAt?: string;
+  url: string;
+}
+
+export interface BloomreachApiKey {
+  id: string;
+  name: string;
+  publicKey: string;
+  createdAt?: string;
+  createdBy?: string;
+  lastUsedAt?: string;
+  status: string;
+  url: string;
+}
+
+export interface ListTeamMembersInput {
+  project: string;
+}
+
+export interface InviteTeamMemberInput {
+  project: string;
+  email: string;
+  role: string;
+  operatorNote?: string;
+}
+
+export interface UpdateMemberRoleInput {
+  project: string;
+  memberId: string;
+  role: string;
+  operatorNote?: string;
+}
+
+export interface RemoveTeamMemberInput {
+  project: string;
+  memberId: string;
+  operatorNote?: string;
+}
+
+export interface ListApiKeysInput {
+  project: string;
+}
+
+export interface CreateApiKeyInput {
+  project: string;
+  name: string;
+  operatorNote?: string;
+}
+
+export interface DeleteApiKeyInput {
+  project: string;
+  apiKeyId: string;
+  operatorNote?: string;
+}
+
+export interface PreparedAccessAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+const MAX_API_KEY_NAME_LENGTH = 200;
+
+export function validateEmail(email: string): string {
+  const trimmed = email.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Email must not be empty.');
+  }
+
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex <= 0 || atIndex === trimmed.length - 1) {
+    throw new Error('Email must contain "@" with text on both sides.');
+  }
+
+  return trimmed;
+}
+
+export function validateMemberRole(role: string): TeamMemberRole {
+  if (!TEAM_MEMBER_ROLES.includes(role as TeamMemberRole)) {
+    throw new Error(
+      `role must be one of: ${TEAM_MEMBER_ROLES.join(', ')} (got "${role}").`,
+    );
+  }
+  return role as TeamMemberRole;
+}
+
+export function validateMemberId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Member ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateApiKeyName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error('API key name must not be empty.');
+  }
+  if (trimmed.length > MAX_API_KEY_NAME_LENGTH) {
+    throw new Error(
+      `API key name must not exceed ${MAX_API_KEY_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateApiKeyId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('API key ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function buildProjectTeamUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/project-team-v2`;
+}
+
+export function buildApiKeysUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/api`;
+}
+
+export interface AccessActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class InviteTeamMemberExecutor implements AccessActionExecutor {
+  readonly actionType = INVITE_TEAM_MEMBER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'InviteTeamMemberExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateMemberRoleExecutor implements AccessActionExecutor {
+  readonly actionType = UPDATE_MEMBER_ROLE_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateMemberRoleExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class RemoveTeamMemberExecutor implements AccessActionExecutor {
+  readonly actionType = REMOVE_TEAM_MEMBER_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'RemoveTeamMemberExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateApiKeyExecutor implements AccessActionExecutor {
+  readonly actionType = CREATE_API_KEY_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateApiKeyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteApiKeyExecutor implements AccessActionExecutor {
+  readonly actionType = DELETE_API_KEY_ACTION_TYPE;
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteApiKeyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createAccessActionExecutors(): Record<string, AccessActionExecutor> {
+  return {
+    [INVITE_TEAM_MEMBER_ACTION_TYPE]: new InviteTeamMemberExecutor(),
+    [UPDATE_MEMBER_ROLE_ACTION_TYPE]: new UpdateMemberRoleExecutor(),
+    [REMOVE_TEAM_MEMBER_ACTION_TYPE]: new RemoveTeamMemberExecutor(),
+    [CREATE_API_KEY_ACTION_TYPE]: new CreateApiKeyExecutor(),
+    [DELETE_API_KEY_ACTION_TYPE]: new DeleteApiKeyExecutor(),
+  };
+}
+
+export class BloomreachAccessManagementService {
+  private readonly teamUrl: string;
+  private readonly keysUrl: string;
+
+  constructor(project: string) {
+    const validatedProject = validateProject(project);
+    this.teamUrl = buildProjectTeamUrl(validatedProject);
+    this.keysUrl = buildApiKeysUrl(validatedProject);
+  }
+
+  get projectTeamUrl(): string {
+    return this.teamUrl;
+  }
+
+  get apiKeysUrl(): string {
+    return this.keysUrl;
+  }
+
+  async listTeamMembers(input?: ListTeamMembersInput): Promise<BloomreachTeamMember[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listTeamMembers: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listApiKeys(input?: ListApiKeysInput): Promise<BloomreachApiKey[]> {
+    if (input !== undefined) {
+      validateProject(input.project);
+    }
+
+    throw new Error(
+      'listApiKeys: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareInviteTeamMember(input: InviteTeamMemberInput): PreparedAccessAction {
+    const project = validateProject(input.project);
+    const email = validateEmail(input.email);
+    const role = validateMemberRole(input.role);
+
+    const preview = {
+      action: INVITE_TEAM_MEMBER_ACTION_TYPE,
+      project,
+      email,
+      role,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateMemberRole(input: UpdateMemberRoleInput): PreparedAccessAction {
+    const project = validateProject(input.project);
+    const memberId = validateMemberId(input.memberId);
+    const role = validateMemberRole(input.role);
+
+    const preview = {
+      action: UPDATE_MEMBER_ROLE_ACTION_TYPE,
+      project,
+      memberId,
+      role,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareRemoveTeamMember(input: RemoveTeamMemberInput): PreparedAccessAction {
+    const project = validateProject(input.project);
+    const memberId = validateMemberId(input.memberId);
+
+    const preview = {
+      action: REMOVE_TEAM_MEMBER_ACTION_TYPE,
+      project,
+      memberId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateApiKey(input: CreateApiKeyInput): PreparedAccessAction {
+    const project = validateProject(input.project);
+    const name = validateApiKeyName(input.name);
+
+    const preview = {
+      action: CREATE_API_KEY_ACTION_TYPE,
+      project,
+      name,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteApiKey(input: DeleteApiKeyInput): PreparedAccessAction {
+    const project = validateProject(input.project);
+    const apiKeyId = validateApiKeyId(input.apiKeyId);
+
+    const preview = {
+      action: DELETE_API_KEY_ACTION_TYPE,
+      project,
+      apiKeyId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from './bloomreachSecuritySettings.js';
 export * from './bloomreachEvaluationSettings.js';
 export * from './bloomreachWeblayers.js';
 export * from './bloomreachUseCases.js';
+export * from './bloomreachAccessManagement.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Implements the Access Management feature module (#56) for managing project team members, roles, and API access credentials.

## Changes

### Core Module (`packages/core/src/bloomreachAccessManagement.ts`)
- **Team Member Management**: list, invite, update role, remove — all mutations use two-phase commit pattern
- **API Key Management**: list, create, delete — all mutations use two-phase commit pattern
- 5 action type constants, 4 rate limit constants
- Role system: admin, manager, analyst, editor, viewer
- Full input validation (email, role, member ID, API key name/ID)
- URL builders for `/p/{project}/project-settings/project-team-v2` and `/p/{project}/project-settings/api`
- 5 action executors (stubbed pending browser automation infrastructure)

### CLI (`packages/cli/src/bin/bloomreach.ts`)
7 new commands under `bloomreach access`:
- `list-members` — List team members with roles
- `invite` — Prepare team member invitation
- `update-role` — Prepare role update
- `remove-member` — Prepare member removal
- `list-api-keys` — List API credentials
- `create-api-key` — Prepare API key creation
- `delete-api-key` — Prepare API key deletion

### Tests (`packages/core/src/__tests__/bloomreachAccessManagement.test.ts`)
Comprehensive unit tests covering all constants, validators, executors, and service methods.

## Quality Gates
- ✅ `npm run typecheck` — zero errors
- ✅ `npm run lint` — zero errors
- ✅ `npm test` — **2050 tests pass** (23 test files)
- ✅ `npm run build` — successful

## Pattern Compliance
Follows the exact established feature module convention used by all existing modules (dashboards, scenarios, email campaigns, etc.).

Closes #56
