### PR TITLE
feat: add campaign settings management (#57)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import {
   BloomreachAssetManagerService,
   BloomreachCampaignCalendarService,
+  BloomreachCampaignSettingsService,
   BloomreachClient,
   BloomreachCustomersService,
   BloomreachDataManagerService,
@@ -2402,7 +2403,11 @@ geoAnalyses
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--name <name>', 'Geo analysis name')
   .requiredOption('--attribute <attribute>', 'Event or customer attribute for geographic mapping')
-  .option('--granularity <granularity>', 'Geographic granularity (country, region, city)', 'country')
+  .option(
+    '--granularity <granularity>',
+    'Geographic granularity (country, region, city)',
+    'country',
+  )
   .option('--customer-attributes <json>', 'JSON object of customer attribute filters')
   .option('--event-properties <json>', 'JSON object of event property filters')
   .option('--note <note>', 'Operator note for audit trail')
@@ -2537,9 +2542,7 @@ geoAnalyses
     },
   );
 
-const customers = program
-  .command('customers')
-  .description('Manage Bloomreach customer profiles');
+const customers = program.command('customers').description('Manage Bloomreach customer profiles');
 
 customers
   .command('list')
@@ -2548,38 +2551,36 @@ customers
   .option('--limit <limit>', 'Maximum number of customers to return', '50')
   .option('--offset <offset>', 'Offset for pagination', '0')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; limit: string; offset: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachCustomersService(options.project);
