### PR TITLE
feat #58: add channel settings management feature module

### DIFF
--- a/packages/core/src/__tests__/bloomreachChannelSettings.test.ts
+++ b/packages/core/src/__tests__/bloomreachChannelSettings.test.ts
@@ -1,0 +1,610 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE,
+  CONFIGURE_PUSH_PROVIDER_ACTION_TYPE,
+  CONFIGURE_SMS_PROVIDER_ACTION_TYPE,
+  CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE,
+  CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE,
+  CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE,
+  CHANNEL_SETTINGS_RATE_LIMIT_WINDOW_MS,
+  CHANNEL_SETTINGS_CONFIGURE_RATE_LIMIT,
+  validateDomain,
+  validateProviderName,
+  validateSenderNumber,
+  validatePageId,
+  buildEmailSettingsUrl,
+  buildPushNotificationSettingsUrl,
+  buildSmsSettingsUrl,
+  buildMobileMessagingSettingsUrl,
+  buildPaymentTrackingSettingsUrl,
+  buildFacebookMessagingSettingsUrl,
+  createChannelSettingsActionExecutors,
+  BloomreachChannelSettingsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE', () => {
+    expect(CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE).toBe('channel_settings.configure_email_domain');
+  });
+
+  it('exports CONFIGURE_PUSH_PROVIDER_ACTION_TYPE', () => {
+    expect(CONFIGURE_PUSH_PROVIDER_ACTION_TYPE).toBe('channel_settings.configure_push_provider');
+  });
+
+  it('exports CONFIGURE_SMS_PROVIDER_ACTION_TYPE', () => {
+    expect(CONFIGURE_SMS_PROVIDER_ACTION_TYPE).toBe('channel_settings.configure_sms_provider');
+  });
+
+  it('exports CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE', () => {
+    expect(CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE).toBe(
+      'channel_settings.configure_mobile_messaging',
+    );
+  });
+
+  it('exports CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE', () => {
+    expect(CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE).toBe(
+      'channel_settings.configure_payment_tracking',
+    );
+  });
+
+  it('exports CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE', () => {
+    expect(CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE).toBe(
+      'channel_settings.configure_facebook_messaging',
+    );
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports CHANNEL_SETTINGS_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(CHANNEL_SETTINGS_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports CHANNEL_SETTINGS_CONFIGURE_RATE_LIMIT', () => {
+    expect(CHANNEL_SETTINGS_CONFIGURE_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('validateDomain', () => {
+  it('throws for empty string', () => {
+    expect(() => validateDomain('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateDomain('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed domain for valid input', () => {
+    expect(validateDomain('  mail.example.com  ')).toBe('mail.example.com');
+  });
+
+  it('accepts domain at maximum length', () => {
+    const domain = 'x'.repeat(253);
+    expect(validateDomain(domain)).toBe(domain);
+  });
+
+  it('throws for domain exceeding maximum length', () => {
+    const domain = 'x'.repeat(254);
+    expect(() => validateDomain(domain)).toThrow('must not exceed 253 characters');
+  });
+});
+
+describe('validateProviderName', () => {
+  it('throws for empty string', () => {
+    expect(() => validateProviderName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateProviderName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed provider name for valid input', () => {
+    expect(validateProviderName('  Firebase  ')).toBe('Firebase');
+  });
+
+  it('accepts provider name at maximum length', () => {
+    const provider = 'x'.repeat(100);
+    expect(validateProviderName(provider)).toBe(provider);
+  });
+
+  it('throws for provider name exceeding maximum length', () => {
+    const provider = 'x'.repeat(101);
+    expect(() => validateProviderName(provider)).toThrow('must not exceed 100 characters');
+  });
+});
+
+describe('validateSenderNumber', () => {
+  it('throws for empty string', () => {
+    expect(() => validateSenderNumber('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateSenderNumber('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed sender number for valid input', () => {
+    expect(validateSenderNumber('  +15551234567  ')).toBe('+15551234567');
+  });
+
+  it('accepts sender number at maximum length', () => {
+    const senderNumber = 'x'.repeat(30);
+    expect(validateSenderNumber(senderNumber)).toBe(senderNumber);
+  });
+
+  it('throws for sender number exceeding maximum length', () => {
+    const senderNumber = 'x'.repeat(31);
+    expect(() => validateSenderNumber(senderNumber)).toThrow('must not exceed 30 characters');
+  });
+});
+
+describe('validatePageId', () => {
+  it('throws for empty string', () => {
+    expect(() => validatePageId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validatePageId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed page ID for valid input', () => {
+    expect(validatePageId('  page-123  ')).toBe('page-123');
+  });
+});
+
+describe('URL builders', () => {
+  it('builds all URLs for a simple project name', () => {
+    expect(buildEmailSettingsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/project-settings/emails');
+    expect(buildPushNotificationSettingsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/push-notifications',
+    );
+    expect(buildSmsSettingsUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/project-settings/sms');
+    expect(buildMobileMessagingSettingsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/mobile-messaging',
+    );
+    expect(buildPaymentTrackingSettingsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/payment-tracking',
+    );
+    expect(buildFacebookMessagingSettingsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/facebook-messaging',
+    );
+  });
+
+  it('encodes spaces in all URLs', () => {
+    expect(buildEmailSettingsUrl('my project')).toBe('/p/my%20project/project-settings/emails');
+    expect(buildPushNotificationSettingsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/push-notifications',
+    );
+    expect(buildSmsSettingsUrl('my project')).toBe('/p/my%20project/project-settings/sms');
+    expect(buildMobileMessagingSettingsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/mobile-messaging',
+    );
+    expect(buildPaymentTrackingSettingsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/payment-tracking',
+    );
+    expect(buildFacebookMessagingSettingsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/facebook-messaging',
+    );
+  });
+
+  it('handles project names with slashes in all URLs', () => {
+    expect(buildEmailSettingsUrl('org/project')).toBe('/p/org%2Fproject/project-settings/emails');
+    expect(buildPushNotificationSettingsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/push-notifications',
+    );
+    expect(buildSmsSettingsUrl('org/project')).toBe('/p/org%2Fproject/project-settings/sms');
+    expect(buildMobileMessagingSettingsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/mobile-messaging',
+    );
+    expect(buildPaymentTrackingSettingsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/payment-tracking',
+    );
+    expect(buildFacebookMessagingSettingsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/facebook-messaging',
+    );
+  });
+});
+
+describe('createChannelSettingsActionExecutors', () => {
+  it('returns executors for all six action types', () => {
+    const executors = createChannelSettingsActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(6);
+    expect(executors[CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_PUSH_PROVIDER_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_SMS_PROVIDER_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching key', () => {
+    const executors = createChannelSettingsActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createChannelSettingsActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachChannelSettingsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachChannelSettingsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachChannelSettingsService);
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachChannelSettingsService('  my-project  ');
+      expect(service.emailSettingsUrl).toBe('/p/my-project/project-settings/emails');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachChannelSettingsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('URL getters', () => {
+    it('returns all channel settings URLs', () => {
+      const service = new BloomreachChannelSettingsService('kingdom-of-joakim');
+      expect(service.emailSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/emails');
+      expect(service.pushNotificationSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/push-notifications',
+      );
+      expect(service.smsSettingsUrl).toBe('/p/kingdom-of-joakim/project-settings/sms');
+      expect(service.mobileMessagingSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/mobile-messaging',
+      );
+      expect(service.paymentTrackingSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/payment-tracking',
+      );
+      expect(service.facebookMessagingSettingsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/facebook-messaging',
+      );
+    });
+  });
+
+  describe('read methods', () => {
+    it('viewEmailSettings throws not-yet-implemented error', async () => {
+      const service = new BloomreachChannelSettingsService('test');
+      await expect(service.viewEmailSettings()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewPushNotificationSettings throws not-yet-implemented error', async () => {
+      const service = new BloomreachChannelSettingsService('test');
+      await expect(service.viewPushNotificationSettings()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewSmsSettings throws not-yet-implemented error', async () => {
+      const service = new BloomreachChannelSettingsService('test');
+      await expect(service.viewSmsSettings()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewMobileMessagingSettings throws not-yet-implemented error', async () => {
+      const service = new BloomreachChannelSettingsService('test');
+      await expect(service.viewMobileMessagingSettings()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewPaymentTrackingSettings throws not-yet-implemented error', async () => {
+      const service = new BloomreachChannelSettingsService('test');
+      await expect(service.viewPaymentTrackingSettings()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewFacebookMessagingSettings throws not-yet-implemented error', async () => {
+      const service = new BloomreachChannelSettingsService('test');
+      await expect(service.viewFacebookMessagingSettings()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareConfigureEmailDomain', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureEmailDomain({
+        project: 'test',
+        domain: 'mail.example.com',
+        operatorNote: 'set sending domain',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'channel_settings.configure_email_domain',
+          project: 'test',
+          domain: 'mail.example.com',
+          operatorNote: 'set sending domain',
+        }),
+      );
+    });
+
+    it('trims the domain value', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureEmailDomain({
+        project: 'test',
+        domain: '  mail.example.com  ',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ domain: 'mail.example.com' }));
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureEmailDomain({ project: '', domain: 'mail.example.com' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty domain', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureEmailDomain({ project: 'test', domain: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareConfigurePushProvider', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigurePushProvider({
+        project: 'test',
+        provider: 'firebase',
+        firebaseCredentials: '  firebase-secret  ',
+        apnsCertificate: '  apns-cert  ',
+        operatorNote: 'configure push stack',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'channel_settings.configure_push_provider',
+          project: 'test',
+          provider: 'firebase',
+          firebaseCredentials: 'firebase-secret',
+          apnsCertificate: 'apns-cert',
+          operatorNote: 'configure push stack',
+        }),
+      );
+    });
+
+    it('trims provider name', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigurePushProvider({
+        project: 'test',
+        provider: '  fcm  ',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ provider: 'fcm' }));
+    });
+
+    it('keeps optional credentials undefined when omitted', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigurePushProvider({ project: 'test', provider: 'fcm' });
+      expect(result.preview).toEqual(
+        expect.objectContaining({ firebaseCredentials: undefined, apnsCertificate: undefined }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigurePushProvider({ project: '', provider: 'fcm' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty provider', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigurePushProvider({ project: 'test', provider: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareConfigureSmsProvider', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureSmsProvider({
+        project: 'test',
+        provider: 'twilio',
+        senderNumber: '  +15551234567  ',
+        operatorNote: 'set sms provider',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'channel_settings.configure_sms_provider',
+          project: 'test',
+          provider: 'twilio',
+          senderNumber: '+15551234567',
+          operatorNote: 'set sms provider',
+        }),
+      );
+    });
+
+    it('allows sender number to be omitted', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureSmsProvider({ project: 'test', provider: 'twilio' });
+      expect(result.preview).toEqual(expect.objectContaining({ senderNumber: undefined }));
+    });
+
+    it('trims provider name', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureSmsProvider({ project: 'test', provider: '  twilio  ' });
+      expect(result.preview).toEqual(expect.objectContaining({ provider: 'twilio' }));
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureSmsProvider({ project: '', provider: 'twilio' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty provider', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureSmsProvider({ project: 'test', provider: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareConfigureMobileMessaging', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureMobileMessaging({
+        project: 'test',
+        provider: 'meta',
+        whatsappEnabled: true,
+        rcsEnabled: false,
+        operatorNote: 'configure mobile messaging channels',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'channel_settings.configure_mobile_messaging',
+          project: 'test',
+          provider: 'meta',
+          whatsappEnabled: true,
+          rcsEnabled: false,
+          operatorNote: 'configure mobile messaging channels',
+        }),
+      );
+    });
+
+    it('allows boolean flags to be omitted', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureMobileMessaging({ project: 'test', provider: 'meta' });
+      expect(result.preview).toEqual(
+        expect.objectContaining({ whatsappEnabled: undefined, rcsEnabled: undefined }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureMobileMessaging({ project: '', provider: 'meta' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty provider', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureMobileMessaging({ project: 'test', provider: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareConfigurePaymentTracking', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigurePaymentTracking({
+        project: 'test',
+        provider: 'stripe',
+        enabled: true,
+        operatorNote: 'enable payment provider tracking',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'channel_settings.configure_payment_tracking',
+          project: 'test',
+          provider: 'stripe',
+          enabled: true,
+          operatorNote: 'enable payment provider tracking',
+        }),
+      );
+    });
+
+    it('allows enabled flag to be omitted', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigurePaymentTracking({
+        project: 'test',
+        provider: 'stripe',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ enabled: undefined }));
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigurePaymentTracking({ project: '', provider: 'stripe' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty provider', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigurePaymentTracking({ project: 'test', provider: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareConfigureFacebookMessaging', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureFacebookMessaging({
+        project: 'test',
+        pageId: '  123456789  ',
+        accessToken: '  fb-access-token  ',
+        operatorNote: 'connect page',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'channel_settings.configure_facebook_messaging',
+          project: 'test',
+          pageId: '123456789',
+          accessToken: 'fb-access-token',
+          operatorNote: 'connect page',
+        }),
+      );
+    });
+
+    it('allows access token to be omitted', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureFacebookMessaging({
+        project: 'test',
+        pageId: '123456789',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ accessToken: undefined }));
+    });
+
+    it('trims page ID', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      const result = service.prepareConfigureFacebookMessaging({
+        project: 'test',
+        pageId: '  page-123  ',
+      });
+      expect(result.preview).toEqual(expect.objectContaining({ pageId: 'page-123' }));
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureFacebookMessaging({ project: '', pageId: 'x' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty page ID', () => {
+      const service = new BloomreachChannelSettingsService('test');
+      expect(() => service.prepareConfigureFacebookMessaging({ project: 'test', pageId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+});

--- a/packages/core/src/bloomreachChannelSettings.ts
+++ b/packages/core/src/bloomreachChannelSettings.ts
@@ -1,0 +1,537 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+// ---------------------------------------------------------------------------
+// Action type constants
+// ---------------------------------------------------------------------------
+
+export const CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE = 'channel_settings.configure_email_domain';
+export const CONFIGURE_PUSH_PROVIDER_ACTION_TYPE = 'channel_settings.configure_push_provider';
+export const CONFIGURE_SMS_PROVIDER_ACTION_TYPE = 'channel_settings.configure_sms_provider';
+export const CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE =
+  'channel_settings.configure_mobile_messaging';
+export const CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE =
+  'channel_settings.configure_payment_tracking';
+export const CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE =
+  'channel_settings.configure_facebook_messaging';
+
+// ---------------------------------------------------------------------------
+// Rate limit constants
+// ---------------------------------------------------------------------------
+
+export const CHANNEL_SETTINGS_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const CHANNEL_SETTINGS_CONFIGURE_RATE_LIMIT = 20;
+
+// ---------------------------------------------------------------------------
+// Data interfaces
+// ---------------------------------------------------------------------------
+
+export interface BloomreachEmailSettings {
+  senderDomains?: string[];
+  dkimConfigured?: boolean;
+  spfConfigured?: boolean;
+  defaultFromAddress?: string;
+  url: string;
+}
+
+export interface BloomreachPushNotificationSettings {
+  provider?: string;
+  firebaseConfigured?: boolean;
+  apnsConfigured?: boolean;
+  url: string;
+}
+
+export interface BloomreachSmsSettings {
+  provider?: string;
+  senderNumber?: string;
+  url: string;
+}
+
+export interface BloomreachMobileMessagingSettings {
+  whatsappConfigured?: boolean;
+  rcsConfigured?: boolean;
+  url: string;
+}
+
+export interface BloomreachPaymentTrackingSettings {
+  provider?: string;
+  enabled?: boolean;
+  url: string;
+}
+
+export interface BloomreachFacebookMessagingSettings {
+  pageConnected?: boolean;
+  pageName?: string;
+  url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input interfaces
+// ---------------------------------------------------------------------------
+
+export interface ViewEmailSettingsInput {
+  project: string;
+}
+
+export interface ViewPushNotificationSettingsInput {
+  project: string;
+}
+
+export interface ViewSmsSettingsInput {
+  project: string;
+}
+
+export interface ViewMobileMessagingSettingsInput {
+  project: string;
+}
+
+export interface ViewPaymentTrackingSettingsInput {
+  project: string;
+}
+
+export interface ViewFacebookMessagingSettingsInput {
+  project: string;
+}
+
+export interface ConfigureEmailDomainInput {
+  project: string;
+  domain: string;
+  operatorNote?: string;
+}
+
+export interface ConfigurePushProviderInput {
+  project: string;
+  provider: string;
+  firebaseCredentials?: string;
+  apnsCertificate?: string;
+  operatorNote?: string;
+}
+
+export interface ConfigureSmsProviderInput {
+  project: string;
+  provider: string;
+  senderNumber?: string;
+  operatorNote?: string;
+}
+
+export interface ConfigureMobileMessagingInput {
+  project: string;
+  provider: string;
+  whatsappEnabled?: boolean;
+  rcsEnabled?: boolean;
+  operatorNote?: string;
+}
+
+export interface ConfigurePaymentTrackingInput {
+  project: string;
+  provider: string;
+  enabled?: boolean;
+  operatorNote?: string;
+}
+
+export interface ConfigureFacebookMessagingInput {
+  project: string;
+  pageId: string;
+  accessToken?: string;
+  operatorNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Prepared action result
+// ---------------------------------------------------------------------------
+
+export interface PreparedChannelSettingsAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const MAX_DOMAIN_LENGTH = 253;
+const MAX_PROVIDER_NAME_LENGTH = 100;
+const MAX_SENDER_NUMBER_LENGTH = 30;
+
+export function validateDomain(domain: string): string {
+  const trimmed = domain.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Domain must not be empty.');
+  }
+  if (trimmed.length > MAX_DOMAIN_LENGTH) {
+    throw new Error(
+      `Domain must not exceed ${MAX_DOMAIN_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateProviderName(provider: string): string {
+  const trimmed = provider.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Provider name must not be empty.');
+  }
+  if (trimmed.length > MAX_PROVIDER_NAME_LENGTH) {
+    throw new Error(
+      `Provider name must not exceed ${MAX_PROVIDER_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateSenderNumber(number: string): string {
+  const trimmed = number.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Sender number must not be empty.');
+  }
+  if (trimmed.length > MAX_SENDER_NUMBER_LENGTH) {
+    throw new Error(
+      `Sender number must not exceed ${MAX_SENDER_NUMBER_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validatePageId(pageId: string): string {
+  const trimmed = pageId.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Page ID must not be empty.');
+  }
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+export function buildEmailSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/emails`;
+}
+
+export function buildPushNotificationSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/push-notifications`;
+}
+
+export function buildSmsSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/sms`;
+}
+
+export function buildMobileMessagingSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/mobile-messaging`;
+}
+
+export function buildPaymentTrackingSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/payment-tracking`;
+}
+
+export function buildFacebookMessagingSettingsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/facebook-messaging`;
+}
+
+// ---------------------------------------------------------------------------
+// Action executor interface + implementations
+// ---------------------------------------------------------------------------
+
+export interface ChannelSettingsActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class ConfigureEmailDomainExecutor implements ChannelSettingsActionExecutor {
+  readonly actionType = CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureEmailDomainExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigurePushProviderExecutor implements ChannelSettingsActionExecutor {
+  readonly actionType = CONFIGURE_PUSH_PROVIDER_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigurePushProviderExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigureSmsProviderExecutor implements ChannelSettingsActionExecutor {
+  readonly actionType = CONFIGURE_SMS_PROVIDER_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureSmsProviderExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigureMobileMessagingExecutor implements ChannelSettingsActionExecutor {
+  readonly actionType = CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureMobileMessagingExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigurePaymentTrackingExecutor implements ChannelSettingsActionExecutor {
+  readonly actionType = CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigurePaymentTrackingExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigureFacebookMessagingExecutor implements ChannelSettingsActionExecutor {
+  readonly actionType = CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureFacebookMessagingExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createChannelSettingsActionExecutors(): Record<string, ChannelSettingsActionExecutor> {
+  return {
+    [CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE]: new ConfigureEmailDomainExecutor(),
+    [CONFIGURE_PUSH_PROVIDER_ACTION_TYPE]: new ConfigurePushProviderExecutor(),
+    [CONFIGURE_SMS_PROVIDER_ACTION_TYPE]: new ConfigureSmsProviderExecutor(),
+    [CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE]: new ConfigureMobileMessagingExecutor(),
+    [CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE]: new ConfigurePaymentTrackingExecutor(),
+    [CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE]: new ConfigureFacebookMessagingExecutor(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
+export class BloomreachChannelSettingsService {
+  private readonly emailsUrl: string;
+  private readonly pushNotificationsUrl: string;
+  private readonly smsUrl: string;
+  private readonly mobileMessagingUrl: string;
+  private readonly paymentTrackingUrl: string;
+  private readonly facebookMessagingUrl: string;
+
+  constructor(project: string) {
+    const validated = validateProject(project);
+    this.emailsUrl = buildEmailSettingsUrl(validated);
+    this.pushNotificationsUrl = buildPushNotificationSettingsUrl(validated);
+    this.smsUrl = buildSmsSettingsUrl(validated);
+    this.mobileMessagingUrl = buildMobileMessagingSettingsUrl(validated);
+    this.paymentTrackingUrl = buildPaymentTrackingSettingsUrl(validated);
+    this.facebookMessagingUrl = buildFacebookMessagingSettingsUrl(validated);
+  }
+
+  get emailSettingsUrl(): string {
+    return this.emailsUrl;
+  }
+
+  get pushNotificationSettingsUrl(): string {
+    return this.pushNotificationsUrl;
+  }
+
+  get smsSettingsUrl(): string {
+    return this.smsUrl;
+  }
+
+  get mobileMessagingSettingsUrl(): string {
+    return this.mobileMessagingUrl;
+  }
+
+  get paymentTrackingSettingsUrl(): string {
+    return this.paymentTrackingUrl;
+  }
+
+  get facebookMessagingSettingsUrl(): string {
+    return this.facebookMessagingUrl;
+  }
+
+  async viewEmailSettings(_input?: ViewEmailSettingsInput): Promise<BloomreachEmailSettings> {
+    throw new Error(
+      'viewEmailSettings: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewPushNotificationSettings(
+    _input?: ViewPushNotificationSettingsInput,
+  ): Promise<BloomreachPushNotificationSettings> {
+    throw new Error(
+      'viewPushNotificationSettings: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewSmsSettings(_input?: ViewSmsSettingsInput): Promise<BloomreachSmsSettings> {
+    throw new Error(
+      'viewSmsSettings: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewMobileMessagingSettings(
+    _input?: ViewMobileMessagingSettingsInput,
+  ): Promise<BloomreachMobileMessagingSettings> {
+    throw new Error(
+      'viewMobileMessagingSettings: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewPaymentTrackingSettings(
+    _input?: ViewPaymentTrackingSettingsInput,
+  ): Promise<BloomreachPaymentTrackingSettings> {
+    throw new Error(
+      'viewPaymentTrackingSettings: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewFacebookMessagingSettings(
+    _input?: ViewFacebookMessagingSettingsInput,
+  ): Promise<BloomreachFacebookMessagingSettings> {
+    throw new Error(
+      'viewFacebookMessagingSettings: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareConfigureEmailDomain(input: ConfigureEmailDomainInput): PreparedChannelSettingsAction {
+    const project = validateProject(input.project);
+    const domain = validateDomain(input.domain);
+
+    const preview = {
+      action: CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE,
+      project,
+      domain,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigurePushProvider(
+    input: ConfigurePushProviderInput,
+  ): PreparedChannelSettingsAction {
+    const project = validateProject(input.project);
+    const provider = validateProviderName(input.provider);
+    const firebaseCredentials =
+      input.firebaseCredentials !== undefined ? input.firebaseCredentials.trim() : undefined;
+    const apnsCertificate =
+      input.apnsCertificate !== undefined ? input.apnsCertificate.trim() : undefined;
+
+    const preview = {
+      action: CONFIGURE_PUSH_PROVIDER_ACTION_TYPE,
+      project,
+      provider,
+      firebaseCredentials,
+      apnsCertificate,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigureSmsProvider(input: ConfigureSmsProviderInput): PreparedChannelSettingsAction {
+    const project = validateProject(input.project);
+    const provider = validateProviderName(input.provider);
+    const senderNumber =
+      input.senderNumber !== undefined ? validateSenderNumber(input.senderNumber) : undefined;
+
+    const preview = {
+      action: CONFIGURE_SMS_PROVIDER_ACTION_TYPE,
+      project,
+      provider,
+      senderNumber,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigureMobileMessaging(
+    input: ConfigureMobileMessagingInput,
+  ): PreparedChannelSettingsAction {
+    const project = validateProject(input.project);
+    const provider = validateProviderName(input.provider);
+
+    const preview = {
+      action: CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE,
+      project,
+      provider,
+      whatsappEnabled: input.whatsappEnabled,
+      rcsEnabled: input.rcsEnabled,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigurePaymentTracking(
+    input: ConfigurePaymentTrackingInput,
+  ): PreparedChannelSettingsAction {
+    const project = validateProject(input.project);
+    const provider = validateProviderName(input.provider);
+
+    const preview = {
+      action: CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE,
+      project,
+      provider,
+      enabled: input.enabled,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigureFacebookMessaging(
+    input: ConfigureFacebookMessagingInput,
+  ): PreparedChannelSettingsAction {
+    const project = validateProject(input.project);
+    const pageId = validatePageId(input.pageId);
+    const accessToken = input.accessToken !== undefined ? input.accessToken.trim() : undefined;
+
+    const preview = {
+      action: CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE,
+      project,
+      pageId,
+      accessToken,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export * from './bloomreachExports.js';
 export * from './bloomreachInitiatives.js';
 export * from './bloomreachIntegrations.js';
 export * from './bloomreachProjectSettings.js';
+export * from './bloomreachChannelSettings.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Add `BloomreachChannelSettingsService` feature module covering 6 communication channel types: email, push notifications, SMS, mobile messaging, payment tracking, and Facebook messaging.

## Changes

- **New module** `packages/core/src/bloomreachChannelSettings.ts` (537 lines)
  - 6 action type constants (`channel_settings.*` namespace)
  - Rate limit constants (1-hour window, 20 ops/window)
  - 6 data interfaces for channel settings results
  - 12 input interfaces (6 view + 6 configure)
  - 4 validation helpers (domain, provider name, sender number, page ID)
  - 6 URL builders matching Bloomreach dashboard routes
  - 6 executor stub classes (pending browser automation)
  - `BloomreachChannelSettingsService` with URL getters, read methods, and prepare methods

- **New tests** `packages/core/src/__tests__/bloomreachChannelSettings.test.ts` (610 lines)
  - 69 tests covering constants, validators, URL builders, executors, service constructor, getters, read methods, and all 6 prepare methods

- **Barrel export** added to `packages/core/src/index.ts`

## Quality Gates

| Gate | Status |
|------|--------|
| `npm run typecheck` | ✅ Pass |
| `npm run lint` | ✅ Pass |
| `npm test` | ✅ Pass (2341 tests, 25 files) |
| `npm run build` | ✅ Pass |

Closes #58