-        const result = await service.listCustomers({
-          project: options.project,
-          limit: parseInt(options.limit, 10),
-          offset: parseInt(options.offset, 10),
-        });
+  .action(async (options: { project: string; limit: string; offset: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCustomersService(options.project);
+      const result = await service.listCustomers({
+        project: options.project,
+        limit: parseInt(options.limit, 10),
+        offset: parseInt(options.offset, 10),
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No customers found.');
-            return;
-          }
-
-          for (const customer of result) {
-            const identifiers = Object.entries(customer.customerIds)
-              .map(([key, value]) => `${key}=${value}`)
-              .join(', ');
-            console.log(`  ${identifiers || '(no customer IDs)'}`);
-            console.log(`    Properties: ${Object.keys(customer.properties).length}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No customers found.');
+          return;
         }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+
+        for (const customer of result) {
+          const identifiers = Object.entries(customer.customerIds)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(', ');
+          console.log(`  ${identifiers || '(no customer IDs)'}`);
+          console.log(`    Properties: ${Object.keys(customer.properties).length}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 customers
   .command('search')
@@ -2637,12 +2638,7 @@ customers
   .option('--id-type <idType>', 'Identifier type', 'registered')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      customerId: string;
-      idType: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; customerId: string; idType: string; json?: boolean }) => {
       try {
         const service = new BloomreachCustomersService(options.project);
         const result = await service.viewCustomer({
@@ -2818,37 +2814,35 @@ vouchers
   .option('--limit <limit>', 'Maximum number of pools to return', '50')
   .option('--offset <offset>', 'Offset for pagination', '0')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; limit: string; offset: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachVouchersService(options.project);
-        const result = await service.listVoucherPools({
-          project: options.project,
-          limit: parseInt(options.limit, 10),
-          offset: parseInt(options.offset, 10),
-        });
+  .action(async (options: { project: string; limit: string; offset: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachVouchersService(options.project);
+      const result = await service.listVoucherPools({
+        project: options.project,
+        limit: parseInt(options.limit, 10),
+        offset: parseInt(options.offset, 10),
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No voucher pools found.');
-            return;
-          }
-          for (const pool of result) {
-            console.log(`  ${pool.name}`);
-            console.log(`    Status:   ${pool.status}`);
-            console.log(`    Vouchers: ${pool.voucherCount} total, ${pool.redeemedCount} redeemed`);
-            console.log(`    ID:       ${pool.id}`);
-            console.log(`    URL:      ${pool.url}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No voucher pools found.');
+          return;
         }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+        for (const pool of result) {
+          console.log(`  ${pool.name}`);
+          console.log(`    Status:   ${pool.status}`);
+          console.log(`    Vouchers: ${pool.voucherCount} total, ${pool.redeemedCount} redeemed`);
+          console.log(`    ID:       ${pool.id}`);
+          console.log(`    URL:      ${pool.url}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 vouchers
   .command('view-status')
@@ -2858,12 +2852,7 @@ vouchers
   .option('--voucher-code <code>', 'Specific voucher code to check')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      poolId: string;
-      voucherCode?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; poolId: string; voucherCode?: string; json?: boolean }) => {
       try {
         const service = new BloomreachVouchersService(options.project);
         const result = await service.viewVoucherStatus({
@@ -2921,9 +2910,7 @@ vouchers
       json?: boolean;
     }) => {
       try {
-        const voucherCodes = options.codes
-          ? (JSON.parse(options.codes) as string[])
-          : undefined;
+        const voucherCodes = options.codes ? (JSON.parse(options.codes) as string[]) : undefined;
         const autoGenerateCount = options.autoGenerate
           ? parseInt(options.autoGenerate, 10)
           : undefined;
@@ -2955,7 +2942,9 @@ vouchers
         } else {
           console.log('Voucher pool creation prepared.');
           console.log(`  Name:     ${options.name}`);
-          console.log(`  Vouchers: ${result.preview.voucherCount} (${result.preview.voucherSource})`);
+          console.log(
+            `  Vouchers: ${result.preview.voucherCount} (${result.preview.voucherSource})`,
+          );
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
@@ -2988,9 +2977,7 @@ vouchers
       json?: boolean;
     }) => {
       try {
-        const voucherCodes = options.codes
-          ? (JSON.parse(options.codes) as string[])
-          : undefined;
+        const voucherCodes = options.codes ? (JSON.parse(options.codes) as string[]) : undefined;
         const autoGenerateCount = options.autoGenerate
           ? parseInt(options.autoGenerate, 10)
           : undefined;
@@ -3009,7 +2996,9 @@ vouchers
         } else {
           console.log('Add vouchers prepared.');
           console.log(`  Pool:     ${options.poolId}`);
-          console.log(`  Vouchers: ${result.preview.voucherCount} (${result.preview.voucherSource})`);
+          console.log(
+            `  Vouchers: ${result.preview.voucherCount} (${result.preview.voucherSource})`,
+          );
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
@@ -3030,41 +3019,37 @@ vouchers
   .requiredOption('--pool-id <id>', 'Voucher pool ID to delete')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; poolId: string; note?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachVouchersService(options.project);
-        const result = service.prepareDeleteVoucherPool({
-          project: options.project,
-          poolId: options.poolId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; poolId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachVouchersService(options.project);
+      const result = service.prepareDeleteVoucherPool({
+        project: options.project,
+        poolId: options.poolId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Voucher pool deletion prepared.');
-          console.log(`  Pool:    ${options.poolId}`);
-          console.log(`  Token:   ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Voucher pool deletion prepared.');
+        console.log(`  Pool:    ${options.poolId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 const assets = program
   .command('assets')
   .description('Manage Asset Manager templates, snippets, and files');
 
-const assetEmailTemplates = assets
-  .command('email-templates')
-  .description('Manage email templates');
+const assetEmailTemplates = assets.command('email-templates').description('Manage email templates');
 
 assetEmailTemplates
   .command('list')
@@ -3298,9 +3283,7 @@ assetBlocks
     },
   );
 
-const assetCustomRows = assets
-  .command('custom-rows')
-  .description('Manage custom rows');
+const assetCustomRows = assets.command('custom-rows').description('Manage custom rows');
 
 assetCustomRows
   .command('list')
@@ -3600,33 +3583,31 @@ assetFiles
   .requiredOption('--file-id <id>', 'File ID')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; fileId: string; note?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachAssetManagerService(options.project);
-        const result = service.prepareDeleteFile({
-          project: options.project,
-          fileId: options.fileId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; fileId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAssetManagerService(options.project);
+      const result = service.prepareDeleteFile({
+        project: options.project,
+        fileId: options.fileId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('File deletion prepared.');
-          console.log(`  File:    ${options.fileId}`);
-          console.log(`  Token:   ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('File deletion prepared.');
+        console.log(`  File:    ${options.fileId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 assets
   .command('clone')
@@ -4067,7 +4048,10 @@ metrics
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--name <name>', 'Metric name')
   .requiredOption('--event-name <eventName>', 'Event name for aggregation')
-  .requiredOption('--aggregation-type <type>', 'Aggregation type (sum, count, average, min, max, unique)')
+  .requiredOption(
+    '--aggregation-type <type>',
+    'Aggregation type (sum, count, average, min, max, unique)',
+  )
   .option('--property-name <prop>', 'Event property name for property-based aggregations')
   .option('--description <desc>', 'Metric description')
   .option('--filters <json>', 'JSON object of metric filters')
@@ -4128,7 +4112,10 @@ metrics
   .requiredOption('--metric-id <id>', 'Metric ID')
   .option('--name <name>', 'New metric name')
   .option('--event-name <eventName>', 'New event name for aggregation')
-  .option('--aggregation-type <type>', 'New aggregation type (sum, count, average, min, max, unique)')
+  .option(
+    '--aggregation-type <type>',
+    'New aggregation type (sum, count, average, min, max, unique)',
+  )
   .option('--property-name <prop>', 'New event property name for property-based aggregations')
   .option('--description <desc>', 'New metric description')
   .option('--filters <json>', 'JSON object of metric filters')
@@ -4932,7 +4919,10 @@ exportsCmd
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--name <name>', 'Export name')
   .requiredOption('--export-type <type>', 'Export type (customers, events)')
-  .requiredOption('--data-selection <json>', 'JSON object: {"attributes":["a"],"events":["b"],"segments":["c"]}')
+  .requiredOption(
+    '--data-selection <json>',
+    'JSON object: {"attributes":["a"],"events":["b"],"segments":["c"]}',
+  )
   .requiredOption('--destination <json>', 'JSON object: {"type":"sftp","host":"...","path":"..."}')
   .option('--schedule <json>', 'JSON object: {"frequency":"daily","time":"09:00","timezone":"UTC"}')
   .option('--note <note>', 'Operator note for audit trail')
@@ -5022,11 +5012,20 @@ exportsCmd
   .description('Prepare configuring a recurring schedule (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--export-id <id>', 'Export ID')
-  .requiredOption('--schedule <json>', 'JSON object: {"frequency":"weekly","daysOfWeek":[1,3,5],"time":"08:00","timezone":"UTC"}')
+  .requiredOption(
+    '--schedule <json>',
+    'JSON object: {"frequency":"weekly","daysOfWeek":[1,3,5],"time":"08:00","timezone":"UTC"}',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: { project: string; exportId: string; schedule: string; note?: string; json?: boolean }) => {
+    async (options: {
+      project: string;
+      exportId: string;
+      schedule: string;
+      note?: string;
+      json?: boolean;
+    }) => {
       try {
         const schedule = JSON.parse(options.schedule) as ExportSchedule;
 
@@ -5103,40 +5102,38 @@ integrations
   )
   .option('--status <status>', 'Filter by status (active, inactive, error, pending)')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; type?: string; status?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachIntegrationsService(options.project);
-        const input: { project: string; type?: string; status?: string } = {
-          project: options.project,
-        };
-        if (options.type) input.type = options.type;
-        if (options.status) input.status = options.status;
+  .action(async (options: { project: string; type?: string; status?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachIntegrationsService(options.project);
+      const input: { project: string; type?: string; status?: string } = {
+        project: options.project,
+      };
+      if (options.type) input.type = options.type;
+      if (options.status) input.status = options.status;
 
-        const result = await service.listIntegrations(input);
+      const result = await service.listIntegrations(input);
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No integrations found.');
-            return;
-          }
-          for (const integration of result) {
-            console.log(`  ${integration.name}`);
-            console.log(`    Type:     ${integration.type}`);
-            console.log(`    Provider: ${integration.provider}`);
-            console.log(`    Status:   ${integration.status}`);
-            console.log(`    ID:       ${integration.id}`);
-            console.log(`    URL:      ${integration.url}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No integrations found.');
+          return;
         }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+        for (const integration of result) {
+          console.log(`  ${integration.name}`);
+          console.log(`    Type:     ${integration.type}`);
+          console.log(`    Provider: ${integration.provider}`);
+          console.log(`    Status:   ${integration.status}`);
+          console.log(`    ID:       ${integration.id}`);
+          console.log(`    URL:      ${integration.url}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 integrations
   .command('view')
@@ -5892,37 +5889,35 @@ projectSettings
   .requiredOption('--accepted <accepted>', 'Whether terms are accepted (true or false)')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; accepted: string; note?: string; json?: boolean }) => {
-      try {
-        if (options.accepted !== 'true' && options.accepted !== 'false') {
-          throw new Error('Option --accepted must be "true" or "false".');
-        }
-
-        const service = new BloomreachProjectSettingsService(options.project);
-        const result = service.prepareUpdateTermsAndConditions({
-          project: options.project,
-          accepted: options.accepted === 'true',
-          operatorNote: options.note,
-        });
-
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Project terms and conditions update prepared.');
-          console.log(`  Accepted: ${options.accepted}`);
-          console.log(`  Token:    ${result.confirmToken}`);
-          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+  .action(async (options: { project: string; accepted: string; note?: string; json?: boolean }) => {
+    try {
+      if (options.accepted !== 'true' && options.accepted !== 'false') {
+        throw new Error('Option --accepted must be "true" or "false".');
       }
-    },
-  );
+
+      const service = new BloomreachProjectSettingsService(options.project);
+      const result = service.prepareUpdateTermsAndConditions({
+        project: options.project,
+        accepted: options.accepted === 'true',
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Project terms and conditions update prepared.');
+        console.log(`  Accepted: ${options.accepted}`);
+        console.log(`  Token:    ${result.confirmToken}`);
+        console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 const projectSettingsTags = projectSettings.command('tags').description('Manage custom tags');
 
@@ -6249,6 +6244,1568 @@ projectSettingsVariables
           console.log(`  Variable: ${options.variableName}`);
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const campaignSettings = program
+  .command('campaign-settings')
+  .description('Manage Bloomreach campaign settings');
+
+campaignSettings
+  .command('defaults')
+  .description('View campaign defaults')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.viewCampaignDefaults({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Campaign defaults');
+        if (result.defaultSenderName) {
+          console.log(`  Default sender name:  ${result.defaultSenderName}`);
+        }
+        if (result.defaultSenderEmail) {
+          console.log(`  Default sender email: ${result.defaultSenderEmail}`);
+        }
+        if (result.defaultReplyToEmail) {
+          console.log(`  Default reply-to:     ${result.defaultReplyToEmail}`);
+        }
+        if (result.defaultUtmSource) {
+          console.log(`  Default UTM source:   ${result.defaultUtmSource}`);
+        }
+        if (result.defaultUtmMedium) {
+          console.log(`  Default UTM medium:   ${result.defaultUtmMedium}`);
+        }
+        if (result.defaultUtmCampaign) {
+          console.log(`  Default UTM campaign: ${result.defaultUtmCampaign}`);
+        }
+        console.log(`  URL:                  ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettings
+  .command('update-defaults')
+  .description('Prepare campaign defaults update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--default-sender-name <name>', 'Default sender name')
+  .option('--default-sender-email <email>', 'Default sender email address')
+  .option('--default-reply-to-email <email>', 'Default reply-to email address')
+  .option('--default-utm-source <source>', 'Default UTM source parameter')
+  .option('--default-utm-medium <medium>', 'Default UTM medium parameter')
+  .option('--default-utm-campaign <campaign>', 'Default UTM campaign parameter')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      defaultSenderName?: string;
+      defaultSenderEmail?: string;
+      defaultReplyToEmail?: string;
+      defaultUtmSource?: string;
+      defaultUtmMedium?: string;
+      defaultUtmCampaign?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateCampaignDefaults({
+          project: options.project,
+          defaultSenderName: options.defaultSenderName,
+          defaultSenderEmail: options.defaultSenderEmail,
+          defaultReplyToEmail: options.defaultReplyToEmail,
+          defaultUtmSource: options.defaultUtmSource,
+          defaultUtmMedium: options.defaultUtmMedium,
+          defaultUtmCampaign: options.defaultUtmCampaign,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Campaign defaults update prepared.');
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const campaignSettingsTimezones = campaignSettings
+  .command('timezones')
+  .description('Manage configured timezones');
+
+campaignSettingsTimezones
+  .command('list')
+  .description('List configured timezones')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listTimezones({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No timezones found.');
+          return;
+        }
+        for (const timezone of result) {
+          console.log(`  ${timezone.name}`);
+          console.log(`    ID: ${timezone.id}`);
+          if (timezone.utcOffset) {
+            console.log(`    UTC Offset: ${timezone.utcOffset}`);
+          }
+          if (timezone.isDefault) {
+            console.log('    Default: yes');
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsTimezones
+  .command('create')
+  .description('Prepare timezone creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Timezone name (IANA format, e.g. "Europe/Prague")')
+  .option('--utc-offset <offset>', 'UTC offset (e.g. "+01:00")')
+  .option('--is-default', 'Set as default timezone')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      utcOffset?: string;
+      isDefault?: boolean;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateTimezone({
+          project: options.project,
+          name: options.name,
+          utcOffset: options.utcOffset,
+          isDefault: options.isDefault,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Timezone creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsTimezones
+  .command('update')
+  .description('Prepare timezone update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--timezone-id <id>', 'Timezone ID')
+  .option('--name <name>', 'Timezone name (IANA format, e.g. "Europe/Prague")')
+  .option('--utc-offset <offset>', 'UTC offset (e.g. "+01:00")')
+  .option('--is-default', 'Set as default timezone')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      timezoneId: string;
+      name?: string;
+      utcOffset?: string;
+      isDefault?: boolean;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateTimezone({
+          project: options.project,
+          timezoneId: options.timezoneId,
+          name: options.name,
+          utcOffset: options.utcOffset,
+          isDefault: options.isDefault,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Timezone update prepared.');
+          console.log(`  Timezone ID: ${options.timezoneId}`);
+          if (options.name) {
+            console.log(`  Name:        ${options.name}`);
+          }
+          console.log(`  Token:       ${result.confirmToken}`);
+          console.log(`  Expires:     ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsTimezones
+  .command('delete')
+  .description('Prepare timezone deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--timezone-id <id>', 'Timezone ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; timezoneId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareDeleteTimezone({
+          project: options.project,
+          timezoneId: options.timezoneId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Timezone deletion prepared.');
+          console.log(`  Timezone ID: ${options.timezoneId}`);
+          console.log(`  Token:       ${result.confirmToken}`);
+          console.log(`  Expires:     ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const campaignSettingsLanguages = campaignSettings
+  .command('languages')
+  .description('Manage configured languages');
+
+campaignSettingsLanguages
+  .command('list')
+  .description('List configured languages')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listLanguages({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No languages found.');
+          return;
+        }
+        for (const language of result) {
+          console.log(`  ${language.name}`);
+          console.log(`    Code: ${language.code}`);
+          if (language.isDefault) {
+            console.log('    Default: yes');
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsLanguages
+  .command('create')
+  .description('Prepare language creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--code <code>', 'Language code (ISO 639-1, e.g. "en")')
+  .requiredOption('--name <name>', 'Language name')
+  .option('--is-default', 'Set as default language')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      code: string;
+      name: string;
+      isDefault?: boolean;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateLanguage({
+          project: options.project,
+          code: options.code,
+          name: options.name,
+          isDefault: options.isDefault,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Language creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsLanguages
+  .command('update')
+  .description('Prepare language update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--language-code <code>', 'Language code to update')
+  .option('--code <code>', 'Updated language code (ISO 639-1, e.g. "en")')
+  .option('--name <name>', 'Updated language name')
+  .option('--is-default', 'Set as default language')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      languageCode: string;
+      code?: string;
+      name?: string;
+      isDefault?: boolean;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateLanguage({
+          project: options.project,
+          languageCode: options.languageCode,
+          code: options.code,
+          name: options.name,
+          isDefault: options.isDefault,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Language update prepared.');
+          console.log(`  Language: ${options.languageCode}`);
+          if (options.name) {
+            console.log(`  Name:     ${options.name}`);
+          }
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsLanguages
+  .command('delete')
+  .description('Prepare language deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--language-code <code>', 'Language code')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; languageCode: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareDeleteLanguage({
+          project: options.project,
+          languageCode: options.languageCode,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Language deletion prepared.');
+          console.log(`  Language: ${options.languageCode}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const campaignSettingsFonts = campaignSettings
+  .command('fonts')
+  .description('Manage configured fonts');
+
+campaignSettingsFonts
+  .command('list')
+  .description('List configured fonts')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listFonts({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No fonts found.');
+          return;
+        }
+        for (const font of result) {
+          console.log(`  ${font.name}`);
+          console.log(`    ID: ${font.id}`);
+          console.log(`    Type: ${font.type}`);
+          if (font.fileUrl) {
+            console.log(`    File URL: ${font.fileUrl}`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsFonts
+  .command('create')
+  .description('Prepare font creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Font name')
+  .requiredOption('--type <type>', 'Font type')
+  .option('--file-url <url>', 'Font file URL')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      type: string;
+      fileUrl?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateFont({
+          project: options.project,
+          name: options.name,
+          type: options.type,
+          fileUrl: options.fileUrl,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Font creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsFonts
+  .command('update')
+  .description('Prepare font update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--font-id <id>', 'Font ID')
+  .option('--name <name>', 'Updated font name')
+  .option('--type <type>', 'Updated font type')
+  .option('--file-url <url>', 'Updated font file URL')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      fontId: string;
+      name?: string;
+      type?: string;
+      fileUrl?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateFont({
+          project: options.project,
+          fontId: options.fontId,
+          name: options.name,
+          type: options.type,
+          fileUrl: options.fileUrl,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Font update prepared.');
+          console.log(`  Font ID: ${options.fontId}`);
+          if (options.name) {
+            console.log(`  Name:    ${options.name}`);
+          }
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsFonts
+  .command('delete')
+  .description('Prepare font deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--font-id <id>', 'Font ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; fontId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = service.prepareDeleteFont({
+        project: options.project,
+        fontId: options.fontId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Font deletion prepared.');
+        console.log(`  Font ID: ${options.fontId}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const campaignSettingsThroughput = campaignSettings
+  .command('throughput')
+  .description('Manage throughput policies');
+
+campaignSettingsThroughput
+  .command('list')
+  .description('List throughput policies')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listThroughputPolicies({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No throughput policies found.');
+          return;
+        }
+        for (const policy of result) {
+          console.log(`  ${policy.name}`);
+          console.log(`    ID: ${policy.id}`);
+          if (policy.channel) {
+            console.log(`    Channel: ${policy.channel}`);
+          }
+          if (policy.maxRate !== undefined) {
+            console.log(`    Max rate: ${policy.maxRate}`);
+          }
+          if (policy.periodSeconds !== undefined) {
+            console.log(`    Period seconds: ${policy.periodSeconds}`);
+          }
+          if (policy.description) {
+            console.log(`    Description: ${policy.description}`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsThroughput
+  .command('create')
+  .description('Prepare throughput policy creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Policy name')
+  .option('--channel <channel>', 'Channel (email, sms, push, etc.)')
+  .option('--max-rate <rate>', 'Maximum send rate per period')
+  .option('--period-seconds <seconds>', 'Rate limit period in seconds')
+  .option('--description <description>', 'Human-readable description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      channel?: string;
+      maxRate?: string;
+      periodSeconds?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const maxRate = options.maxRate !== undefined ? parseInt(options.maxRate, 10) : undefined;
+        const periodSeconds =
+          options.periodSeconds !== undefined ? parseInt(options.periodSeconds, 10) : undefined;
+
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateThroughputPolicy({
+          project: options.project,
+          name: options.name,
+          channel: options.channel,
+          maxRate,
+          periodSeconds,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Throughput policy creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsThroughput
+  .command('update')
+  .description('Prepare throughput policy update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--policy-id <id>', 'Policy ID')
+  .option('--name <name>', 'Updated policy name')
+  .option('--channel <channel>', 'Updated channel')
+  .option('--max-rate <rate>', 'Updated maximum send rate per period')
+  .option('--period-seconds <seconds>', 'Updated rate limit period in seconds')
+  .option('--description <description>', 'Updated human-readable description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      policyId: string;
+      name?: string;
+      channel?: string;
+      maxRate?: string;
+      periodSeconds?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const maxRate = options.maxRate !== undefined ? parseInt(options.maxRate, 10) : undefined;
+        const periodSeconds =
+          options.periodSeconds !== undefined ? parseInt(options.periodSeconds, 10) : undefined;
+
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateThroughputPolicy({
+          project: options.project,
+          policyId: options.policyId,
+          name: options.name,
+          channel: options.channel,
+          maxRate,
+          periodSeconds,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Throughput policy update prepared.');
+          console.log(`  Policy ID: ${options.policyId}`);
+          if (options.name) {
+            console.log(`  Name:      ${options.name}`);
+          }
+          console.log(`  Token:     ${result.confirmToken}`);
+          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsThroughput
+  .command('delete')
+  .description('Prepare throughput policy deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--policy-id <id>', 'Policy ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; policyId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = service.prepareDeleteThroughputPolicy({
+        project: options.project,
+        policyId: options.policyId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Throughput policy deletion prepared.');
+        console.log(`  Policy ID: ${options.policyId}`);
+        console.log(`  Token:     ${result.confirmToken}`);
+        console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const campaignSettingsFrequency = campaignSettings
+  .command('frequency')
+  .description('Manage frequency policies');
+
+campaignSettingsFrequency
+  .command('list')
+  .description('List frequency policies')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listFrequencyPolicies({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No frequency policies found.');
+          return;
+        }
+        for (const policy of result) {
+          console.log(`  ${policy.name}`);
+          console.log(`    ID: ${policy.id}`);
+          if (policy.policyType) {
+            console.log(`    Policy type: ${policy.policyType}`);
+          }
+          if (policy.maxSends !== undefined) {
+            console.log(`    Max sends: ${policy.maxSends}`);
+          }
+          if (policy.windowHours !== undefined) {
+            console.log(`    Window hours: ${policy.windowHours}`);
+          }
+          if (policy.channels && policy.channels.length > 0) {
+            console.log(`    Channels: ${policy.channels.join(', ')}`);
+          }
+          if (policy.description) {
+            console.log(`    Description: ${policy.description}`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsFrequency
+  .command('create')
+  .description('Prepare frequency policy creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Policy name')
+  .option('--policy-type <type>', 'Policy type (global or per-campaign)')
+  .option('--max-sends <count>', 'Maximum number of sends allowed')
+  .option('--window-hours <hours>', 'Frequency window in hours')
+  .option('--channels <channels>', 'Comma-separated channels (email,sms,push)')
+  .option('--description <description>', 'Human-readable description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      policyType?: string;
+      maxSends?: string;
+      windowHours?: string;
+      channels?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const maxSends =
+          options.maxSends !== undefined ? parseInt(options.maxSends, 10) : undefined;
+        const windowHours =
+          options.windowHours !== undefined ? parseInt(options.windowHours, 10) : undefined;
+        const channels =
+          options.channels !== undefined
+            ? options.channels
+                .split(',')
+                .map((channel) => channel.trim())
+                .filter((channel) => channel.length > 0)
+            : undefined;
+
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateFrequencyPolicy({
+          project: options.project,
+          name: options.name,
+          policyType: options.policyType,
+          maxSends,
+          windowHours,
+          channels,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Frequency policy creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsFrequency
+  .command('update')
+  .description('Prepare frequency policy update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--policy-id <id>', 'Policy ID')
+  .option('--name <name>', 'Updated policy name')
+  .option('--policy-type <type>', 'Updated policy type')
+  .option('--max-sends <count>', 'Updated maximum sends')
+  .option('--window-hours <hours>', 'Updated frequency window in hours')
+  .option('--channels <channels>', 'Updated comma-separated channels')
+  .option('--description <description>', 'Updated human-readable description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      policyId: string;
+      name?: string;
+      policyType?: string;
+      maxSends?: string;
+      windowHours?: string;
+      channels?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const maxSends =
+          options.maxSends !== undefined ? parseInt(options.maxSends, 10) : undefined;
+        const windowHours =
+          options.windowHours !== undefined ? parseInt(options.windowHours, 10) : undefined;
+        const channels =
+          options.channels !== undefined
+            ? options.channels
+                .split(',')
+                .map((channel) => channel.trim())
+                .filter((channel) => channel.length > 0)
+            : undefined;
+
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateFrequencyPolicy({
+          project: options.project,
+          policyId: options.policyId,
+          name: options.name,
+          policyType: options.policyType,
+          maxSends,
+          windowHours,
+          channels,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Frequency policy update prepared.');
+          console.log(`  Policy ID: ${options.policyId}`);
+          if (options.name) {
+            console.log(`  Name:      ${options.name}`);
+          }
+          console.log(`  Token:     ${result.confirmToken}`);
+          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsFrequency
+  .command('delete')
+  .description('Prepare frequency policy deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--policy-id <id>', 'Policy ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; policyId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = service.prepareDeleteFrequencyPolicy({
+        project: options.project,
+        policyId: options.policyId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Frequency policy deletion prepared.');
+        console.log(`  Policy ID: ${options.policyId}`);
+        console.log(`  Token:     ${result.confirmToken}`);
+        console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const campaignSettingsConsents = campaignSettings
+  .command('consents')
+  .description('Manage consent categories');
+
+campaignSettingsConsents
+  .command('list')
+  .description('List consents')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listConsents({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No consents found.');
+          return;
+        }
+        for (const consent of result) {
+          console.log(`  ${consent.category}`);
+          console.log(`    ID: ${consent.id}`);
+          if (consent.description) {
+            console.log(`    Description: ${consent.description}`);
+          }
+          if (consent.consentType) {
+            console.log(`    Consent type: ${consent.consentType}`);
+          }
+          if (consent.legitimateInterest !== undefined) {
+            console.log(`    Legitimate interest: ${consent.legitimateInterest}`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsConsents
+  .command('create')
+  .description('Prepare consent creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--category <category>', 'Consent category')
+  .option('--description <description>', 'Human-readable description')
+  .option('--consent-type <type>', 'Consent type (opt-in or opt-out)')
+  .option('--legitimate-interest', 'Mark consent as legitimate interest')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      category: string;
+      description?: string;
+      consentType?: string;
+      legitimateInterest?: boolean;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateConsent({
+          project: options.project,
+          category: options.category,
+          description: options.description,
+          consentType: options.consentType,
+          legitimateInterest: options.legitimateInterest,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Consent creation prepared.');
+          console.log(`  Name:    ${options.category}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsConsents
+  .command('update')
+  .description('Prepare consent update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--consent-id <id>', 'Consent ID')
+  .option('--category <category>', 'Updated consent category')
+  .option('--description <description>', 'Updated description')
+  .option('--consent-type <type>', 'Updated consent type')
+  .option('--legitimate-interest', 'Mark consent as legitimate interest')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      consentId: string;
+      category?: string;
+      description?: string;
+      consentType?: string;
+      legitimateInterest?: boolean;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateConsent({
+          project: options.project,
+          consentId: options.consentId,
+          category: options.category,
+          description: options.description,
+          consentType: options.consentType,
+          legitimateInterest: options.legitimateInterest,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Consent update prepared.');
+          console.log(`  Consent ID: ${options.consentId}`);
+          if (options.category) {
+            console.log(`  Category:   ${options.category}`);
+          }
+          console.log(`  Token:      ${result.confirmToken}`);
+          console.log(`  Expires:    ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsConsents
+  .command('delete')
+  .description('Prepare consent deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--consent-id <id>', 'Consent ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; consentId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareDeleteConsent({
+          project: options.project,
+          consentId: options.consentId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Consent deletion prepared.');
+          console.log(`  Consent ID: ${options.consentId}`);
+          console.log(`  Token:      ${result.confirmToken}`);
+          console.log(`  Expires:    ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const campaignSettingsUrlLists = campaignSettings
+  .command('url-lists')
+  .description('Manage global URL lists');
+
+campaignSettingsUrlLists
+  .command('list')
+  .description('List URL lists')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listUrlLists({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No URL lists found.');
+          return;
+        }
+        for (const list of result) {
+          console.log(`  ${list.name}`);
+          console.log(`    ID: ${list.id}`);
+          console.log(`    List type: ${list.listType}`);
+          if (list.urls && list.urls.length > 0) {
+            console.log(`    URLs: ${list.urls.join(', ')}`);
+          }
+          if (list.description) {
+            console.log(`    Description: ${list.description}`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsUrlLists
+  .command('create')
+  .description('Prepare URL list creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'URL list name')
+  .requiredOption('--list-type <type>', 'List type (allowlist or blocklist)')
+  .option('--urls <urls>', 'Comma-separated URLs')
+  .option('--description <description>', 'Human-readable description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      listType: string;
+      urls?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const urls =
+          options.urls !== undefined
+            ? options.urls
+                .split(',')
+                .map((url) => url.trim())
+                .filter((url) => url.length > 0)
+            : undefined;
+
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreateUrlList({
+          project: options.project,
+          name: options.name,
+          listType: options.listType,
+          urls,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('URL list creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsUrlLists
+  .command('update')
+  .description('Prepare URL list update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--url-list-id <id>', 'URL list ID')
+  .option('--name <name>', 'Updated URL list name')
+  .option('--list-type <type>', 'Updated list type')
+  .option('--urls <urls>', 'Updated comma-separated URLs')
+  .option('--description <description>', 'Updated description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      urlListId: string;
+      name?: string;
+      listType?: string;
+      urls?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const urls =
+          options.urls !== undefined
+            ? options.urls
+                .split(',')
+                .map((url) => url.trim())
+                .filter((url) => url.length > 0)
+            : undefined;
+
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdateUrlList({
+          project: options.project,
+          urlListId: options.urlListId,
+          name: options.name,
+          listType: options.listType,
+          urls,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('URL list update prepared.');
+          console.log(`  URL list ID: ${options.urlListId}`);
+          if (options.name) {
+            console.log(`  Name:        ${options.name}`);
+          }
+          console.log(`  Token:       ${result.confirmToken}`);
+          console.log(`  Expires:     ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsUrlLists
+  .command('delete')
+  .description('Prepare URL list deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--url-list-id <id>', 'URL list ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; urlListId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareDeleteUrlList({
+          project: options.project,
+          urlListId: options.urlListId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('URL list deletion prepared.');
+          console.log(`  URL list ID: ${options.urlListId}`);
+          console.log(`  Token:       ${result.confirmToken}`);
+          console.log(`  Expires:     ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const campaignSettingsPageVariables = campaignSettings
+  .command('page-variables')
+  .description('Manage page variables');
+
+campaignSettingsPageVariables
+  .command('list')
+  .description('List page variables')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachCampaignSettingsService(options.project);
+      const result = await service.listPageVariables({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No page variables found.');
+          return;
+        }
+        for (const variable of result) {
+          console.log(`  ${variable.name}`);
+          console.log(`    ID: ${variable.id}`);
+          console.log(`    Value: ${variable.value}`);
+          if (variable.description) {
+            console.log(`    Description: ${variable.description}`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+campaignSettingsPageVariables
+  .command('create')
+  .description('Prepare page variable creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'Page variable name')
+  .requiredOption('--value <value>', 'Page variable value')
+  .option('--description <description>', 'Human-readable description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      value: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareCreatePageVariable({
+          project: options.project,
+          name: options.name,
+          value: options.value,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Page variable creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsPageVariables
+  .command('update')
+  .description('Prepare page variable update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--page-variable-id <id>', 'Page variable ID')
+  .option('--name <name>', 'Updated page variable name')
+  .option('--value <value>', 'Updated page variable value')
+  .option('--description <description>', 'Updated description')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      pageVariableId: string;
+      name?: string;
+      value?: string;
+      description?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareUpdatePageVariable({
+          project: options.project,
+          pageVariableId: options.pageVariableId,
+          name: options.name,
+          value: options.value,
+          description: options.description,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Page variable update prepared.');
+          console.log(`  Page variable ID: ${options.pageVariableId}`);
+          if (options.name) {
+            console.log(`  Name:             ${options.name}`);
+          }
+          console.log(`  Token:            ${result.confirmToken}`);
+          console.log(`  Expires:          ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+campaignSettingsPageVariables
+  .command('delete')
+  .description('Prepare page variable deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--page-variable-id <id>', 'Page variable ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { project: string; pageVariableId: string; note?: string; json?: boolean }) => {
+      try {
+        const service = new BloomreachCampaignSettingsService(options.project);
+        const result = service.prepareDeletePageVariable({
+          project: options.project,
+          pageVariableId: options.pageVariableId,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Page variable deletion prepared.');
+          console.log(`  Page variable ID: ${options.pageVariableId}`);
+          console.log(`  Token:            ${result.confirmToken}`);
+          console.log(`  Expires:          ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
           console.log('To confirm, run:');
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);

--- a/packages/core/src/__tests__/bloomreachCampaignSettings.test.ts
+++ b/packages/core/src/__tests__/bloomreachCampaignSettings.test.ts
@@ -1,0 +1,1959 @@
+import { describe, it, expect } from 'vitest';
+import {
+  UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE,
+  CREATE_TIMEZONE_ACTION_TYPE,
+  UPDATE_TIMEZONE_ACTION_TYPE,
+  DELETE_TIMEZONE_ACTION_TYPE,
+  CREATE_LANGUAGE_ACTION_TYPE,
+  UPDATE_LANGUAGE_ACTION_TYPE,
+  DELETE_LANGUAGE_ACTION_TYPE,
+  CREATE_FONT_ACTION_TYPE,
+  UPDATE_FONT_ACTION_TYPE,
+  DELETE_FONT_ACTION_TYPE,
+  CREATE_THROUGHPUT_POLICY_ACTION_TYPE,
+  UPDATE_THROUGHPUT_POLICY_ACTION_TYPE,
+  DELETE_THROUGHPUT_POLICY_ACTION_TYPE,
+  CREATE_FREQUENCY_POLICY_ACTION_TYPE,
+  UPDATE_FREQUENCY_POLICY_ACTION_TYPE,
+  DELETE_FREQUENCY_POLICY_ACTION_TYPE,
+  CREATE_CONSENT_ACTION_TYPE,
+  UPDATE_CONSENT_ACTION_TYPE,
+  DELETE_CONSENT_ACTION_TYPE,
+  CREATE_URL_LIST_ACTION_TYPE,
+  UPDATE_URL_LIST_ACTION_TYPE,
+  DELETE_URL_LIST_ACTION_TYPE,
+  CREATE_PAGE_VARIABLE_ACTION_TYPE,
+  UPDATE_PAGE_VARIABLE_ACTION_TYPE,
+  DELETE_PAGE_VARIABLE_ACTION_TYPE,
+  CAMPAIGN_SETTINGS_RATE_LIMIT_WINDOW_MS,
+  CAMPAIGN_SETTINGS_MODIFY_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_TIMEZONE_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_LANGUAGE_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_FONT_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_POLICY_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_CONSENT_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_URL_LIST_RATE_LIMIT,
+  CAMPAIGN_SETTINGS_PAGE_VARIABLE_RATE_LIMIT,
+  validateTimezoneName,
+  validateTimezoneId,
+  validateLanguageCode,
+  validateLanguageName,
+  validateFontName,
+  validateFontId,
+  validatePolicyName,
+  validatePolicyId,
+  validateConsentCategory,
+  validateConsentId,
+  validateUrlListName,
+  validateUrlListId,
+  validatePageVariableName,
+  validatePageVariableId,
+  validatePageVariableValue,
+  buildCampaignSettingsUrl,
+  buildTimezonesUrl,
+  buildLanguagesUrl,
+  buildFontsUrl,
+  buildThroughputPolicyUrl,
+  buildFrequencyPoliciesUrl,
+  buildConsentsUrl,
+  buildGlobalUrlListsUrl,
+  buildPageVariablesUrl,
+  createCampaignSettingsActionExecutors,
+  BloomreachCampaignSettingsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE', () => {
+    expect(UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE).toBe('campaign_settings.update_campaign_defaults');
+  });
+
+  it('exports CREATE_TIMEZONE_ACTION_TYPE', () => {
+    expect(CREATE_TIMEZONE_ACTION_TYPE).toBe('campaign_settings.create_timezone');
+  });
+
+  it('exports UPDATE_TIMEZONE_ACTION_TYPE', () => {
+    expect(UPDATE_TIMEZONE_ACTION_TYPE).toBe('campaign_settings.update_timezone');
+  });
+
+  it('exports DELETE_TIMEZONE_ACTION_TYPE', () => {
+    expect(DELETE_TIMEZONE_ACTION_TYPE).toBe('campaign_settings.delete_timezone');
+  });
+
+  it('exports CREATE_LANGUAGE_ACTION_TYPE', () => {
+    expect(CREATE_LANGUAGE_ACTION_TYPE).toBe('campaign_settings.create_language');
+  });
+
+  it('exports UPDATE_LANGUAGE_ACTION_TYPE', () => {
+    expect(UPDATE_LANGUAGE_ACTION_TYPE).toBe('campaign_settings.update_language');
+  });
+
+  it('exports DELETE_LANGUAGE_ACTION_TYPE', () => {
+    expect(DELETE_LANGUAGE_ACTION_TYPE).toBe('campaign_settings.delete_language');
+  });
+
+  it('exports CREATE_FONT_ACTION_TYPE', () => {
+    expect(CREATE_FONT_ACTION_TYPE).toBe('campaign_settings.create_font');
+  });
+
+  it('exports UPDATE_FONT_ACTION_TYPE', () => {
+    expect(UPDATE_FONT_ACTION_TYPE).toBe('campaign_settings.update_font');
+  });
+
+  it('exports DELETE_FONT_ACTION_TYPE', () => {
+    expect(DELETE_FONT_ACTION_TYPE).toBe('campaign_settings.delete_font');
+  });
+
+  it('exports CREATE_THROUGHPUT_POLICY_ACTION_TYPE', () => {
+    expect(CREATE_THROUGHPUT_POLICY_ACTION_TYPE).toBe('campaign_settings.create_throughput_policy');
+  });
+
+  it('exports UPDATE_THROUGHPUT_POLICY_ACTION_TYPE', () => {
+    expect(UPDATE_THROUGHPUT_POLICY_ACTION_TYPE).toBe('campaign_settings.update_throughput_policy');
+  });
+
+  it('exports DELETE_THROUGHPUT_POLICY_ACTION_TYPE', () => {
+    expect(DELETE_THROUGHPUT_POLICY_ACTION_TYPE).toBe('campaign_settings.delete_throughput_policy');
+  });
+
+  it('exports CREATE_FREQUENCY_POLICY_ACTION_TYPE', () => {
+    expect(CREATE_FREQUENCY_POLICY_ACTION_TYPE).toBe('campaign_settings.create_frequency_policy');
+  });
+
+  it('exports UPDATE_FREQUENCY_POLICY_ACTION_TYPE', () => {
+    expect(UPDATE_FREQUENCY_POLICY_ACTION_TYPE).toBe('campaign_settings.update_frequency_policy');
+  });
+
+  it('exports DELETE_FREQUENCY_POLICY_ACTION_TYPE', () => {
+    expect(DELETE_FREQUENCY_POLICY_ACTION_TYPE).toBe('campaign_settings.delete_frequency_policy');
+  });
+
+  it('exports CREATE_CONSENT_ACTION_TYPE', () => {
+    expect(CREATE_CONSENT_ACTION_TYPE).toBe('campaign_settings.create_consent');
+  });
+
+  it('exports UPDATE_CONSENT_ACTION_TYPE', () => {
+    expect(UPDATE_CONSENT_ACTION_TYPE).toBe('campaign_settings.update_consent');
+  });
+
+  it('exports DELETE_CONSENT_ACTION_TYPE', () => {
+    expect(DELETE_CONSENT_ACTION_TYPE).toBe('campaign_settings.delete_consent');
+  });
+
+  it('exports CREATE_URL_LIST_ACTION_TYPE', () => {
+    expect(CREATE_URL_LIST_ACTION_TYPE).toBe('campaign_settings.create_url_list');
+  });
+
+  it('exports UPDATE_URL_LIST_ACTION_TYPE', () => {
+    expect(UPDATE_URL_LIST_ACTION_TYPE).toBe('campaign_settings.update_url_list');
+  });
+
+  it('exports DELETE_URL_LIST_ACTION_TYPE', () => {
+    expect(DELETE_URL_LIST_ACTION_TYPE).toBe('campaign_settings.delete_url_list');
+  });
+
+  it('exports CREATE_PAGE_VARIABLE_ACTION_TYPE', () => {
+    expect(CREATE_PAGE_VARIABLE_ACTION_TYPE).toBe('campaign_settings.create_page_variable');
+  });
+
+  it('exports UPDATE_PAGE_VARIABLE_ACTION_TYPE', () => {
+    expect(UPDATE_PAGE_VARIABLE_ACTION_TYPE).toBe('campaign_settings.update_page_variable');
+  });
+
+  it('exports DELETE_PAGE_VARIABLE_ACTION_TYPE', () => {
+    expect(DELETE_PAGE_VARIABLE_ACTION_TYPE).toBe('campaign_settings.delete_page_variable');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports CAMPAIGN_SETTINGS_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(CAMPAIGN_SETTINGS_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_MODIFY_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_MODIFY_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_TIMEZONE_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_TIMEZONE_RATE_LIMIT).toBe(30);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_LANGUAGE_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_LANGUAGE_RATE_LIMIT).toBe(30);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_FONT_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_FONT_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_POLICY_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_POLICY_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_CONSENT_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_CONSENT_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_URL_LIST_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_URL_LIST_RATE_LIMIT).toBe(20);
+  });
+
+  it('exports CAMPAIGN_SETTINGS_PAGE_VARIABLE_RATE_LIMIT', () => {
+    expect(CAMPAIGN_SETTINGS_PAGE_VARIABLE_RATE_LIMIT).toBe(30);
+  });
+});
+
+describe('validateTimezoneName', () => {
+  it('throws for empty string', () => {
+    expect(() => validateTimezoneName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateTimezoneName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed name for valid input', () => {
+    expect(validateTimezoneName('  Europe/Prague  ')).toBe('Europe/Prague');
+  });
+
+  it('accepts name at maximum length', () => {
+    const name = 'x'.repeat(100);
+    expect(validateTimezoneName(name)).toBe(name);
+  });
+
+  it('throws for name exceeding maximum length', () => {
+    const name = 'x'.repeat(101);
+    expect(() => validateTimezoneName(name)).toThrow('must not exceed 100 characters');
+  });
+});
+
+describe('validateTimezoneId', () => {
+  it('throws for empty string', () => {
+    expect(() => validateTimezoneId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateTimezoneId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed ID for valid input', () => {
+    expect(validateTimezoneId('  tz-123  ')).toBe('tz-123');
+  });
+});
+
+describe('validateLanguageCode', () => {
+  it('throws for empty string', () => {
+    expect(() => validateLanguageCode('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateLanguageCode('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed language code for valid input', () => {
+    expect(validateLanguageCode('  en  ')).toBe('en');
+  });
+
+  it('accepts language code at maximum length', () => {
+    const code = 'x'.repeat(10);
+    expect(validateLanguageCode(code)).toBe(code);
+  });
+
+  it('throws for language code exceeding maximum length', () => {
+    const code = 'x'.repeat(11);
+    expect(() => validateLanguageCode(code)).toThrow('must not exceed 10 characters');
+  });
+});
+
+describe('validateLanguageName', () => {
+  it('throws for empty string', () => {
+    expect(() => validateLanguageName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateLanguageName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed language name for valid input', () => {
+    expect(validateLanguageName('  English  ')).toBe('English');
+  });
+
+  it('accepts language name at maximum length', () => {
+    const name = 'x'.repeat(100);
+    expect(validateLanguageName(name)).toBe(name);
+  });
+
+  it('throws for language name exceeding maximum length', () => {
+    const name = 'x'.repeat(101);
+    expect(() => validateLanguageName(name)).toThrow('must not exceed 100 characters');
+  });
+});
+
+describe('validateFontName', () => {
+  it('throws for empty string', () => {
+    expect(() => validateFontName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateFontName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed font name for valid input', () => {
+    expect(validateFontName('  Inter  ')).toBe('Inter');
+  });
+
+  it('accepts font name at maximum length', () => {
+    const name = 'x'.repeat(100);
+    expect(validateFontName(name)).toBe(name);
+  });
+
+  it('throws for font name exceeding maximum length', () => {
+    const name = 'x'.repeat(101);
+    expect(() => validateFontName(name)).toThrow('must not exceed 100 characters');
+  });
+});
+
+describe('validateFontId', () => {
+  it('throws for empty string', () => {
+    expect(() => validateFontId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateFontId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed ID for valid input', () => {
+    expect(validateFontId('  font-123  ')).toBe('font-123');
+  });
+});
+
+describe('validatePolicyName', () => {
+  it('throws for empty string', () => {
+    expect(() => validatePolicyName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validatePolicyName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed policy name for valid input', () => {
+    expect(validatePolicyName('  Slow And Steady  ')).toBe('Slow And Steady');
+  });
+
+  it('accepts policy name at maximum length', () => {
+    const name = 'x'.repeat(120);
+    expect(validatePolicyName(name)).toBe(name);
+  });
+
+  it('throws for policy name exceeding maximum length', () => {
+    const name = 'x'.repeat(121);
+    expect(() => validatePolicyName(name)).toThrow('must not exceed 120 characters');
+  });
+});
+
+describe('validatePolicyId', () => {
+  it('throws for empty string', () => {
+    expect(() => validatePolicyId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validatePolicyId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed ID for valid input', () => {
+    expect(validatePolicyId('  policy-123  ')).toBe('policy-123');
+  });
+});
+
+describe('validateConsentCategory', () => {
+  it('throws for empty string', () => {
+    expect(() => validateConsentCategory('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateConsentCategory('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed category for valid input', () => {
+    expect(validateConsentCategory('  Marketing  ')).toBe('Marketing');
+  });
+
+  it('accepts category at maximum length', () => {
+    const category = 'x'.repeat(120);
+    expect(validateConsentCategory(category)).toBe(category);
+  });
+
+  it('throws for category exceeding maximum length', () => {
+    const category = 'x'.repeat(121);
+    expect(() => validateConsentCategory(category)).toThrow('must not exceed 120 characters');
+  });
+});
+
+describe('validateConsentId', () => {
+  it('throws for empty string', () => {
+    expect(() => validateConsentId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateConsentId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed ID for valid input', () => {
+    expect(validateConsentId('  consent-123  ')).toBe('consent-123');
+  });
+});
+
+describe('validateUrlListName', () => {
+  it('throws for empty string', () => {
+    expect(() => validateUrlListName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateUrlListName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed URL list name for valid input', () => {
+    expect(validateUrlListName('  Internal Domains  ')).toBe('Internal Domains');
+  });
+
+  it('accepts URL list name at maximum length', () => {
+    const name = 'x'.repeat(120);
+    expect(validateUrlListName(name)).toBe(name);
+  });
+
+  it('throws for URL list name exceeding maximum length', () => {
+    const name = 'x'.repeat(121);
+    expect(() => validateUrlListName(name)).toThrow('must not exceed 120 characters');
+  });
+});
+
+describe('validateUrlListId', () => {
+  it('throws for empty string', () => {
+    expect(() => validateUrlListId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateUrlListId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed ID for valid input', () => {
+    expect(validateUrlListId('  list-123  ')).toBe('list-123');
+  });
+});
+
+describe('validatePageVariableName', () => {
+  it('throws for empty string', () => {
+    expect(() => validatePageVariableName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validatePageVariableName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed page variable name for valid input', () => {
+    expect(validatePageVariableName('  banner_text  ')).toBe('banner_text');
+  });
+
+  it('accepts page variable name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validatePageVariableName(name)).toBe(name);
+  });
+
+  it('throws for page variable name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validatePageVariableName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validatePageVariableId', () => {
+  it('throws for empty string', () => {
+    expect(() => validatePageVariableId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validatePageVariableId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed ID for valid input', () => {
+    expect(validatePageVariableId('  pv-123  ')).toBe('pv-123');
+  });
+});
+
+describe('validatePageVariableValue', () => {
+  it('returns trimmed value for empty string', () => {
+    expect(validatePageVariableValue('')).toBe('');
+  });
+
+  it('returns trimmed value for whitespace-only string', () => {
+    expect(validatePageVariableValue('   ')).toBe('');
+  });
+
+  it('returns trimmed value for valid input', () => {
+    expect(validatePageVariableValue('  hello world  ')).toBe('hello world');
+  });
+
+  it('accepts value at maximum length', () => {
+    const value = 'x'.repeat(5000);
+    expect(validatePageVariableValue(value)).toBe(value);
+  });
+
+  it('throws for value exceeding maximum length', () => {
+    const value = 'x'.repeat(5001);
+    expect(() => validatePageVariableValue(value)).toThrow('must not exceed 5000 characters');
+  });
+});
+
+describe('URL builders', () => {
+  it('builds all URLs for a simple project name', () => {
+    expect(buildCampaignSettingsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/campaigns',
+    );
+    expect(buildTimezonesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/timezones',
+    );
+    expect(buildLanguagesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/languages',
+    );
+    expect(buildFontsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/project-settings/fonts');
+    expect(buildThroughputPolicyUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/throughput-policy',
+    );
+    expect(buildFrequencyPoliciesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/campaign-frequency-policies',
+    );
+    expect(buildConsentsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/consents',
+    );
+    expect(buildGlobalUrlListsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/global-url-lists',
+    );
+    expect(buildPageVariablesUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/page-variables',
+    );
+  });
+
+  it('encodes special characters in all URLs', () => {
+    expect(buildCampaignSettingsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/campaigns',
+    );
+    expect(buildTimezonesUrl('my project')).toBe('/p/my%20project/project-settings/timezones');
+    expect(buildLanguagesUrl('my project')).toBe('/p/my%20project/project-settings/languages');
+    expect(buildFontsUrl('my project')).toBe('/p/my%20project/project-settings/fonts');
+    expect(buildThroughputPolicyUrl('my project')).toBe(
+      '/p/my%20project/project-settings/throughput-policy',
+    );
+    expect(buildFrequencyPoliciesUrl('my project')).toBe(
+      '/p/my%20project/project-settings/campaign-frequency-policies',
+    );
+    expect(buildConsentsUrl('my project')).toBe('/p/my%20project/project-settings/consents');
+    expect(buildGlobalUrlListsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/global-url-lists',
+    );
+    expect(buildPageVariablesUrl('my project')).toBe(
+      '/p/my%20project/project-settings/page-variables',
+    );
+  });
+
+  it('handles project names with slashes in all URLs', () => {
+    expect(buildCampaignSettingsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/campaigns',
+    );
+    expect(buildTimezonesUrl('org/project')).toBe('/p/org%2Fproject/project-settings/timezones');
+    expect(buildLanguagesUrl('org/project')).toBe('/p/org%2Fproject/project-settings/languages');
+    expect(buildFontsUrl('org/project')).toBe('/p/org%2Fproject/project-settings/fonts');
+    expect(buildThroughputPolicyUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/throughput-policy',
+    );
+    expect(buildFrequencyPoliciesUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/campaign-frequency-policies',
+    );
+    expect(buildConsentsUrl('org/project')).toBe('/p/org%2Fproject/project-settings/consents');
+    expect(buildGlobalUrlListsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/global-url-lists',
+    );
+    expect(buildPageVariablesUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/page-variables',
+    );
+  });
+});
+
+describe('createCampaignSettingsActionExecutors', () => {
+  it('returns executors for all 25 action types', () => {
+    const executors = createCampaignSettingsActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(25);
+    expect(executors[UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_TIMEZONE_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_TIMEZONE_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_TIMEZONE_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_LANGUAGE_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_LANGUAGE_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_LANGUAGE_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_FONT_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_FONT_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_FONT_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_THROUGHPUT_POLICY_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_THROUGHPUT_POLICY_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_THROUGHPUT_POLICY_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_FREQUENCY_POLICY_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_FREQUENCY_POLICY_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_FREQUENCY_POLICY_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_CONSENT_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_CONSENT_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_CONSENT_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_URL_LIST_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_URL_LIST_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_URL_LIST_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_PAGE_VARIABLE_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_PAGE_VARIABLE_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_PAGE_VARIABLE_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching key', () => {
+    const executors = createCampaignSettingsActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createCampaignSettingsActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachCampaignSettingsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachCampaignSettingsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachCampaignSettingsService);
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachCampaignSettingsService('  my-project  ');
+      expect(service.campaignSettingsUrl).toBe('/p/my-project/project-settings/campaigns');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachCampaignSettingsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('URL getters', () => {
+    it('returns all campaign settings URLs', () => {
+      const service = new BloomreachCampaignSettingsService('kingdom-of-joakim');
+      expect(service.campaignSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/campaigns');
+      expect(service.timezonesSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/timezones');
+      expect(service.languagesSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/languages');
+      expect(service.fontsSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/fonts');
+      expect(service.throughputPolicySettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/throughput-policy',
+      );
+      expect(service.frequencyPoliciesSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/campaign-frequency-policies',
+      );
+      expect(service.consentsSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/consents');
+      expect(service.globalUrlListsSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/global-url-lists',
+      );
+      expect(service.pageVariablesSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/page-variables',
+      );
+    });
+  });
+
+  describe('read methods', () => {
+    it('viewCampaignDefaults throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.viewCampaignDefaults()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listTimezones throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listTimezones()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listLanguages throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listLanguages()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listFonts throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listFonts()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listThroughputPolicies throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listThroughputPolicies()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listFrequencyPolicies throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listFrequencyPolicies()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listConsents throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listConsents()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listUrlLists throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listUrlLists()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listPageVariables throws not-yet-implemented error', async () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      await expect(service.listPageVariables()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareUpdateCampaignDefaults', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateCampaignDefaults({
+        project: 'test',
+        defaultSenderName: 'Team Bloomreach',
+        defaultSenderEmail: ' team@example.com ',
+        defaultReplyToEmail: ' reply@example.com ',
+        defaultUtmSource: ' newsletter ',
+        defaultUtmMedium: ' email ',
+        defaultUtmCampaign: ' spring-launch ',
+        operatorNote: 'update all defaults',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_campaign_defaults',
+          project: 'test',
+          defaultSenderName: 'Team Bloomreach',
+          defaultSenderEmail: 'team@example.com',
+          defaultReplyToEmail: 'reply@example.com',
+          defaultUtmSource: 'newsletter',
+          defaultUtmMedium: 'email',
+          defaultUtmCampaign: 'spring-launch',
+          operatorNote: 'update all defaults',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateCampaignDefaults({
+          project: '',
+          defaultSenderName: 'Name',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no default fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareUpdateCampaignDefaults({ project: 'test' })).toThrow(
+        'At least one campaign default field must be provided for defaults update.',
+      );
+    });
+  });
+
+  describe('prepareCreateTimezone', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateTimezone({
+        project: 'test',
+        name: 'Europe/Prague',
+        utcOffset: '+01:00',
+        isDefault: true,
+        operatorNote: 'add Prague timezone',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_timezone',
+          project: 'test',
+          name: 'Europe/Prague',
+          utcOffset: '+01:00',
+          isDefault: true,
+          operatorNote: 'add Prague timezone',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareCreateTimezone({ project: '', name: 'Europe/Prague' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareCreateTimezone({ project: 'test', name: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareUpdateTimezone', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateTimezone({
+        project: 'test',
+        timezoneId: 'tz-1',
+        name: 'Europe/Brno',
+        utcOffset: '+02:00',
+        isDefault: false,
+        operatorNote: 'update timezone',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_timezone',
+          project: 'test',
+          timezoneId: 'tz-1',
+          name: 'Europe/Brno',
+          utcOffset: '+02:00',
+          isDefault: false,
+          operatorNote: 'update timezone',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateTimezone({
+          project: '',
+          timezoneId: 'tz-1',
+          name: 'Europe/Brno',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty timezone ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateTimezone({
+          project: 'test',
+          timezoneId: '',
+          name: 'Europe/Brno',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateTimezone({
+          project: 'test',
+          timezoneId: 'tz-1',
+        }),
+      ).toThrow(
+        'At least one of name, utcOffset, or isDefault must be provided for timezone update.',
+      );
+    });
+  });
+
+  describe('prepareDeleteTimezone', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteTimezone({
+        project: 'test',
+        timezoneId: 'tz-2',
+        operatorNote: 'remove old timezone',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_timezone',
+          project: 'test',
+          timezoneId: 'tz-2',
+          operatorNote: 'remove old timezone',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteTimezone({ project: '', timezoneId: 'tz-2' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty timezone ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteTimezone({ project: 'test', timezoneId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateLanguage', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateLanguage({
+        project: 'test',
+        code: 'en',
+        name: 'English',
+        isDefault: true,
+        operatorNote: 'add english',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_language',
+          project: 'test',
+          code: 'en',
+          name: 'English',
+          isDefault: true,
+          operatorNote: 'add english',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateLanguage({
+          project: '',
+          code: 'en',
+          name: 'English',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty code', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateLanguage({
+          project: 'test',
+          code: '',
+          name: 'English',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateLanguage', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateLanguage({
+        project: 'test',
+        languageCode: 'en',
+        code: 'en-GB',
+        name: 'English UK',
+        isDefault: false,
+        operatorNote: 'update language',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_language',
+          project: 'test',
+          languageCode: 'en',
+          code: 'en-GB',
+          name: 'English UK',
+          isDefault: false,
+          operatorNote: 'update language',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateLanguage({
+          project: '',
+          languageCode: 'en',
+          name: 'English',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty language code', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateLanguage({
+          project: 'test',
+          languageCode: '',
+          name: 'English',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateLanguage({
+          project: 'test',
+          languageCode: 'en',
+        }),
+      ).toThrow('At least one of code, name, or isDefault must be provided for language update.');
+    });
+  });
+
+  describe('prepareDeleteLanguage', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteLanguage({
+        project: 'test',
+        languageCode: 'de',
+        operatorNote: 'remove german',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_language',
+          project: 'test',
+          languageCode: 'de',
+          operatorNote: 'remove german',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteLanguage({ project: '', languageCode: 'de' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty language code', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteLanguage({ project: 'test', languageCode: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateFont', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateFont({
+        project: 'test',
+        name: 'Inter',
+        type: 'system',
+        fileUrl: 'https://example.com/inter.woff2',
+        operatorNote: 'add inter',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_font',
+          project: 'test',
+          name: 'Inter',
+          type: 'system',
+          fileUrl: 'https://example.com/inter.woff2',
+          operatorNote: 'add inter',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateFont({
+          project: '',
+          name: 'Inter',
+          type: 'system',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateFont({
+          project: 'test',
+          name: '',
+          type: 'system',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateFont', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateFont({
+        project: 'test',
+        fontId: 'font-1',
+        name: 'Inter Tight',
+        type: 'custom',
+        fileUrl: 'https://example.com/inter-tight.woff2',
+        operatorNote: 'update font',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_font',
+          project: 'test',
+          fontId: 'font-1',
+          name: 'Inter Tight',
+          type: 'custom',
+          fileUrl: 'https://example.com/inter-tight.woff2',
+          operatorNote: 'update font',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateFont({
+          project: '',
+          fontId: 'font-1',
+          name: 'Inter',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty font ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateFont({
+          project: 'test',
+          fontId: '',
+          name: 'Inter',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateFont({
+          project: 'test',
+          fontId: 'font-1',
+        }),
+      ).toThrow('At least one of name, type, or fileUrl must be provided for font update.');
+    });
+  });
+
+  describe('prepareDeleteFont', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteFont({
+        project: 'test',
+        fontId: 'font-2',
+        operatorNote: 'remove old font',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_font',
+          project: 'test',
+          fontId: 'font-2',
+          operatorNote: 'remove old font',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteFont({ project: '', fontId: 'font-2' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty font ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteFont({ project: 'test', fontId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateThroughputPolicy', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateThroughputPolicy({
+        project: 'test',
+        name: 'Email Burst Guard',
+        channel: 'email',
+        maxRate: 1000,
+        periodSeconds: 60,
+        description: 'Cap burst sends',
+        operatorNote: 'create throughput policy',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_throughput_policy',
+          project: 'test',
+          name: 'Email Burst Guard',
+          channel: 'email',
+          maxRate: 1000,
+          periodSeconds: 60,
+          description: 'Cap burst sends',
+          operatorNote: 'create throughput policy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateThroughputPolicy({
+          project: '',
+          name: 'Email Burst Guard',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateThroughputPolicy({
+          project: 'test',
+          name: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateThroughputPolicy', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateThroughputPolicy({
+        project: 'test',
+        policyId: 'tp-1',
+        name: 'Email Burst Guard v2',
+        channel: 'email',
+        maxRate: 750,
+        periodSeconds: 60,
+        description: 'Tighter cap',
+        operatorNote: 'update throughput policy',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_throughput_policy',
+          project: 'test',
+          policyId: 'tp-1',
+          name: 'Email Burst Guard v2',
+          channel: 'email',
+          maxRate: 750,
+          periodSeconds: 60,
+          description: 'Tighter cap',
+          operatorNote: 'update throughput policy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateThroughputPolicy({
+          project: '',
+          policyId: 'tp-1',
+          name: 'x',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty policy ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateThroughputPolicy({
+          project: 'test',
+          policyId: '',
+          name: 'x',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateThroughputPolicy({
+          project: 'test',
+          policyId: 'tp-1',
+        }),
+      ).toThrow('At least one modifiable field must be provided for throughput policy update.');
+    });
+  });
+
+  describe('prepareDeleteThroughputPolicy', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteThroughputPolicy({
+        project: 'test',
+        policyId: 'tp-2',
+        operatorNote: 'remove policy',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_throughput_policy',
+          project: 'test',
+          policyId: 'tp-2',
+          operatorNote: 'remove policy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareDeleteThroughputPolicy({ project: '', policyId: 'tp-2' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty policy ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareDeleteThroughputPolicy({ project: 'test', policyId: '' }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareCreateFrequencyPolicy', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateFrequencyPolicy({
+        project: 'test',
+        name: 'Weekly Cap',
+        policyType: 'global',
+        maxSends: 3,
+        windowHours: 168,
+        channels: ['email', 'push'],
+        description: 'Max 3 sends per week',
+        operatorNote: 'create frequency policy',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_frequency_policy',
+          project: 'test',
+          name: 'Weekly Cap',
+          policyType: 'global',
+          maxSends: 3,
+          windowHours: 168,
+          channels: ['email', 'push'],
+          description: 'Max 3 sends per week',
+          operatorNote: 'create frequency policy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateFrequencyPolicy({
+          project: '',
+          name: 'Weekly Cap',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateFrequencyPolicy({
+          project: 'test',
+          name: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateFrequencyPolicy', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateFrequencyPolicy({
+        project: 'test',
+        policyId: 'fp-1',
+        name: 'Weekly Cap Tightened',
+        policyType: 'global',
+        maxSends: 2,
+        windowHours: 168,
+        channels: ['email'],
+        description: 'Lower weekly cap',
+        operatorNote: 'update frequency policy',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_frequency_policy',
+          project: 'test',
+          policyId: 'fp-1',
+          name: 'Weekly Cap Tightened',
+          policyType: 'global',
+          maxSends: 2,
+          windowHours: 168,
+          channels: ['email'],
+          description: 'Lower weekly cap',
+          operatorNote: 'update frequency policy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateFrequencyPolicy({
+          project: '',
+          policyId: 'fp-1',
+          name: 'x',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty policy ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateFrequencyPolicy({
+          project: 'test',
+          policyId: '',
+          name: 'x',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateFrequencyPolicy({
+          project: 'test',
+          policyId: 'fp-1',
+        }),
+      ).toThrow('At least one modifiable field must be provided for frequency policy update.');
+    });
+  });
+
+  describe('prepareDeleteFrequencyPolicy', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteFrequencyPolicy({
+        project: 'test',
+        policyId: 'fp-2',
+        operatorNote: 'remove frequency policy',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_frequency_policy',
+          project: 'test',
+          policyId: 'fp-2',
+          operatorNote: 'remove frequency policy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteFrequencyPolicy({ project: '', policyId: 'fp-2' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty policy ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteFrequencyPolicy({ project: 'test', policyId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateConsent', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateConsent({
+        project: 'test',
+        category: 'Marketing',
+        description: 'Marketing communication consent',
+        consentType: 'opt-in',
+        legitimateInterest: false,
+        operatorNote: 'create consent',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_consent',
+          project: 'test',
+          category: 'Marketing',
+          description: 'Marketing communication consent',
+          consentType: 'opt-in',
+          legitimateInterest: false,
+          operatorNote: 'create consent',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateConsent({
+          project: '',
+          category: 'Marketing',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty category', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateConsent({
+          project: 'test',
+          category: '',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateConsent', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateConsent({
+        project: 'test',
+        consentId: 'consent-1',
+        category: 'Transactional',
+        description: 'Transactional consent',
+        consentType: 'opt-out',
+        legitimateInterest: true,
+        operatorNote: 'update consent',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_consent',
+          project: 'test',
+          consentId: 'consent-1',
+          category: 'Transactional',
+          description: 'Transactional consent',
+          consentType: 'opt-out',
+          legitimateInterest: true,
+          operatorNote: 'update consent',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateConsent({
+          project: '',
+          consentId: 'consent-1',
+          category: 'Marketing',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty consent ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateConsent({
+          project: 'test',
+          consentId: '',
+          category: 'Marketing',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateConsent({
+          project: 'test',
+          consentId: 'consent-1',
+        }),
+      ).toThrow(
+        'At least one of category, description, consentType, or legitimateInterest must be provided for consent update.',
+      );
+    });
+  });
+
+  describe('prepareDeleteConsent', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteConsent({
+        project: 'test',
+        consentId: 'consent-2',
+        operatorNote: 'remove consent',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_consent',
+          project: 'test',
+          consentId: 'consent-2',
+          operatorNote: 'remove consent',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteConsent({ project: '', consentId: 'consent-2' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty consent ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteConsent({ project: 'test', consentId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreateUrlList', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreateUrlList({
+        project: 'test',
+        name: 'Internal URLs',
+        listType: 'allowlist',
+        urls: ['https://example.com', 'https://app.example.com'],
+        description: 'Trusted domains',
+        operatorNote: 'create allowlist',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_url_list',
+          project: 'test',
+          name: 'Internal URLs',
+          listType: 'allowlist',
+          urls: ['https://example.com', 'https://app.example.com'],
+          description: 'Trusted domains',
+          operatorNote: 'create allowlist',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateUrlList({
+          project: '',
+          name: 'Internal URLs',
+          listType: 'allowlist',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreateUrlList({
+          project: 'test',
+          name: '',
+          listType: 'allowlist',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdateUrlList', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdateUrlList({
+        project: 'test',
+        urlListId: 'list-1',
+        name: 'Known Good URLs',
+        listType: 'allowlist',
+        urls: ['https://good.example.com'],
+        description: 'Updated list',
+        operatorNote: 'update list',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_url_list',
+          project: 'test',
+          urlListId: 'list-1',
+          name: 'Known Good URLs',
+          listType: 'allowlist',
+          urls: ['https://good.example.com'],
+          description: 'Updated list',
+          operatorNote: 'update list',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateUrlList({
+          project: '',
+          urlListId: 'list-1',
+          name: 'Known Good URLs',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty URL list ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateUrlList({
+          project: 'test',
+          urlListId: '',
+          name: 'Known Good URLs',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdateUrlList({
+          project: 'test',
+          urlListId: 'list-1',
+        }),
+      ).toThrow(
+        'At least one of name, listType, urls, or description must be provided for URL list update.',
+      );
+    });
+  });
+
+  describe('prepareDeleteUrlList', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeleteUrlList({
+        project: 'test',
+        urlListId: 'list-2',
+        operatorNote: 'remove stale list',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_url_list',
+          project: 'test',
+          urlListId: 'list-2',
+          operatorNote: 'remove stale list',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteUrlList({ project: '', urlListId: 'list-2' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty URL list ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() => service.prepareDeleteUrlList({ project: 'test', urlListId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareCreatePageVariable', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareCreatePageVariable({
+        project: 'test',
+        name: 'hero_title',
+        value: 'Welcome to our spring sale',
+        description: 'Hero section title',
+        operatorNote: 'create page variable',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.create_page_variable',
+          project: 'test',
+          name: 'hero_title',
+          value: 'Welcome to our spring sale',
+          description: 'Hero section title',
+          operatorNote: 'create page variable',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreatePageVariable({
+          project: '',
+          name: 'hero_title',
+          value: 'Hello',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareCreatePageVariable({
+          project: 'test',
+          name: '',
+          value: 'Hello',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareUpdatePageVariable', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareUpdatePageVariable({
+        project: 'test',
+        pageVariableId: 'pv-1',
+        name: 'hero_title_v2',
+        value: 'Welcome back',
+        description: 'Updated hero title',
+        operatorNote: 'update page variable',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.update_page_variable',
+          project: 'test',
+          pageVariableId: 'pv-1',
+          name: 'hero_title_v2',
+          value: 'Welcome back',
+          description: 'Updated hero title',
+          operatorNote: 'update page variable',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdatePageVariable({
+          project: '',
+          pageVariableId: 'pv-1',
+          name: 'hero_title_v2',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty page variable ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdatePageVariable({
+          project: 'test',
+          pageVariableId: '',
+          name: 'hero_title_v2',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws when no modifiable fields are provided', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareUpdatePageVariable({
+          project: 'test',
+          pageVariableId: 'pv-1',
+        }),
+      ).toThrow(
+        'At least one of name, value, or description must be provided for page variable update.',
+      );
+    });
+  });
+
+  describe('prepareDeletePageVariable', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      const result = service.prepareDeletePageVariable({
+        project: 'test',
+        pageVariableId: 'pv-2',
+        operatorNote: 'remove stale variable',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'campaign_settings.delete_page_variable',
+          project: 'test',
+          pageVariableId: 'pv-2',
+          operatorNote: 'remove stale variable',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareDeletePageVariable({ project: '', pageVariableId: 'pv-2' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty page variable ID', () => {
+      const service = new BloomreachCampaignSettingsService('test');
+      expect(() =>
+        service.prepareDeletePageVariable({ project: 'test', pageVariableId: '' }),
+      ).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachCampaignSettings.ts
+++ b/packages/core/src/bloomreachCampaignSettings.ts
@@ -1,0 +1,1730 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+// ---------------------------------------------------------------------------
+// Action type constants
+// ---------------------------------------------------------------------------
+
+export const UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE = 'campaign_settings.update_campaign_defaults';
+
+export const CREATE_TIMEZONE_ACTION_TYPE = 'campaign_settings.create_timezone';
+export const UPDATE_TIMEZONE_ACTION_TYPE = 'campaign_settings.update_timezone';
+export const DELETE_TIMEZONE_ACTION_TYPE = 'campaign_settings.delete_timezone';
+
+export const CREATE_LANGUAGE_ACTION_TYPE = 'campaign_settings.create_language';
+export const UPDATE_LANGUAGE_ACTION_TYPE = 'campaign_settings.update_language';
+export const DELETE_LANGUAGE_ACTION_TYPE = 'campaign_settings.delete_language';
+
+export const CREATE_FONT_ACTION_TYPE = 'campaign_settings.create_font';
+export const UPDATE_FONT_ACTION_TYPE = 'campaign_settings.update_font';
+export const DELETE_FONT_ACTION_TYPE = 'campaign_settings.delete_font';
+
+export const CREATE_THROUGHPUT_POLICY_ACTION_TYPE = 'campaign_settings.create_throughput_policy';
+export const UPDATE_THROUGHPUT_POLICY_ACTION_TYPE = 'campaign_settings.update_throughput_policy';
+export const DELETE_THROUGHPUT_POLICY_ACTION_TYPE = 'campaign_settings.delete_throughput_policy';
+
+export const CREATE_FREQUENCY_POLICY_ACTION_TYPE = 'campaign_settings.create_frequency_policy';
+export const UPDATE_FREQUENCY_POLICY_ACTION_TYPE = 'campaign_settings.update_frequency_policy';
+export const DELETE_FREQUENCY_POLICY_ACTION_TYPE = 'campaign_settings.delete_frequency_policy';
+
+export const CREATE_CONSENT_ACTION_TYPE = 'campaign_settings.create_consent';
+export const UPDATE_CONSENT_ACTION_TYPE = 'campaign_settings.update_consent';
+export const DELETE_CONSENT_ACTION_TYPE = 'campaign_settings.delete_consent';
+
+export const CREATE_URL_LIST_ACTION_TYPE = 'campaign_settings.create_url_list';
+export const UPDATE_URL_LIST_ACTION_TYPE = 'campaign_settings.update_url_list';
+export const DELETE_URL_LIST_ACTION_TYPE = 'campaign_settings.delete_url_list';
+
+export const CREATE_PAGE_VARIABLE_ACTION_TYPE = 'campaign_settings.create_page_variable';
+export const UPDATE_PAGE_VARIABLE_ACTION_TYPE = 'campaign_settings.update_page_variable';
+export const DELETE_PAGE_VARIABLE_ACTION_TYPE = 'campaign_settings.delete_page_variable';
+
+// ---------------------------------------------------------------------------
+// Rate limit constants
+// ---------------------------------------------------------------------------
+
+export const CAMPAIGN_SETTINGS_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const CAMPAIGN_SETTINGS_MODIFY_RATE_LIMIT = 20;
+export const CAMPAIGN_SETTINGS_TIMEZONE_RATE_LIMIT = 30;
+export const CAMPAIGN_SETTINGS_LANGUAGE_RATE_LIMIT = 30;
+export const CAMPAIGN_SETTINGS_FONT_RATE_LIMIT = 20;
+export const CAMPAIGN_SETTINGS_POLICY_RATE_LIMIT = 20;
+export const CAMPAIGN_SETTINGS_CONSENT_RATE_LIMIT = 20;
+export const CAMPAIGN_SETTINGS_URL_LIST_RATE_LIMIT = 20;
+export const CAMPAIGN_SETTINGS_PAGE_VARIABLE_RATE_LIMIT = 30;
+
+// ---------------------------------------------------------------------------
+// Data interfaces
+// ---------------------------------------------------------------------------
+
+/** General campaign defaults from /project-settings/campaigns. */
+export interface BloomreachCampaignDefaults {
+  /** Default sender name for campaigns. */
+  defaultSenderName?: string;
+  /** Default sender email address. */
+  defaultSenderEmail?: string;
+  /** Default reply-to email address. */
+  defaultReplyToEmail?: string;
+  /** Default UTM source parameter. */
+  defaultUtmSource?: string;
+  /** Default UTM medium parameter. */
+  defaultUtmMedium?: string;
+  /** Default UTM campaign parameter. */
+  defaultUtmCampaign?: string;
+  /** Full URL path to the campaign settings page. */
+  url: string;
+}
+
+export interface BloomreachTimezone {
+  id: string;
+  /** IANA timezone name (e.g. "Europe/Prague"). */
+  name: string;
+  /** UTC offset string (e.g. "+01:00"). */
+  utcOffset?: string;
+  /** Whether this is the default timezone for the project. */
+  isDefault?: boolean;
+}
+
+export interface BloomreachLanguage {
+  /** ISO 639-1 code (e.g. "en", "cs"). */
+  code: string;
+  /** Human-readable name (e.g. "English", "Czech"). */
+  name: string;
+  /** Whether this is the default language. */
+  isDefault?: boolean;
+}
+
+export interface BloomreachFont {
+  id: string;
+  /** Font family name. */
+  name: string;
+  /** Font type (system or custom). */
+  type: string;
+  /** URL to the font file (for custom fonts). */
+  fileUrl?: string;
+}
+
+export interface BloomreachThroughputPolicy {
+  id: string;
+  name: string;
+  /** Channel this policy applies to (email, sms, push, etc.). */
+  channel?: string;
+  /** Maximum send rate per period. */
+  maxRate?: number;
+  /** Period in seconds for the rate limit. */
+  periodSeconds?: number;
+  /** Human-readable description. */
+  description?: string;
+}
+
+export interface BloomreachFrequencyPolicy {
+  id: string;
+  name: string;
+  /** Policy type (global or per-campaign). */
+  policyType?: string;
+  /** Maximum number of sends allowed. */
+  maxSends?: number;
+  /** Time window in hours for the frequency cap. */
+  windowHours?: number;
+  /** Channels this policy applies to. */
+  channels?: string[];
+  /** Human-readable description. */
+  description?: string;
+}
+
+export interface BloomreachConsent {
+  id: string;
+  /** Consent category name (e.g. "Marketing", "Transactional"). */
+  category: string;
+  /** Human-readable description. */
+  description?: string;
+  /** Consent type (opt-in or opt-out). */
+  consentType?: string;
+  /** Whether legitimate interest applies. */
+  legitimateInterest?: boolean;
+}
+
+export interface BloomreachUrlList {
+  id: string;
+  name: string;
+  /** List type (allowlist or blocklist). */
+  listType: string;
+  /** URLs in the list. */
+  urls?: string[];
+  /** Human-readable description. */
+  description?: string;
+}
+
+export interface BloomreachPageVariable {
+  id: string;
+  /** Variable name used in templates. */
+  name: string;
+  /** Default value. */
+  value: string;
+  /** Human-readable description. */
+  description?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input interfaces
+// ---------------------------------------------------------------------------
+
+export interface ViewCampaignDefaultsInput {
+  project: string;
+}
+
+export interface UpdateCampaignDefaultsInput {
+  project: string;
+  defaultSenderName?: string;
+  defaultSenderEmail?: string;
+  defaultReplyToEmail?: string;
+  defaultUtmSource?: string;
+  defaultUtmMedium?: string;
+  defaultUtmCampaign?: string;
+  operatorNote?: string;
+}
+
+export interface ListTimezonesInput {
+  project: string;
+}
+
+export interface CreateTimezoneInput {
+  project: string;
+  name: string;
+  utcOffset?: string;
+  isDefault?: boolean;
+  operatorNote?: string;
+}
+
+export interface UpdateTimezoneInput {
+  project: string;
+  timezoneId: string;
+  name?: string;
+  utcOffset?: string;
+  isDefault?: boolean;
+  operatorNote?: string;
+}
+
+export interface DeleteTimezoneInput {
+  project: string;
+  timezoneId: string;
+  operatorNote?: string;
+}
+
+export interface ListLanguagesInput {
+  project: string;
+}
+
+export interface CreateLanguageInput {
+  project: string;
+  code: string;
+  name: string;
+  isDefault?: boolean;
+  operatorNote?: string;
+}
+
+export interface UpdateLanguageInput {
+  project: string;
+  languageCode: string;
+  code?: string;
+  name?: string;
+  isDefault?: boolean;
+  operatorNote?: string;
+}
+
+export interface DeleteLanguageInput {
+  project: string;
+  languageCode: string;
+  operatorNote?: string;
+}
+
+export interface ListFontsInput {
+  project: string;
+}
+
+export interface CreateFontInput {
+  project: string;
+  name: string;
+  type: string;
+  fileUrl?: string;
+  operatorNote?: string;
+}
+
+export interface UpdateFontInput {
+  project: string;
+  fontId: string;
+  name?: string;
+  type?: string;
+  fileUrl?: string;
+  operatorNote?: string;
+}
+
+export interface DeleteFontInput {
+  project: string;
+  fontId: string;
+  operatorNote?: string;
+}
+
+export interface ListThroughputPoliciesInput {
+  project: string;
+}
+
+export interface CreateThroughputPolicyInput {
+  project: string;
+  name: string;
+  channel?: string;
+  maxRate?: number;
+  periodSeconds?: number;
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface UpdateThroughputPolicyInput {
+  project: string;
+  policyId: string;
+  name?: string;
+  channel?: string;
+  maxRate?: number;
+  periodSeconds?: number;
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface DeleteThroughputPolicyInput {
+  project: string;
+  policyId: string;
+  operatorNote?: string;
+}
+
+export interface ListFrequencyPoliciesInput {
+  project: string;
+}
+
+export interface CreateFrequencyPolicyInput {
+  project: string;
+  name: string;
+  policyType?: string;
+  maxSends?: number;
+  windowHours?: number;
+  channels?: string[];
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface UpdateFrequencyPolicyInput {
+  project: string;
+  policyId: string;
+  name?: string;
+  policyType?: string;
+  maxSends?: number;
+  windowHours?: number;
+  channels?: string[];
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface DeleteFrequencyPolicyInput {
+  project: string;
+  policyId: string;
+  operatorNote?: string;
+}
+
+export interface ListConsentsInput {
+  project: string;
+}
+
+export interface CreateConsentInput {
+  project: string;
+  category: string;
+  description?: string;
+  consentType?: string;
+  legitimateInterest?: boolean;
+  operatorNote?: string;
+}
+
+export interface UpdateConsentInput {
+  project: string;
+  consentId: string;
+  category?: string;
+  description?: string;
+  consentType?: string;
+  legitimateInterest?: boolean;
+  operatorNote?: string;
+}
+
+export interface DeleteConsentInput {
+  project: string;
+  consentId: string;
+  operatorNote?: string;
+}
+
+export interface ListUrlListsInput {
+  project: string;
+}
+
+export interface CreateUrlListInput {
+  project: string;
+  name: string;
+  listType: string;
+  urls?: string[];
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface UpdateUrlListInput {
+  project: string;
+  urlListId: string;
+  name?: string;
+  listType?: string;
+  urls?: string[];
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface DeleteUrlListInput {
+  project: string;
+  urlListId: string;
+  operatorNote?: string;
+}
+
+export interface ListPageVariablesInput {
+  project: string;
+}
+
+export interface CreatePageVariableInput {
+  project: string;
+  name: string;
+  value: string;
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface UpdatePageVariableInput {
+  project: string;
+  pageVariableId: string;
+  name?: string;
+  value?: string;
+  description?: string;
+  operatorNote?: string;
+}
+
+export interface DeletePageVariableInput {
+  project: string;
+  pageVariableId: string;
+  operatorNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Prepared action result
+// ---------------------------------------------------------------------------
+
+export interface PreparedCampaignSettingsAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const MAX_TIMEZONE_NAME_LENGTH = 100;
+const MIN_TIMEZONE_NAME_LENGTH = 1;
+const MAX_LANGUAGE_CODE_LENGTH = 10;
+const MIN_LANGUAGE_CODE_LENGTH = 1;
+const MAX_LANGUAGE_NAME_LENGTH = 100;
+const MIN_LANGUAGE_NAME_LENGTH = 1;
+const MAX_FONT_NAME_LENGTH = 100;
+const MIN_FONT_NAME_LENGTH = 1;
+const MAX_POLICY_NAME_LENGTH = 120;
+const MIN_POLICY_NAME_LENGTH = 1;
+const MAX_CONSENT_CATEGORY_LENGTH = 120;
+const MIN_CONSENT_CATEGORY_LENGTH = 1;
+const MAX_URL_LIST_NAME_LENGTH = 120;
+const MIN_URL_LIST_NAME_LENGTH = 1;
+const MAX_PAGE_VARIABLE_NAME_LENGTH = 200;
+const MIN_PAGE_VARIABLE_NAME_LENGTH = 1;
+const MAX_PAGE_VARIABLE_VALUE_LENGTH = 5000;
+
+export function validateTimezoneName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_TIMEZONE_NAME_LENGTH) {
+    throw new Error('Timezone name must not be empty.');
+  }
+  if (trimmed.length > MAX_TIMEZONE_NAME_LENGTH) {
+    throw new Error(
+      `Timezone name must not exceed ${MAX_TIMEZONE_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateTimezoneId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Timezone ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateLanguageCode(code: string): string {
+  const trimmed = code.trim();
+  if (trimmed.length < MIN_LANGUAGE_CODE_LENGTH) {
+    throw new Error('Language code must not be empty.');
+  }
+  if (trimmed.length > MAX_LANGUAGE_CODE_LENGTH) {
+    throw new Error(
+      `Language code must not exceed ${MAX_LANGUAGE_CODE_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateLanguageName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_LANGUAGE_NAME_LENGTH) {
+    throw new Error('Language name must not be empty.');
+  }
+  if (trimmed.length > MAX_LANGUAGE_NAME_LENGTH) {
+    throw new Error(
+      `Language name must not exceed ${MAX_LANGUAGE_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateFontName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_FONT_NAME_LENGTH) {
+    throw new Error('Font name must not be empty.');
+  }
+  if (trimmed.length > MAX_FONT_NAME_LENGTH) {
+    throw new Error(
+      `Font name must not exceed ${MAX_FONT_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateFontId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Font ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validatePolicyName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_POLICY_NAME_LENGTH) {
+    throw new Error('Policy name must not be empty.');
+  }
+  if (trimmed.length > MAX_POLICY_NAME_LENGTH) {
+    throw new Error(
+      `Policy name must not exceed ${MAX_POLICY_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validatePolicyId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Policy ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateConsentCategory(category: string): string {
+  const trimmed = category.trim();
+  if (trimmed.length < MIN_CONSENT_CATEGORY_LENGTH) {
+    throw new Error('Consent category must not be empty.');
+  }
+  if (trimmed.length > MAX_CONSENT_CATEGORY_LENGTH) {
+    throw new Error(
+      `Consent category must not exceed ${MAX_CONSENT_CATEGORY_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateConsentId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Consent ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateUrlListName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_URL_LIST_NAME_LENGTH) {
+    throw new Error('URL list name must not be empty.');
+  }
+  if (trimmed.length > MAX_URL_LIST_NAME_LENGTH) {
+    throw new Error(
+      `URL list name must not exceed ${MAX_URL_LIST_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateUrlListId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('URL list ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validatePageVariableName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_PAGE_VARIABLE_NAME_LENGTH) {
+    throw new Error('Page variable name must not be empty.');
+  }
+  if (trimmed.length > MAX_PAGE_VARIABLE_NAME_LENGTH) {
+    throw new Error(
+      `Page variable name must not exceed ${MAX_PAGE_VARIABLE_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validatePageVariableId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Page variable ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validatePageVariableValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length > MAX_PAGE_VARIABLE_VALUE_LENGTH) {
+    throw new Error(
+      `Page variable value must not exceed ${MAX_PAGE_VARIABLE_VALUE_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+export function buildCampaignSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/campaigns`;
+}
+
+export function buildTimezonesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/timezones`;
+}
+
+export function buildLanguagesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/languages`;
+}
+
+export function buildFontsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/fonts`;
+}
+
+export function buildThroughputPolicyUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/throughput-policy`;
+}
+
+export function buildFrequencyPoliciesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/campaign-frequency-policies`;
+}
+
+export function buildConsentsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/consents`;
+}
+
+export function buildGlobalUrlListsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/global-url-lists`;
+}
+
+export function buildPageVariablesUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/page-variables`;
+}
+
+// ---------------------------------------------------------------------------
+// Action executor interface + implementations
+// ---------------------------------------------------------------------------
+
+export interface CampaignSettingsActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class UpdateCampaignDefaultsExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateCampaignDefaultsExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateTimezoneExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_TIMEZONE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateTimezoneExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateTimezoneExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_TIMEZONE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateTimezoneExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteTimezoneExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_TIMEZONE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteTimezoneExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateLanguageExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_LANGUAGE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateLanguageExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateLanguageExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_LANGUAGE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateLanguageExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteLanguageExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_LANGUAGE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteLanguageExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateFontExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_FONT_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateFontExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateFontExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_FONT_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateFontExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteFontExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_FONT_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteFontExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateThroughputPolicyExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_THROUGHPUT_POLICY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateThroughputPolicyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateThroughputPolicyExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_THROUGHPUT_POLICY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateThroughputPolicyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteThroughputPolicyExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_THROUGHPUT_POLICY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteThroughputPolicyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateFrequencyPolicyExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_FREQUENCY_POLICY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateFrequencyPolicyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateFrequencyPolicyExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_FREQUENCY_POLICY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateFrequencyPolicyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteFrequencyPolicyExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_FREQUENCY_POLICY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteFrequencyPolicyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateConsentExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_CONSENT_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateConsentExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateConsentExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_CONSENT_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateConsentExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteConsentExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_CONSENT_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteConsentExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreateUrlListExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_URL_LIST_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateUrlListExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateUrlListExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_URL_LIST_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateUrlListExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteUrlListExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_URL_LIST_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteUrlListExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class CreatePageVariableExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = CREATE_PAGE_VARIABLE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreatePageVariableExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdatePageVariableExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = UPDATE_PAGE_VARIABLE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdatePageVariableExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeletePageVariableExecutor implements CampaignSettingsActionExecutor {
+  readonly actionType = DELETE_PAGE_VARIABLE_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeletePageVariableExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createCampaignSettingsActionExecutors(): Record<
+  string,
+  CampaignSettingsActionExecutor
+> {
+  return {
+    [UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE]: new UpdateCampaignDefaultsExecutor(),
+    [CREATE_TIMEZONE_ACTION_TYPE]: new CreateTimezoneExecutor(),
+    [UPDATE_TIMEZONE_ACTION_TYPE]: new UpdateTimezoneExecutor(),
+    [DELETE_TIMEZONE_ACTION_TYPE]: new DeleteTimezoneExecutor(),
+    [CREATE_LANGUAGE_ACTION_TYPE]: new CreateLanguageExecutor(),
+    [UPDATE_LANGUAGE_ACTION_TYPE]: new UpdateLanguageExecutor(),
+    [DELETE_LANGUAGE_ACTION_TYPE]: new DeleteLanguageExecutor(),
+    [CREATE_FONT_ACTION_TYPE]: new CreateFontExecutor(),
+    [UPDATE_FONT_ACTION_TYPE]: new UpdateFontExecutor(),
+    [DELETE_FONT_ACTION_TYPE]: new DeleteFontExecutor(),
+    [CREATE_THROUGHPUT_POLICY_ACTION_TYPE]: new CreateThroughputPolicyExecutor(),
+    [UPDATE_THROUGHPUT_POLICY_ACTION_TYPE]: new UpdateThroughputPolicyExecutor(),
+    [DELETE_THROUGHPUT_POLICY_ACTION_TYPE]: new DeleteThroughputPolicyExecutor(),
+    [CREATE_FREQUENCY_POLICY_ACTION_TYPE]: new CreateFrequencyPolicyExecutor(),
+    [UPDATE_FREQUENCY_POLICY_ACTION_TYPE]: new UpdateFrequencyPolicyExecutor(),
+    [DELETE_FREQUENCY_POLICY_ACTION_TYPE]: new DeleteFrequencyPolicyExecutor(),
+    [CREATE_CONSENT_ACTION_TYPE]: new CreateConsentExecutor(),
+    [UPDATE_CONSENT_ACTION_TYPE]: new UpdateConsentExecutor(),
+    [DELETE_CONSENT_ACTION_TYPE]: new DeleteConsentExecutor(),
+    [CREATE_URL_LIST_ACTION_TYPE]: new CreateUrlListExecutor(),
+    [UPDATE_URL_LIST_ACTION_TYPE]: new UpdateUrlListExecutor(),
+    [DELETE_URL_LIST_ACTION_TYPE]: new DeleteUrlListExecutor(),
+    [CREATE_PAGE_VARIABLE_ACTION_TYPE]: new CreatePageVariableExecutor(),
+    [UPDATE_PAGE_VARIABLE_ACTION_TYPE]: new UpdatePageVariableExecutor(),
+    [DELETE_PAGE_VARIABLE_ACTION_TYPE]: new DeletePageVariableExecutor(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
+export class BloomreachCampaignSettingsService {
+  private readonly campaignsUrl: string;
+  private readonly timezonesUrl: string;
+  private readonly languagesUrl: string;
+  private readonly fontsUrl: string;
+  private readonly throughputUrl: string;
+  private readonly frequencyUrl: string;
+  private readonly consentsUrl: string;
+  private readonly urlListsUrl: string;
+  private readonly pageVariablesUrl: string;
+
+  constructor(project: string) {
+    const validated = validateProject(project);
+    this.campaignsUrl = buildCampaignSettingsUrl(validated);
+    this.timezonesUrl = buildTimezonesUrl(validated);
+    this.languagesUrl = buildLanguagesUrl(validated);
+    this.fontsUrl = buildFontsUrl(validated);
+    this.throughputUrl = buildThroughputPolicyUrl(validated);
+    this.frequencyUrl = buildFrequencyPoliciesUrl(validated);
+    this.consentsUrl = buildConsentsUrl(validated);
+    this.urlListsUrl = buildGlobalUrlListsUrl(validated);
+    this.pageVariablesUrl = buildPageVariablesUrl(validated);
+  }
+
+  get campaignSettingsUrl(): string {
+    return this.campaignsUrl;
+  }
+
+  get timezonesSettingsUrl(): string {
+    return this.timezonesUrl;
+  }
+
+  get languagesSettingsUrl(): string {
+    return this.languagesUrl;
+  }
+
+  get fontsSettingsUrl(): string {
+    return this.fontsUrl;
+  }
+
+  get throughputPolicySettingsUrl(): string {
+    return this.throughputUrl;
+  }
+
+  get frequencyPoliciesSettingsUrl(): string {
+    return this.frequencyUrl;
+  }
+
+  get consentsSettingsUrl(): string {
+    return this.consentsUrl;
+  }
+
+  get globalUrlListsSettingsUrl(): string {
+    return this.urlListsUrl;
+  }
+
+  get pageVariablesSettingsUrl(): string {
+    return this.pageVariablesUrl;
+  }
+
+  async viewCampaignDefaults(
+    _input?: ViewCampaignDefaultsInput,
+  ): Promise<BloomreachCampaignDefaults> {
+    throw new Error(
+      'viewCampaignDefaults: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listTimezones(_input?: ListTimezonesInput): Promise<BloomreachTimezone[]> {
+    throw new Error(
+      'listTimezones: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listLanguages(_input?: ListLanguagesInput): Promise<BloomreachLanguage[]> {
+    throw new Error(
+      'listLanguages: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listFonts(_input?: ListFontsInput): Promise<BloomreachFont[]> {
+    throw new Error('listFonts: not yet implemented. Requires browser automation infrastructure.');
+  }
+
+  async listThroughputPolicies(
+    _input?: ListThroughputPoliciesInput,
+  ): Promise<BloomreachThroughputPolicy[]> {
+    throw new Error(
+      'listThroughputPolicies: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listFrequencyPolicies(
+    _input?: ListFrequencyPoliciesInput,
+  ): Promise<BloomreachFrequencyPolicy[]> {
+    throw new Error(
+      'listFrequencyPolicies: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listConsents(_input?: ListConsentsInput): Promise<BloomreachConsent[]> {
+    throw new Error(
+      'listConsents: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listUrlLists(_input?: ListUrlListsInput): Promise<BloomreachUrlList[]> {
+    throw new Error(
+      'listUrlLists: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async listPageVariables(_input?: ListPageVariablesInput): Promise<BloomreachPageVariable[]> {
+    throw new Error(
+      'listPageVariables: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareUpdateCampaignDefaults(
+    input: UpdateCampaignDefaultsInput,
+  ): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const defaultSenderName =
+      input.defaultSenderName !== undefined
+        ? validatePolicyName(input.defaultSenderName)
+        : undefined;
+    const defaultSenderEmail =
+      input.defaultSenderEmail !== undefined ? input.defaultSenderEmail.trim() : undefined;
+    const defaultReplyToEmail =
+      input.defaultReplyToEmail !== undefined ? input.defaultReplyToEmail.trim() : undefined;
+    const defaultUtmSource =
+      input.defaultUtmSource !== undefined ? input.defaultUtmSource.trim() : undefined;
+    const defaultUtmMedium =
+      input.defaultUtmMedium !== undefined ? input.defaultUtmMedium.trim() : undefined;
+    const defaultUtmCampaign =
+      input.defaultUtmCampaign !== undefined ? input.defaultUtmCampaign.trim() : undefined;
+
+    if (
+      defaultSenderName === undefined &&
+      defaultSenderEmail === undefined &&
+      defaultReplyToEmail === undefined &&
+      defaultUtmSource === undefined &&
+      defaultUtmMedium === undefined &&
+      defaultUtmCampaign === undefined
+    ) {
+      throw new Error('At least one campaign default field must be provided for defaults update.');
+    }
+
+    const preview = {
+      action: UPDATE_CAMPAIGN_DEFAULTS_ACTION_TYPE,
+      project,
+      defaultSenderName,
+      defaultSenderEmail,
+      defaultReplyToEmail,
+      defaultUtmSource,
+      defaultUtmMedium,
+      defaultUtmCampaign,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateTimezone(input: CreateTimezoneInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const name = validateTimezoneName(input.name);
+
+    const preview = {
+      action: CREATE_TIMEZONE_ACTION_TYPE,
+      project,
+      name,
+      utcOffset: input.utcOffset,
+      isDefault: input.isDefault,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateTimezone(input: UpdateTimezoneInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const timezoneId = validateTimezoneId(input.timezoneId);
+    const name = input.name !== undefined ? validateTimezoneName(input.name) : undefined;
+
+    if (name === undefined && input.utcOffset === undefined && input.isDefault === undefined) {
+      throw new Error(
+        'At least one of name, utcOffset, or isDefault must be provided for timezone update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_TIMEZONE_ACTION_TYPE,
+      project,
+      timezoneId,
+      name,
+      utcOffset: input.utcOffset,
+      isDefault: input.isDefault,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteTimezone(input: DeleteTimezoneInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const timezoneId = validateTimezoneId(input.timezoneId);
+
+    const preview = {
+      action: DELETE_TIMEZONE_ACTION_TYPE,
+      project,
+      timezoneId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateLanguage(input: CreateLanguageInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const code = validateLanguageCode(input.code);
+    const name = validateLanguageName(input.name);
+
+    const preview = {
+      action: CREATE_LANGUAGE_ACTION_TYPE,
+      project,
+      code,
+      name,
+      isDefault: input.isDefault,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateLanguage(input: UpdateLanguageInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const languageCode = validateLanguageCode(input.languageCode);
+    const code = input.code !== undefined ? validateLanguageCode(input.code) : undefined;
+    const name = input.name !== undefined ? validateLanguageName(input.name) : undefined;
+
+    if (code === undefined && name === undefined && input.isDefault === undefined) {
+      throw new Error(
+        'At least one of code, name, or isDefault must be provided for language update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_LANGUAGE_ACTION_TYPE,
+      project,
+      languageCode,
+      code,
+      name,
+      isDefault: input.isDefault,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteLanguage(input: DeleteLanguageInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const languageCode = validateLanguageCode(input.languageCode);
+
+    const preview = {
+      action: DELETE_LANGUAGE_ACTION_TYPE,
+      project,
+      languageCode,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateFont(input: CreateFontInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const name = validateFontName(input.name);
+    const type = input.type.trim();
+    if (type.length === 0) {
+      throw new Error('Font type must not be empty.');
+    }
+
+    const preview = {
+      action: CREATE_FONT_ACTION_TYPE,
+      project,
+      name,
+      type,
+      fileUrl: input.fileUrl,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateFont(input: UpdateFontInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const fontId = validateFontId(input.fontId);
+    const name = input.name !== undefined ? validateFontName(input.name) : undefined;
+    const type = input.type !== undefined ? input.type.trim() : undefined;
+
+    if (type !== undefined && type.length === 0) {
+      throw new Error('Font type must not be empty.');
+    }
+
+    if (name === undefined && type === undefined && input.fileUrl === undefined) {
+      throw new Error('At least one of name, type, or fileUrl must be provided for font update.');
+    }
+
+    const preview = {
+      action: UPDATE_FONT_ACTION_TYPE,
+      project,
+      fontId,
+      name,
+      type,
+      fileUrl: input.fileUrl,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteFont(input: DeleteFontInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const fontId = validateFontId(input.fontId);
+
+    const preview = {
+      action: DELETE_FONT_ACTION_TYPE,
+      project,
+      fontId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateThroughputPolicy(
+    input: CreateThroughputPolicyInput,
+  ): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const name = validatePolicyName(input.name);
+
+    const preview = {
+      action: CREATE_THROUGHPUT_POLICY_ACTION_TYPE,
+      project,
+      name,
+      channel: input.channel,
+      maxRate: input.maxRate,
+      periodSeconds: input.periodSeconds,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateThroughputPolicy(
+    input: UpdateThroughputPolicyInput,
+  ): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const policyId = validatePolicyId(input.policyId);
+    const name = input.name !== undefined ? validatePolicyName(input.name) : undefined;
+
+    if (
+      name === undefined &&
+      input.channel === undefined &&
+      input.maxRate === undefined &&
+      input.periodSeconds === undefined &&
+      input.description === undefined
+    ) {
+      throw new Error(
+        'At least one modifiable field must be provided for throughput policy update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_THROUGHPUT_POLICY_ACTION_TYPE,
+      project,
+      policyId,
+      name,
+      channel: input.channel,
+      maxRate: input.maxRate,
+      periodSeconds: input.periodSeconds,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteThroughputPolicy(
+    input: DeleteThroughputPolicyInput,
+  ): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const policyId = validatePolicyId(input.policyId);
+
+    const preview = {
+      action: DELETE_THROUGHPUT_POLICY_ACTION_TYPE,
+      project,
+      policyId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateFrequencyPolicy(input: CreateFrequencyPolicyInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const name = validatePolicyName(input.name);
+
+    const preview = {
+      action: CREATE_FREQUENCY_POLICY_ACTION_TYPE,
+      project,
+      name,
+      policyType: input.policyType,
+      maxSends: input.maxSends,
+      windowHours: input.windowHours,
+      channels: input.channels,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateFrequencyPolicy(input: UpdateFrequencyPolicyInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const policyId = validatePolicyId(input.policyId);
+    const name = input.name !== undefined ? validatePolicyName(input.name) : undefined;
+
+    if (
+      name === undefined &&
+      input.policyType === undefined &&
+      input.maxSends === undefined &&
+      input.windowHours === undefined &&
+      input.channels === undefined &&
+      input.description === undefined
+    ) {
+      throw new Error(
+        'At least one modifiable field must be provided for frequency policy update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_FREQUENCY_POLICY_ACTION_TYPE,
+      project,
+      policyId,
+      name,
+      policyType: input.policyType,
+      maxSends: input.maxSends,
+      windowHours: input.windowHours,
+      channels: input.channels,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteFrequencyPolicy(input: DeleteFrequencyPolicyInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const policyId = validatePolicyId(input.policyId);
+
+    const preview = {
+      action: DELETE_FREQUENCY_POLICY_ACTION_TYPE,
+      project,
+      policyId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateConsent(input: CreateConsentInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const category = validateConsentCategory(input.category);
+
+    const preview = {
+      action: CREATE_CONSENT_ACTION_TYPE,
+      project,
+      category,
+      description: input.description,
+      consentType: input.consentType,
+      legitimateInterest: input.legitimateInterest,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateConsent(input: UpdateConsentInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const consentId = validateConsentId(input.consentId);
+    const category =
+      input.category !== undefined ? validateConsentCategory(input.category) : undefined;
+
+    if (
+      category === undefined &&
+      input.description === undefined &&
+      input.consentType === undefined &&
+      input.legitimateInterest === undefined
+    ) {
+      throw new Error(
+        'At least one of category, description, consentType, or legitimateInterest must be provided for consent update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_CONSENT_ACTION_TYPE,
+      project,
+      consentId,
+      category,
+      description: input.description,
+      consentType: input.consentType,
+      legitimateInterest: input.legitimateInterest,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteConsent(input: DeleteConsentInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const consentId = validateConsentId(input.consentId);
+
+    const preview = {
+      action: DELETE_CONSENT_ACTION_TYPE,
+      project,
+      consentId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreateUrlList(input: CreateUrlListInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const name = validateUrlListName(input.name);
+    const listType = input.listType.trim();
+    if (listType.length === 0) {
+      throw new Error('URL list type must not be empty.');
+    }
+
+    const preview = {
+      action: CREATE_URL_LIST_ACTION_TYPE,
+      project,
+      name,
+      listType,
+      urls: input.urls,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateUrlList(input: UpdateUrlListInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const urlListId = validateUrlListId(input.urlListId);
+    const name = input.name !== undefined ? validateUrlListName(input.name) : undefined;
+    const listType = input.listType !== undefined ? input.listType.trim() : undefined;
+
+    if (listType !== undefined && listType.length === 0) {
+      throw new Error('URL list type must not be empty.');
+    }
+
+    if (
+      name === undefined &&
+      listType === undefined &&
+      input.urls === undefined &&
+      input.description === undefined
+    ) {
+      throw new Error(
+        'At least one of name, listType, urls, or description must be provided for URL list update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_URL_LIST_ACTION_TYPE,
+      project,
+      urlListId,
+      name,
+      listType,
+      urls: input.urls,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteUrlList(input: DeleteUrlListInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const urlListId = validateUrlListId(input.urlListId);
+
+    const preview = {
+      action: DELETE_URL_LIST_ACTION_TYPE,
+      project,
+      urlListId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareCreatePageVariable(input: CreatePageVariableInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const name = validatePageVariableName(input.name);
+    const value = validatePageVariableValue(input.value);
+
+    const preview = {
+      action: CREATE_PAGE_VARIABLE_ACTION_TYPE,
+      project,
+      name,
+      value,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdatePageVariable(input: UpdatePageVariableInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const pageVariableId = validatePageVariableId(input.pageVariableId);
+    const name = input.name !== undefined ? validatePageVariableName(input.name) : undefined;
+    const value = input.value !== undefined ? validatePageVariableValue(input.value) : undefined;
+
+    if (name === undefined && value === undefined && input.description === undefined) {
+      throw new Error(
+        'At least one of name, value, or description must be provided for page variable update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_PAGE_VARIABLE_ACTION_TYPE,
+      project,
+      pageVariableId,
+      name,
+      value,
+      description: input.description,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeletePageVariable(input: DeletePageVariableInput): PreparedCampaignSettingsAction {
+    const project = validateProject(input.project);
+    const pageVariableId = validatePageVariableId(input.pageVariableId);
+
+    const preview = {
+      action: DELETE_PAGE_VARIABLE_ACTION_TYPE,
+      project,
+      pageVariableId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './bloomreachCampaignCalendar.js';
+export * from './bloomreachCampaignSettings.js';
 export * from './bloomreachDashboards.js';
 export * from './bloomreachEmailCampaigns.js';
 export * from './bloomreachFlows.js';


### PR DESCRIPTION
## Summary

Add campaign settings management feature module covering all 9 campaign settings sub-areas from the Bloomreach Engagement project settings:

- **Campaign Defaults** — View/update default campaign configuration
- **Time Zones** — CRUD for project time zones
- **Languages** — CRUD for supported languages
- **Fonts** — CRUD for custom fonts
- **Throughput Policies** — CRUD for send rate limits
- **Frequency Policies** — CRUD for global send frequency caps
- **Consents** — CRUD for consent categories and settings
- **URL Lists** — CRUD for global URL allow/block lists
- **Page Variables** — CRUD for page-level variables

## Changes

### Core Module (`packages/core/src/bloomreachCampaignSettings.ts` — 1,761 lines)
- 25 action type constants across 9 sub-areas
- 9 rate limit constants
- 9 data interfaces with full JSDoc documentation
- Input interfaces for all read/list and mutation operations
- `PreparedCampaignSettingsAction` interface for two-phase commit
- 15 validation helpers (name, ID, value validators per entity)
- 9 URL builders matching Bloomreach dashboard paths
- 25 action executor classes with factory function
- `BloomreachCampaignSettingsService` with 9 read methods + 25 prepare methods

### Barrel Export (`packages/core/src/index.ts`)
- Added `export * from './bloomreachCampaignSettings.js'`

### Test Suite (`packages/core/src/__tests__/bloomreachCampaignSettings.test.ts`)
- **199 tests** covering all exports:
  - Action type constants (25 tests)
  - Rate limit constants (9 tests)
  - Validation helpers (~60 tests with boundary conditions)
  - URL builders (27 tests with encoding)
  - Executor factory (3 tests)
  - Service class constructor, URL getters, read methods, and all 25 prepare methods

### CLI Commands (`packages/cli/src/bin/bloomreach.ts`)
- New `campaign-settings` command group with 34 subcommands across 9 sub-areas
- Each entity supports list + create/update/delete (two-phase commit)
- Human-readable and JSON output modes
- Full option sets matching entity interfaces

## Quality Gates

| Gate | Status |
|------|--------|
| Tests | ✅ 2,272 passed (199 new + 2,073 existing) |
| Lint | ✅ Clean |
| Build | ✅ Clean |
| Format | ✅ Applied |
| LSP Diagnostics | ✅ 0 errors on all changed files |

Closes #57
