### PR TITLE
feat #59: add security & evaluation settings feature modules

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -10,6 +10,7 @@ import {
   BloomreachDataManagerService,
   BloomreachDashboardsService,
   BloomreachEmailCampaignsService,
+  BloomreachEvaluationSettingsService,
   BloomreachExportsService,
   BloomreachFlowsService,
   BloomreachIntegrationsService,
@@ -21,6 +22,7 @@ import {
   BloomreachPerformanceService,
   BloomreachRetentionsService,
   BloomreachScenariosService,
+  BloomreachSecuritySettingsService,
   BloomreachSurveysService,
   BloomreachTagManagerService,
   BloomreachTrendsService,
@@ -7806,6 +7808,551 @@ campaignSettingsPageVariables
           console.log(`  Page variable ID: ${options.pageVariableId}`);
           console.log(`  Token:            ${result.confirmToken}`);
           console.log(`  Expires:          ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const securitySettings = program
+  .command('security-settings')
+  .description('Manage Bloomreach security settings (SSH tunnels, 2FA)');
+
+const securitySettingsSshTunnels = securitySettings
+  .command('ssh-tunnels')
+  .description('Manage SSH tunnel configurations');
+
+securitySettingsSshTunnels
+  .command('list')
+  .description('List all configured SSH tunnels')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSecuritySettingsService(options.project);
+      const result = await service.listSshTunnels({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No SSH tunnels found.');
+          return;
+        }
+        for (const tunnel of result) {
+          console.log(`  ${tunnel.name} (${tunnel.host}:${tunnel.port})`);
+          console.log(`    Username: ${tunnel.username}`);
+          console.log(`    Status:   ${tunnel.status}`);
+          console.log(`    ID:       ${tunnel.id}`);
+          console.log(`    URL:      ${tunnel.url}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+securitySettingsSshTunnels
+  .command('view')
+  .description('View details of a configured SSH tunnel')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tunnel-id <id>', 'SSH tunnel ID')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; tunnelId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSecuritySettingsService(options.project);
+      const result = await service.viewSshTunnel({
+        project: options.project,
+        tunnelId: options.tunnelId,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`SSH Tunnel: ${result.name}`);
+        console.log(`  Host:     ${result.host}:${result.port}`);
+        console.log(`  Username: ${result.username}`);
+        console.log(`  Status:   ${result.status}`);
+        console.log(`  ID:       ${result.id}`);
+        console.log(`  URL:      ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+securitySettingsSshTunnels
+  .command('create')
+  .description('Prepare SSH tunnel creation (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--name <name>', 'SSH tunnel name')
+  .requiredOption('--host <host>', 'SSH tunnel host')
+  .requiredOption('--port <port>', 'SSH tunnel port')
+  .requiredOption('--username <username>', 'SSH tunnel username')
+  .option('--password <password>', 'SSH tunnel password')
+  .option('--host-key <key>', 'SSH host key fingerprint')
+  .option('--database-type <type>', 'Database type for tunnel usage')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      name: string;
+      host: string;
+      port: string;
+      username: string;
+      password?: string;
+      hostKey?: string;
+      databaseType?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachSecuritySettingsService(options.project);
+        const result = service.prepareCreateSshTunnel({
+          project: options.project,
+          name: options.name,
+          host: options.host,
+          port: parseInt(options.port, 10),
+          username: options.username,
+          password: options.password,
+          hostKey: options.hostKey,
+          databaseType: options.databaseType,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('SSH tunnel creation prepared.');
+          console.log(`  Name:    ${options.name}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+securitySettingsSshTunnels
+  .command('delete')
+  .description('Prepare SSH tunnel deletion (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--tunnel-id <id>', 'SSH tunnel ID')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; tunnelId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSecuritySettingsService(options.project);
+      const result = service.prepareDeleteSshTunnel({
+        project: options.project,
+        tunnelId: options.tunnelId,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('SSH tunnel deletion prepared.');
+        console.log(`  Tunnel ID: ${options.tunnelId}`);
+        console.log(`  Token:     ${result.confirmToken}`);
+        console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const securitySettingsTwoStep = securitySettings
+  .command('two-step')
+  .description('Manage project two-step verification settings');
+
+securitySettingsTwoStep
+  .command('view')
+  .description('View two-step verification settings')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSecuritySettingsService(options.project);
+      const result = await service.viewTwoStepVerification({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Two-step verification (${options.project})`);
+        console.log(`  Enabled:  ${result.enabled}`);
+        console.log(`  Enforced: ${result.enforced ?? false}`);
+        console.log(`  URL:      ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+securitySettingsTwoStep
+  .command('enable')
+  .description('Prepare enabling two-step verification (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSecuritySettingsService(options.project);
+      const result = service.prepareEnableTwoStep({
+        project: options.project,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Enable two-step verification prepared.');
+        console.log(`  Project: ${options.project}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+securitySettingsTwoStep
+  .command('disable')
+  .description('Prepare disabling two-step verification (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachSecuritySettingsService(options.project);
+      const result = service.prepareDisableTwoStep({
+        project: options.project,
+        operatorNote: options.note,
+      });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Disable two-step verification prepared.');
+        console.log(`  Project: ${options.project}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+const evaluationSettings = program
+  .command('evaluation-settings')
+  .description('Manage Bloomreach evaluation settings');
+
+const evaluationSettingsRevenueAttribution = evaluationSettings
+  .command('revenue-attribution')
+  .description('Manage revenue attribution settings');
+
+evaluationSettingsRevenueAttribution
+  .command('view')
+  .description('View revenue attribution settings')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachEvaluationSettingsService(options.project);
+      const result = await service.viewRevenueAttribution({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Revenue attribution (${options.project})`);
+        console.log(`  Model:    ${result.model}`);
+        console.log(`  Window:   ${result.attributionWindow ?? 'n/a'}`);
+        console.log(`  Channels: ${result.channels?.join(', ') ?? 'n/a'}`);
+        console.log(`  URL:      ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+evaluationSettingsRevenueAttribution
+  .command('configure')
+  .description('Prepare revenue attribution configuration (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--model <model>', 'Revenue attribution model')
+  .option('--attribution-window <days>', 'Attribution window in days')
+  .option('--channels <csv>', 'Comma-separated channels list')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      model: string;
+      attributionWindow?: string;
+      channels?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachEvaluationSettingsService(options.project);
+        const result = service.prepareConfigureRevenueAttribution({
+          project: options.project,
+          model: options.model,
+          attributionWindow: options.attributionWindow
+            ? parseInt(options.attributionWindow, 10)
+            : undefined,
+          channels: options.channels
+            ? options.channels.split(',').map((channel) => channel.trim())
+            : undefined,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Revenue attribution configuration prepared.');
+          console.log(`  Model:   ${options.model}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const evaluationSettingsCurrency = evaluationSettings
+  .command('currency')
+  .description('Manage project currency settings');
+
+evaluationSettingsCurrency
+  .command('view')
+  .description('View currency settings')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachEvaluationSettingsService(options.project);
+      const result = await service.viewCurrency({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Currency settings (${options.project})`);
+        console.log(`  Code:   ${result.currencyCode}`);
+        console.log(`  Symbol: ${result.currencySymbol ?? 'n/a'}`);
+        console.log(`  URL:    ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+evaluationSettingsCurrency
+  .command('set')
+  .description('Prepare currency update (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--currency-code <code>', 'ISO 4217 currency code')
+  .option('--currency-symbol <symbol>', 'Currency symbol')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      currencyCode: string;
+      currencySymbol?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachEvaluationSettingsService(options.project);
+        const result = service.prepareSetCurrency({
+          project: options.project,
+          currencyCode: options.currencyCode,
+          currencySymbol: options.currencySymbol,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Currency update prepared.');
+          console.log(`  Currency: ${options.currencyCode}`);
+          console.log(`  Token:    ${result.confirmToken}`);
+          console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const evaluationSettingsDashboards = evaluationSettings
+  .command('dashboards')
+  .description('Manage evaluation dashboard settings');
+
+evaluationSettingsDashboards
+  .command('view')
+  .description('View evaluation dashboard settings')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachEvaluationSettingsService(options.project);
+      const result = await service.viewEvaluationDashboards({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Evaluation dashboards (${options.project})`);
+        console.log(`  URL: ${result.url}`);
+        for (const dashboard of result.dashboards) {
+          console.log(`  - ${dashboard.id} (${dashboard.name}) enabled=${dashboard.enabled ?? false}`);
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+evaluationSettingsDashboards
+  .command('configure')
+  .description('Prepare evaluation dashboards configuration (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--dashboards <json>', 'JSON dashboard config array [{id, enabled}]')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      dashboards: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachEvaluationSettingsService(options.project);
+        const dashboards = JSON.parse(options.dashboards) as { id: string; enabled: boolean }[];
+        const result = service.prepareConfigureEvaluationDashboards({
+          project: options.project,
+          dashboards,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Evaluation dashboards configuration prepared.');
+          console.log(`  Dashboards: ${dashboards.length}`);
+          console.log(`  Token:      ${result.confirmToken}`);
+          console.log(`  Expires:    ${new Date(result.expiresAtMs).toISOString()}`);
+          console.log('');
+          console.log('To confirm, run:');
+          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
+        }
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+const evaluationSettingsVoucherMapping = evaluationSettings
+  .command('voucher-mapping')
+  .description('Manage voucher mapping settings');
+
+evaluationSettingsVoucherMapping
+  .command('view')
+  .description('View voucher mapping settings')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachEvaluationSettingsService(options.project);
+      const result = await service.viewVoucherMapping({ project: options.project });
+
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Voucher mapping (${options.project})`);
+        console.log(`  Mapping field: ${result.mappingField ?? 'n/a'}`);
+        console.log(`  Mapping type:  ${result.mappingType ?? 'n/a'}`);
+        console.log(`  URL:           ${result.url}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+evaluationSettingsVoucherMapping
+  .command('configure')
+  .description('Prepare voucher mapping configuration (two-phase commit)')
+  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--mapping-field <field>', 'Voucher mapping field')
+  .option('--mapping-type <type>', 'Voucher mapping type')
+  .option('--note <note>', 'Operator note for audit trail')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      project: string;
+      mappingField: string;
+      mappingType?: string;
+      note?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const service = new BloomreachEvaluationSettingsService(options.project);
+        const result = service.prepareConfigureVoucherMapping({
+          project: options.project,
+          mappingField: options.mappingField,
+          mappingType: options.mappingType,
+          operatorNote: options.note,
+        });
+
+        if (options.json) {
+          printJson(result);
+        } else {
+          console.log('Voucher mapping configuration prepared.');
+          console.log(`  Field:   ${options.mappingField}`);
+          console.log(`  Token:   ${result.confirmToken}`);
+          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
           console.log('');
           console.log('To confirm, run:');
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);

--- a/packages/core/src/__tests__/bloomreachEvaluationSettings.test.ts
+++ b/packages/core/src/__tests__/bloomreachEvaluationSettings.test.ts
@@ -1,0 +1,536 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE,
+  SET_CURRENCY_ACTION_TYPE,
+  CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE,
+  CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE,
+  EVALUATION_SETTINGS_RATE_LIMIT_WINDOW_MS,
+  EVALUATION_SETTINGS_CONFIGURE_RATE_LIMIT,
+  validateAttributionModel,
+  validateAttributionWindow,
+  validateCurrencyCode,
+  validateDashboardId,
+  validateMappingField,
+  buildRevenueAttributionUrl,
+  buildCurrencyUrl,
+  buildEvaluationDashboardsUrl,
+  buildVoucherMappingUrl,
+  createEvaluationSettingsActionExecutors,
+  BloomreachEvaluationSettingsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE', () => {
+    expect(CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE).toBe(
+      'evaluation_settings.configure_revenue_attribution',
+    );
+  });
+
+  it('exports SET_CURRENCY_ACTION_TYPE', () => {
+    expect(SET_CURRENCY_ACTION_TYPE).toBe('evaluation_settings.set_currency');
+  });
+
+  it('exports CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE', () => {
+    expect(CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE).toBe(
+      'evaluation_settings.configure_evaluation_dashboards',
+    );
+  });
+
+  it('exports CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE', () => {
+    expect(CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE).toBe(
+      'evaluation_settings.configure_voucher_mapping',
+    );
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports EVALUATION_SETTINGS_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(EVALUATION_SETTINGS_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports EVALUATION_SETTINGS_CONFIGURE_RATE_LIMIT', () => {
+    expect(EVALUATION_SETTINGS_CONFIGURE_RATE_LIMIT).toBe(20);
+  });
+});
+
+describe('validateAttributionModel', () => {
+  it('throws for empty string', () => {
+    expect(() => validateAttributionModel('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateAttributionModel('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed model for valid input', () => {
+    expect(validateAttributionModel('  first-touch  ')).toBe('first-touch');
+  });
+
+  it('accepts model at maximum length', () => {
+    const model = 'x'.repeat(100);
+    expect(validateAttributionModel(model)).toBe(model);
+  });
+
+  it('throws for model exceeding maximum length', () => {
+    const model = 'x'.repeat(101);
+    expect(() => validateAttributionModel(model)).toThrow('must not exceed 100 characters');
+  });
+});
+
+describe('validateAttributionWindow', () => {
+  it('throws for zero', () => {
+    expect(() => validateAttributionWindow(0)).toThrow();
+  });
+
+  it('throws for negative value', () => {
+    expect(() => validateAttributionWindow(-1)).toThrow();
+  });
+
+  it('throws for non-integer value', () => {
+    expect(() => validateAttributionWindow(1.5)).toThrow();
+  });
+
+  it('throws for values greater than 365', () => {
+    expect(() => validateAttributionWindow(366)).toThrow();
+  });
+
+  it('accepts 1 as minimum valid value', () => {
+    expect(validateAttributionWindow(1)).toBe(1);
+  });
+
+  it('accepts 365 as maximum valid value', () => {
+    expect(validateAttributionWindow(365)).toBe(365);
+  });
+
+  it('accepts a typical value', () => {
+    expect(validateAttributionWindow(30)).toBe(30);
+  });
+});
+
+describe('validateCurrencyCode', () => {
+  it('throws for empty string', () => {
+    expect(() => validateCurrencyCode('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateCurrencyCode('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for 2-character code', () => {
+    expect(() => validateCurrencyCode('EU')).toThrow();
+  });
+
+  it('throws for 4-character code', () => {
+    expect(() => validateCurrencyCode('EURO')).toThrow();
+  });
+
+  it('accepts and uppercases lowercase code', () => {
+    expect(validateCurrencyCode('eur')).toBe('EUR');
+  });
+
+  it('throws for non-alpha code', () => {
+    expect(() => validateCurrencyCode('12E')).toThrow();
+  });
+
+  it('returns trimmed uppercased 3-letter code', () => {
+    expect(validateCurrencyCode(' usd ')).toBe('USD');
+  });
+
+  it('accepts EUR', () => {
+    expect(validateCurrencyCode('EUR')).toBe('EUR');
+  });
+
+  it('accepts USD', () => {
+    expect(validateCurrencyCode('USD')).toBe('USD');
+  });
+
+  it('accepts lower-case input with trimming and uppercasing', () => {
+    expect(validateCurrencyCode(' eur ')).toBe('EUR');
+  });
+});
+
+describe('validateDashboardId', () => {
+  it('throws for empty string', () => {
+    expect(() => validateDashboardId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateDashboardId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed dashboard ID for valid input', () => {
+    expect(validateDashboardId('  dashboard-123  ')).toBe('dashboard-123');
+  });
+});
+
+describe('validateMappingField', () => {
+  it('throws for empty string', () => {
+    expect(() => validateMappingField('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateMappingField('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed mapping field for valid input', () => {
+    expect(validateMappingField('  voucher_code  ')).toBe('voucher_code');
+  });
+
+  it('accepts mapping field at maximum length', () => {
+    const mappingField = 'x'.repeat(200);
+    expect(validateMappingField(mappingField)).toBe(mappingField);
+  });
+
+  it('throws for mapping field exceeding maximum length', () => {
+    const mappingField = 'x'.repeat(201);
+    expect(() => validateMappingField(mappingField)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('URL builders', () => {
+  it('builds all URLs for a simple project name', () => {
+    expect(buildRevenueAttributionUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/project-revenue-attribution',
+    );
+    expect(buildCurrencyUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/project-settings/currency');
+    expect(buildEvaluationDashboardsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/evaluation-dashboards',
+    );
+    expect(buildVoucherMappingUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/vouchers',
+    );
+  });
+
+  it('encodes spaces in all URLs', () => {
+    expect(buildRevenueAttributionUrl('my project')).toBe(
+      '/p/my%20project/project-settings/project-revenue-attribution',
+    );
+    expect(buildCurrencyUrl('my project')).toBe('/p/my%20project/project-settings/currency');
+    expect(buildEvaluationDashboardsUrl('my project')).toBe(
+      '/p/my%20project/project-settings/evaluation-dashboards',
+    );
+    expect(buildVoucherMappingUrl('my project')).toBe('/p/my%20project/project-settings/vouchers');
+  });
+
+  it('handles project names with slashes in all URLs', () => {
+    expect(buildRevenueAttributionUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/project-revenue-attribution',
+    );
+    expect(buildCurrencyUrl('org/project')).toBe('/p/org%2Fproject/project-settings/currency');
+    expect(buildEvaluationDashboardsUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/evaluation-dashboards',
+    );
+    expect(buildVoucherMappingUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/vouchers',
+    );
+  });
+});
+
+describe('createEvaluationSettingsActionExecutors', () => {
+  it('returns executors for all four action types', () => {
+    const executors = createEvaluationSettingsActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(4);
+    expect(executors[CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE]).toBeDefined();
+    expect(executors[SET_CURRENCY_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE]).toBeDefined();
+    expect(executors[CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching key', () => {
+    const executors = createEvaluationSettingsActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createEvaluationSettingsActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachEvaluationSettingsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachEvaluationSettingsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachEvaluationSettingsService);
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachEvaluationSettingsService('  my-project  ');
+      expect(service.revenueAttributionUrl).toBe(
+        '/p/my-project/project-settings/project-revenue-attribution',
+      );
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachEvaluationSettingsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('URL getters', () => {
+    it('returns all evaluation settings URLs', () => {
+      const service = new BloomreachEvaluationSettingsService('kingdom-of-joakim');
+      expect(service.revenueAttributionUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/project-revenue-attribution',
+      );
+      expect(service.currencyUrl).toBe('/p/kingdom-of-joakim/project-settings/currency');
+      expect(service.evaluationDashboardsUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/evaluation-dashboards',
+      );
+      expect(service.voucherMappingUrl).toBe('/p/kingdom-of-joakim/project-settings/vouchers');
+    });
+  });
+
+  describe('read methods', () => {
+    it('viewRevenueAttribution throws not-yet-implemented error', async () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      await expect(service.viewRevenueAttribution()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewCurrency throws not-yet-implemented error', async () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      await expect(service.viewCurrency()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewEvaluationDashboards throws not-yet-implemented error', async () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      await expect(service.viewEvaluationDashboards()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewVoucherMapping throws not-yet-implemented error', async () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      await expect(service.viewVoucherMapping()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareConfigureRevenueAttribution', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        model: 'first-touch',
+        attributionWindow: 30,
+        operatorNote: 'align attribution model',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureRevenueAttribution']>[0];
+      const result = service.prepareConfigureRevenueAttribution(input);
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'evaluation_settings.configure_revenue_attribution',
+          project: 'test',
+          model: 'first-touch',
+          attributionWindow: 30,
+          operatorNote: 'align attribution model',
+        }),
+      );
+    });
+
+    it('trims the model value', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        model: '  first-touch  ',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureRevenueAttribution']>[0];
+      const result = service.prepareConfigureRevenueAttribution(input);
+      expect(result.preview).toEqual(expect.objectContaining({ model: 'first-touch' }));
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: '',
+        model: 'first-touch',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureRevenueAttribution']>[0];
+      expect(() => service.prepareConfigureRevenueAttribution(input)).toThrow('must not be empty');
+    });
+
+    it('throws for empty model', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        model: '',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureRevenueAttribution']>[0];
+      expect(() => service.prepareConfigureRevenueAttribution(input)).toThrow('must not be empty');
+    });
+
+    it('validates attribution window when provided', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        model: 'first-touch',
+        attributionWindow: 0,
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureRevenueAttribution']>[0];
+      expect(() => service.prepareConfigureRevenueAttribution(input)).toThrow();
+    });
+  });
+
+  describe('prepareSetCurrency', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        currencyCode: 'USD',
+        operatorNote: 'set billing currency',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareSetCurrency']>[0];
+      const result = service.prepareSetCurrency(input);
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'evaluation_settings.set_currency',
+          project: 'test',
+          currencyCode: 'USD',
+          operatorNote: 'set billing currency',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: '',
+        currencyCode: 'USD',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareSetCurrency']>[0];
+      expect(() => service.prepareSetCurrency(input)).toThrow('must not be empty');
+    });
+
+    it('throws for invalid currency code', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        currencyCode: 'US',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareSetCurrency']>[0];
+      expect(() => service.prepareSetCurrency(input)).toThrow();
+    });
+
+    it('trims and uppercases currency code', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        currencyCode: ' eur ',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareSetCurrency']>[0];
+      const result = service.prepareSetCurrency(input);
+      expect(result.preview).toEqual(expect.objectContaining({ currencyCode: 'EUR' }));
+    });
+  });
+
+  describe('prepareConfigureEvaluationDashboards', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        dashboards: [
+          { id: 'dashboard-1', enabled: true },
+          { id: ' dashboard-2 ', enabled: false },
+        ],
+        operatorNote: 'set dashboard mappings',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureEvaluationDashboards']>[0];
+      const result = service.prepareConfigureEvaluationDashboards(input);
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'evaluation_settings.configure_evaluation_dashboards',
+          project: 'test',
+          dashboards: [
+            { id: 'dashboard-1', enabled: true },
+            { id: 'dashboard-2', enabled: false },
+          ],
+          operatorNote: 'set dashboard mappings',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: '',
+        dashboards: [{ id: 'dashboard-1', enabled: true }],
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureEvaluationDashboards']>[0];
+      expect(() => service.prepareConfigureEvaluationDashboards(input)).toThrow('must not be empty');
+    });
+
+    it('throws for empty dashboards array', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        dashboards: [],
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureEvaluationDashboards']>[0];
+      expect(() => service.prepareConfigureEvaluationDashboards(input)).toThrow();
+    });
+
+    it('validates dashboard IDs', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        dashboards: [
+          { id: 'dashboard-1', enabled: true },
+          { id: '   ', enabled: false },
+        ],
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureEvaluationDashboards']>[0];
+      expect(() => service.prepareConfigureEvaluationDashboards(input)).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareConfigureVoucherMapping', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        mappingField: 'externalVoucherCode',
+        operatorNote: 'map voucher field',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureVoucherMapping']>[0];
+      const result = service.prepareConfigureVoucherMapping(input);
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'evaluation_settings.configure_voucher_mapping',
+          project: 'test',
+          mappingField: 'externalVoucherCode',
+          operatorNote: 'map voucher field',
+        }),
+      );
+    });
+
+    it('trims mapping field', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        mappingField: '  voucherCode  ',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureVoucherMapping']>[0];
+      const result = service.prepareConfigureVoucherMapping(input);
+      expect(result.preview).toEqual(expect.objectContaining({ mappingField: 'voucherCode' }));
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: '',
+        mappingField: 'voucherCode',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureVoucherMapping']>[0];
+      expect(() => service.prepareConfigureVoucherMapping(input)).toThrow('must not be empty');
+    });
+
+    it('throws for empty mapping field', () => {
+      const service = new BloomreachEvaluationSettingsService('test');
+      const input = {
+        project: 'test',
+        mappingField: '',
+      } as Parameters<BloomreachEvaluationSettingsService['prepareConfigureVoucherMapping']>[0];
+      expect(() => service.prepareConfigureVoucherMapping(input)).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/__tests__/bloomreachSecuritySettings.test.ts
+++ b/packages/core/src/__tests__/bloomreachSecuritySettings.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_SSH_TUNNEL_ACTION_TYPE,
+  UPDATE_SSH_TUNNEL_ACTION_TYPE,
+  DELETE_SSH_TUNNEL_ACTION_TYPE,
+  ENABLE_TWO_STEP_ACTION_TYPE,
+  DISABLE_TWO_STEP_ACTION_TYPE,
+  UPDATE_TWO_STEP_ACTION_TYPE,
+  SECURITY_SETTINGS_RATE_LIMIT_WINDOW_MS,
+  SECURITY_SETTINGS_SSH_TUNNEL_RATE_LIMIT,
+  SECURITY_SETTINGS_TWO_STEP_RATE_LIMIT,
+  validateTunnelName,
+  validateHost,
+  validatePort,
+  validateUsername,
+  validateTunnelId,
+  buildSshTunnelsUrl,
+  buildTwoStepVerificationUrl,
+  createSecuritySettingsActionExecutors,
+  BloomreachSecuritySettingsService,
+} from '../index.js';
+
+describe('action type constants', () => {
+  it('exports CREATE_SSH_TUNNEL_ACTION_TYPE', () => {
+    expect(CREATE_SSH_TUNNEL_ACTION_TYPE).toBe('security_settings.create_ssh_tunnel');
+  });
+
+  it('exports UPDATE_SSH_TUNNEL_ACTION_TYPE', () => {
+    expect(UPDATE_SSH_TUNNEL_ACTION_TYPE).toBe('security_settings.update_ssh_tunnel');
+  });
+
+  it('exports DELETE_SSH_TUNNEL_ACTION_TYPE', () => {
+    expect(DELETE_SSH_TUNNEL_ACTION_TYPE).toBe('security_settings.delete_ssh_tunnel');
+  });
+
+  it('exports ENABLE_TWO_STEP_ACTION_TYPE', () => {
+    expect(ENABLE_TWO_STEP_ACTION_TYPE).toBe('security_settings.enable_two_step');
+  });
+
+  it('exports DISABLE_TWO_STEP_ACTION_TYPE', () => {
+    expect(DISABLE_TWO_STEP_ACTION_TYPE).toBe('security_settings.disable_two_step');
+  });
+
+  it('exports UPDATE_TWO_STEP_ACTION_TYPE', () => {
+    expect(UPDATE_TWO_STEP_ACTION_TYPE).toBe('security_settings.update_two_step');
+  });
+});
+
+describe('rate limit constants', () => {
+  it('exports SECURITY_SETTINGS_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(SECURITY_SETTINGS_RATE_LIMIT_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('exports SECURITY_SETTINGS_SSH_TUNNEL_RATE_LIMIT', () => {
+    expect(SECURITY_SETTINGS_SSH_TUNNEL_RATE_LIMIT).toBe(10);
+  });
+
+  it('exports SECURITY_SETTINGS_TWO_STEP_RATE_LIMIT', () => {
+    expect(SECURITY_SETTINGS_TWO_STEP_RATE_LIMIT).toBe(10);
+  });
+});
+
+describe('validateTunnelName', () => {
+  it('throws for empty string', () => {
+    expect(() => validateTunnelName('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateTunnelName('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed name for valid input', () => {
+    expect(validateTunnelName('  Primary SSH Tunnel  ')).toBe('Primary SSH Tunnel');
+  });
+
+  it('accepts tunnel name at maximum length', () => {
+    const name = 'x'.repeat(200);
+    expect(validateTunnelName(name)).toBe(name);
+  });
+
+  it('throws for tunnel name exceeding maximum length', () => {
+    const name = 'x'.repeat(201);
+    expect(() => validateTunnelName(name)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateHost', () => {
+  it('throws for empty string', () => {
+    expect(() => validateHost('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateHost('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed host for valid input', () => {
+    expect(validateHost('  ssh.example.com  ')).toBe('ssh.example.com');
+  });
+
+  it('accepts host at maximum length', () => {
+    const host = 'x'.repeat(253);
+    expect(validateHost(host)).toBe(host);
+  });
+
+  it('throws for host exceeding maximum length', () => {
+    const host = 'x'.repeat(254);
+    expect(() => validateHost(host)).toThrow('must not exceed 253 characters');
+  });
+});
+
+describe('validatePort', () => {
+  it('throws for 0', () => {
+    expect(() => validatePort(0)).toThrow();
+  });
+
+  it('throws for negative value', () => {
+    expect(() => validatePort(-1)).toThrow();
+  });
+
+  it('throws for value greater than 65535', () => {
+    expect(() => validatePort(65536)).toThrow();
+  });
+
+  it('throws for non-integer value', () => {
+    expect(() => validatePort(1.5)).toThrow();
+  });
+
+  it('accepts 1', () => {
+    expect(validatePort(1)).toBe(1);
+  });
+
+  it('accepts 65535', () => {
+    expect(validatePort(65535)).toBe(65535);
+  });
+
+  it('accepts typical SSH port', () => {
+    expect(validatePort(22)).toBe(22);
+  });
+});
+
+describe('validateUsername', () => {
+  it('throws for empty string', () => {
+    expect(() => validateUsername('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateUsername('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed username for valid input', () => {
+    expect(validateUsername('  deploy  ')).toBe('deploy');
+  });
+
+  it('accepts username at maximum length', () => {
+    const username = 'x'.repeat(200);
+    expect(validateUsername(username)).toBe(username);
+  });
+
+  it('throws for username exceeding maximum length', () => {
+    const username = 'x'.repeat(201);
+    expect(() => validateUsername(username)).toThrow('must not exceed 200 characters');
+  });
+});
+
+describe('validateTunnelId', () => {
+  it('throws for empty string', () => {
+    expect(() => validateTunnelId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateTunnelId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed tunnel ID for valid input', () => {
+    expect(validateTunnelId('  tunnel-123  ')).toBe('tunnel-123');
+  });
+});
+
+describe('URL builders', () => {
+  it('builds URLs for a simple project name', () => {
+    expect(buildSshTunnelsUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/ssh-tunnels',
+    );
+    expect(buildTwoStepVerificationUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/project-two-step',
+    );
+  });
+
+  it('encodes spaces in URLs', () => {
+    expect(buildSshTunnelsUrl('my project')).toBe('/p/my%20project/project-settings/ssh-tunnels');
+    expect(buildTwoStepVerificationUrl('my project')).toBe(
+      '/p/my%20project/project-settings/project-two-step',
+    );
+  });
+
+  it('handles project names with slashes in URLs', () => {
+    expect(buildSshTunnelsUrl('org/project')).toBe('/p/org%2Fproject/project-settings/ssh-tunnels');
+    expect(buildTwoStepVerificationUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/project-two-step',
+    );
+  });
+});
+
+describe('createSecuritySettingsActionExecutors', () => {
+  it('returns executors for all six action types', () => {
+    const executors = createSecuritySettingsActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(6);
+    expect(executors[CREATE_SSH_TUNNEL_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_SSH_TUNNEL_ACTION_TYPE]).toBeDefined();
+    expect(executors[DELETE_SSH_TUNNEL_ACTION_TYPE]).toBeDefined();
+    expect(executors[ENABLE_TWO_STEP_ACTION_TYPE]).toBeDefined();
+    expect(executors[DISABLE_TWO_STEP_ACTION_TYPE]).toBeDefined();
+    expect(executors[UPDATE_TWO_STEP_ACTION_TYPE]).toBeDefined();
+  });
+
+  it('each executor has an actionType property matching key', () => {
+    const executors = createSecuritySettingsActionExecutors();
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('executors throw "not yet implemented" on execute', async () => {
+    const executors = createSecuritySettingsActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+});
+
+describe('BloomreachSecuritySettingsService', () => {
+  describe('constructor', () => {
+    it('creates a service instance with valid project', () => {
+      const service = new BloomreachSecuritySettingsService('kingdom-of-joakim');
+      expect(service).toBeInstanceOf(BloomreachSecuritySettingsService);
+    });
+
+    it('trims project name', () => {
+      const service = new BloomreachSecuritySettingsService('  my-project  ');
+      expect(service.sshTunnelsUrl).toBe('/p/my-project/project-settings/ssh-tunnels');
+    });
+
+    it('throws for empty project', () => {
+      expect(() => new BloomreachSecuritySettingsService('')).toThrow('must not be empty');
+    });
+  });
+
+  describe('URL getters', () => {
+    it('returns both security settings URLs', () => {
+      const service = new BloomreachSecuritySettingsService('kingdom-of-joakim');
+      expect(service.sshTunnelsUrl).toBe('/p/kingdom-of-joakim/project-settings/ssh-tunnels');
+      expect(service.twoStepVerificationUrl).toBe(
+        '/p/kingdom-of-joakim/project-settings/project-two-step',
+      );
+    });
+  });
+
+  describe('read methods', () => {
+    it('listSshTunnels throws not-yet-implemented error', async () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      await expect(service.listSshTunnels()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewSshTunnel throws not-yet-implemented error', async () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      await expect(service.viewSshTunnel()).rejects.toThrow('not yet implemented');
+    });
+
+    it('viewTwoStepVerification throws not-yet-implemented error', async () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      await expect(service.viewTwoStepVerification()).rejects.toThrow('not yet implemented');
+    });
+  });
+
+  describe('prepareCreateSshTunnel', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      const result = service.prepareCreateSshTunnel({
+        project: 'test',
+        name: 'Main tunnel',
+        host: 'ssh.example.com',
+        port: 22,
+        username: 'deploy',
+        operatorNote: 'create primary tunnel',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'security_settings.create_ssh_tunnel',
+          project: 'test',
+          name: 'Main tunnel',
+          host: 'ssh.example.com',
+          port: 22,
+          username: 'deploy',
+          operatorNote: 'create primary tunnel',
+        }),
+      );
+    });
+
+    it('trims name, host, and username values', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      const result = service.prepareCreateSshTunnel({
+        project: 'test',
+        name: '  Main tunnel  ',
+        host: '  ssh.example.com  ',
+        port: 22,
+        username: '  deploy  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: 'Main tunnel',
+          host: 'ssh.example.com',
+          username: 'deploy',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareCreateSshTunnel({
+          project: '',
+          name: 'Main tunnel',
+          host: 'ssh.example.com',
+          port: 22,
+          username: 'deploy',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty name', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareCreateSshTunnel({
+          project: 'test',
+          name: '',
+          host: 'ssh.example.com',
+          port: 22,
+          username: 'deploy',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty host', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareCreateSshTunnel({
+          project: 'test',
+          name: 'Main tunnel',
+          host: '',
+          port: 22,
+          username: 'deploy',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for invalid port', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareCreateSshTunnel({
+          project: 'test',
+          name: 'Main tunnel',
+          host: 'ssh.example.com',
+          port: 0,
+          username: 'deploy',
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe('prepareUpdateSshTunnel', () => {
+    it('returns a prepared action with valid input and name field', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      const result = service.prepareUpdateSshTunnel({
+        project: 'test',
+        tunnelId: 'tunnel-1',
+        name: 'Updated tunnel name',
+        operatorNote: 'rename tunnel',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'security_settings.update_ssh_tunnel',
+          project: 'test',
+          tunnelId: 'tunnel-1',
+          name: 'Updated tunnel name',
+          operatorNote: 'rename tunnel',
+        }),
+      );
+    });
+
+    it('throws when no fields are provided for update', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareUpdateSshTunnel({
+          project: 'test',
+          tunnelId: 'tunnel-1',
+        }),
+      ).toThrow('At least one');
+    });
+
+    it('validates tunnel ID', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareUpdateSshTunnel({
+          project: 'test',
+          tunnelId: '',
+          name: 'Updated tunnel name',
+        }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() =>
+        service.prepareUpdateSshTunnel({
+          project: '',
+          tunnelId: 'tunnel-1',
+          name: 'Updated tunnel name',
+        }),
+      ).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareDeleteSshTunnel', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      const result = service.prepareDeleteSshTunnel({
+        project: 'test',
+        tunnelId: 'tunnel-2',
+        operatorNote: 'remove stale tunnel',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'security_settings.delete_ssh_tunnel',
+          project: 'test',
+          tunnelId: 'tunnel-2',
+          operatorNote: 'remove stale tunnel',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() => service.prepareDeleteSshTunnel({ project: '', tunnelId: 'tunnel-2' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for empty tunnel ID', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() => service.prepareDeleteSshTunnel({ project: 'test', tunnelId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+  });
+
+  describe('prepareEnableTwoStep', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      const result = service.prepareEnableTwoStep({
+        project: 'test',
+        operatorNote: 'turn on 2sv',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'security_settings.enable_two_step',
+          project: 'test',
+          operatorNote: 'turn on 2sv',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() => service.prepareEnableTwoStep({ project: '' })).toThrow('must not be empty');
+    });
+  });
+
+  describe('prepareDisableTwoStep', () => {
+    it('returns a prepared action with valid input', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      const result = service.prepareDisableTwoStep({
+        project: 'test',
+        operatorNote: 'turn off 2sv',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          action: 'security_settings.disable_two_step',
+          project: 'test',
+          operatorNote: 'turn off 2sv',
+        }),
+      );
+    });
+
+    it('throws for empty project', () => {
+      const service = new BloomreachSecuritySettingsService('test');
+      expect(() => service.prepareDisableTwoStep({ project: '' })).toThrow('must not be empty');
+    });
+  });
+});

--- a/packages/core/src/bloomreachEvaluationSettings.ts
+++ b/packages/core/src/bloomreachEvaluationSettings.ts
@@ -1,0 +1,428 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+// ---------------------------------------------------------------------------
+// Action type constants
+// ---------------------------------------------------------------------------
+
+export const CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE =
+  'evaluation_settings.configure_revenue_attribution';
+export const SET_CURRENCY_ACTION_TYPE = 'evaluation_settings.set_currency';
+export const CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE =
+  'evaluation_settings.configure_evaluation_dashboards';
+export const CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE =
+  'evaluation_settings.configure_voucher_mapping';
+
+// ---------------------------------------------------------------------------
+// Rate limit constants
+// ---------------------------------------------------------------------------
+
+export const EVALUATION_SETTINGS_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const EVALUATION_SETTINGS_CONFIGURE_RATE_LIMIT = 20;
+
+// ---------------------------------------------------------------------------
+// Data interfaces
+// ---------------------------------------------------------------------------
+
+export interface BloomreachRevenueAttributionSettings {
+  model: string;
+  attributionWindow?: number;
+  channels?: string[];
+  url: string;
+}
+
+export interface BloomreachCurrencySettings {
+  currencyCode: string;
+  currencySymbol?: string;
+  url: string;
+}
+
+export interface BloomreachEvaluationDashboardSettings {
+  dashboards: EvaluationDashboard[];
+  url: string;
+}
+
+export interface EvaluationDashboard {
+  id: string;
+  name: string;
+  metrics?: string[];
+  enabled?: boolean;
+}
+
+export interface BloomreachVoucherMappingSettings {
+  mappingField?: string;
+  mappingType?: string;
+  url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input interfaces
+// ---------------------------------------------------------------------------
+
+export interface ViewRevenueAttributionInput {
+  project: string;
+}
+
+export interface ConfigureRevenueAttributionInput {
+  project: string;
+  model: string;
+  attributionWindow?: number;
+  channels?: string[];
+  operatorNote?: string;
+}
+
+export interface ViewCurrencyInput {
+  project: string;
+}
+
+export interface SetCurrencyInput {
+  project: string;
+  currencyCode: string;
+  currencySymbol?: string;
+  operatorNote?: string;
+}
+
+export interface ViewEvaluationDashboardsInput {
+  project: string;
+}
+
+export interface ConfigureEvaluationDashboardsInput {
+  project: string;
+  dashboards: { id: string; enabled: boolean }[];
+  operatorNote?: string;
+}
+
+export interface ViewVoucherMappingInput {
+  project: string;
+}
+
+export interface ConfigureVoucherMappingInput {
+  project: string;
+  mappingField: string;
+  mappingType?: string;
+  operatorNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Prepared action result
+// ---------------------------------------------------------------------------
+
+export interface PreparedEvaluationSettingsAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const MAX_ATTRIBUTION_MODEL_LENGTH = 100;
+const MAX_ATTRIBUTION_WINDOW_DAYS = 365;
+const MAX_MAPPING_FIELD_LENGTH = 200;
+
+export function validateAttributionModel(model: string): string {
+  const trimmed = model.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Attribution model must not be empty.');
+  }
+  if (trimmed.length > MAX_ATTRIBUTION_MODEL_LENGTH) {
+    throw new Error(
+      `Attribution model must not exceed ${MAX_ATTRIBUTION_MODEL_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateAttributionWindow(window: number): number {
+  if (!Number.isInteger(window) || window <= 0) {
+    throw new Error('Attribution window must be a positive integer.');
+  }
+  if (window > MAX_ATTRIBUTION_WINDOW_DAYS) {
+    throw new Error(
+      `Attribution window must not exceed ${MAX_ATTRIBUTION_WINDOW_DAYS} days (got ${window}).`,
+    );
+  }
+  return window;
+}
+
+export function validateCurrencyCode(code: string): string {
+  const trimmed = code.trim().toUpperCase();
+  if (trimmed.length === 0) {
+    throw new Error('Currency code must not be empty.');
+  }
+  if (trimmed.length !== 3) {
+    throw new Error(`Currency code must be exactly 3 characters (got ${trimmed.length}).`);
+  }
+  if (!/^[A-Z]{3}$/.test(trimmed)) {
+    throw new Error('Currency code must contain uppercase letters only (ISO 4217).');
+  }
+  return trimmed;
+}
+
+export function validateDashboardId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Dashboard ID must not be empty.');
+  }
+  return trimmed;
+}
+
+export function validateMappingField(field: string): string {
+  const trimmed = field.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Mapping field must not be empty.');
+  }
+  if (trimmed.length > MAX_MAPPING_FIELD_LENGTH) {
+    throw new Error(
+      `Mapping field must not exceed ${MAX_MAPPING_FIELD_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+export function buildRevenueAttributionUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/project-revenue-attribution`;
+}
+
+export function buildCurrencyUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/currency`;
+}
+
+export function buildEvaluationDashboardsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/evaluation-dashboards`;
+}
+
+export function buildVoucherMappingUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/vouchers`;
+}
+
+// ---------------------------------------------------------------------------
+// Action executor interface + implementations
+// ---------------------------------------------------------------------------
+
+export interface EvaluationSettingsActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class ConfigureRevenueAttributionExecutor implements EvaluationSettingsActionExecutor {
+  readonly actionType = CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureRevenueAttributionExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class SetCurrencyExecutor implements EvaluationSettingsActionExecutor {
+  readonly actionType = SET_CURRENCY_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'SetCurrencyExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigureEvaluationDashboardsExecutor implements EvaluationSettingsActionExecutor {
+  readonly actionType = CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureEvaluationDashboardsExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class ConfigureVoucherMappingExecutor implements EvaluationSettingsActionExecutor {
+  readonly actionType = CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'ConfigureVoucherMappingExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createEvaluationSettingsActionExecutors(): Record<
+  string,
+  EvaluationSettingsActionExecutor
+> {
+  return {
+    [CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE]: new ConfigureRevenueAttributionExecutor(),
+    [SET_CURRENCY_ACTION_TYPE]: new SetCurrencyExecutor(),
+    [CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE]: new ConfigureEvaluationDashboardsExecutor(),
+    [CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE]: new ConfigureVoucherMappingExecutor(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
+export class BloomreachEvaluationSettingsService {
+  private readonly revenueAttributionSettingsUrl: string;
+  private readonly currencySettingsUrl: string;
+  private readonly evaluationDashboardsSettingsUrl: string;
+  private readonly voucherMappingSettingsUrl: string;
+
+  constructor(project: string) {
+    const validated = validateProject(project);
+    this.revenueAttributionSettingsUrl = buildRevenueAttributionUrl(validated);
+    this.currencySettingsUrl = buildCurrencyUrl(validated);
+    this.evaluationDashboardsSettingsUrl = buildEvaluationDashboardsUrl(validated);
+    this.voucherMappingSettingsUrl = buildVoucherMappingUrl(validated);
+  }
+
+  get revenueAttributionUrl(): string {
+    return this.revenueAttributionSettingsUrl;
+  }
+
+  get currencyUrl(): string {
+    return this.currencySettingsUrl;
+  }
+
+  get evaluationDashboardsUrl(): string {
+    return this.evaluationDashboardsSettingsUrl;
+  }
+
+  get voucherMappingUrl(): string {
+    return this.voucherMappingSettingsUrl;
+  }
+
+  async viewRevenueAttribution(
+    _input?: ViewRevenueAttributionInput,
+  ): Promise<BloomreachRevenueAttributionSettings> {
+    throw new Error(
+      'viewRevenueAttribution: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewCurrency(_input?: ViewCurrencyInput): Promise<BloomreachCurrencySettings> {
+    throw new Error(
+      'viewCurrency: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewEvaluationDashboards(
+    _input?: ViewEvaluationDashboardsInput,
+  ): Promise<BloomreachEvaluationDashboardSettings> {
+    throw new Error(
+      'viewEvaluationDashboards: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewVoucherMapping(
+    _input?: ViewVoucherMappingInput,
+  ): Promise<BloomreachVoucherMappingSettings> {
+    throw new Error(
+      'viewVoucherMapping: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareConfigureRevenueAttribution(
+    input: ConfigureRevenueAttributionInput,
+  ): PreparedEvaluationSettingsAction {
+    const project = validateProject(input.project);
+    const model = validateAttributionModel(input.model);
+    const attributionWindow =
+      input.attributionWindow !== undefined
+        ? validateAttributionWindow(input.attributionWindow)
+        : undefined;
+    const channels = input.channels?.map((channel) => channel.trim());
+
+    const preview = {
+      action: CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE,
+      project,
+      model,
+      attributionWindow,
+      channels,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareSetCurrency(input: SetCurrencyInput): PreparedEvaluationSettingsAction {
+    const project = validateProject(input.project);
+    const currencyCode = validateCurrencyCode(input.currencyCode);
+    const currencySymbol =
+      input.currencySymbol !== undefined ? input.currencySymbol.trim() : undefined;
+
+    const preview = {
+      action: SET_CURRENCY_ACTION_TYPE,
+      project,
+      currencyCode,
+      currencySymbol,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigureEvaluationDashboards(
+    input: ConfigureEvaluationDashboardsInput,
+  ): PreparedEvaluationSettingsAction {
+    const project = validateProject(input.project);
+    if (input.dashboards.length === 0) {
+      throw new Error('At least one dashboard configuration must be provided.');
+    }
+    const dashboards = input.dashboards.map((dashboard) => ({
+      id: validateDashboardId(dashboard.id),
+      enabled: dashboard.enabled,
+    }));
+
+    const preview = {
+      action: CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE,
+      project,
+      dashboards,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareConfigureVoucherMapping(
+    input: ConfigureVoucherMappingInput,
+  ): PreparedEvaluationSettingsAction {
+    const project = validateProject(input.project);
+    const mappingField = validateMappingField(input.mappingField);
+    const mappingType = input.mappingType !== undefined ? input.mappingType.trim() : undefined;
+
+    const preview = {
+      action: CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE,
+      project,
+      mappingField,
+      mappingType,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/bloomreachSecuritySettings.ts
+++ b/packages/core/src/bloomreachSecuritySettings.ts
@@ -1,0 +1,444 @@
+import { validateProject } from './bloomreachDashboards.js';
+
+// ---------------------------------------------------------------------------
+// Action type constants
+// ---------------------------------------------------------------------------
+
+export const CREATE_SSH_TUNNEL_ACTION_TYPE = 'security_settings.create_ssh_tunnel';
+export const UPDATE_SSH_TUNNEL_ACTION_TYPE = 'security_settings.update_ssh_tunnel';
+export const DELETE_SSH_TUNNEL_ACTION_TYPE = 'security_settings.delete_ssh_tunnel';
+export const ENABLE_TWO_STEP_ACTION_TYPE = 'security_settings.enable_two_step';
+export const DISABLE_TWO_STEP_ACTION_TYPE = 'security_settings.disable_two_step';
+export const UPDATE_TWO_STEP_ACTION_TYPE = 'security_settings.update_two_step';
+
+// ---------------------------------------------------------------------------
+// Rate limit constants
+// ---------------------------------------------------------------------------
+
+export const SECURITY_SETTINGS_RATE_LIMIT_WINDOW_MS = 3_600_000;
+export const SECURITY_SETTINGS_SSH_TUNNEL_RATE_LIMIT = 10;
+export const SECURITY_SETTINGS_TWO_STEP_RATE_LIMIT = 10;
+
+// ---------------------------------------------------------------------------
+// Data interfaces
+// ---------------------------------------------------------------------------
+
+export interface BloomreachSshTunnel {
+  id: string;
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  status: string;
+  databaseType?: string;
+  createdAt?: string;
+  url: string;
+}
+
+export interface BloomreachTwoStepVerificationSettings {
+  enabled: boolean;
+  enforced?: boolean;
+  enforcedAt?: string;
+  url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input interfaces
+// ---------------------------------------------------------------------------
+
+export interface ListSshTunnelsInput {
+  project: string;
+}
+
+export interface ViewSshTunnelInput {
+  project: string;
+  tunnelId: string;
+}
+
+export interface CreateSshTunnelInput {
+  project: string;
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  hostKey?: string;
+  databaseType?: string;
+  operatorNote?: string;
+}
+
+export interface UpdateSshTunnelInput {
+  project: string;
+  tunnelId: string;
+  name?: string;
+  host?: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  hostKey?: string;
+  operatorNote?: string;
+}
+
+export interface DeleteSshTunnelInput {
+  project: string;
+  tunnelId: string;
+  operatorNote?: string;
+}
+
+export interface ViewTwoStepVerificationInput {
+  project: string;
+}
+
+export interface EnableTwoStepVerificationInput {
+  project: string;
+  operatorNote?: string;
+}
+
+export interface DisableTwoStepVerificationInput {
+  project: string;
+  operatorNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Prepared action result
+// ---------------------------------------------------------------------------
+
+export interface PreparedSecuritySettingsAction {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const MAX_TUNNEL_NAME_LENGTH = 200;
+const MAX_HOST_LENGTH = 253;
+const MAX_USERNAME_LENGTH = 200;
+
+export function validateTunnelName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Tunnel name must not be empty.');
+  }
+  if (trimmed.length > MAX_TUNNEL_NAME_LENGTH) {
+    throw new Error(
+      `Tunnel name must not exceed ${MAX_TUNNEL_NAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateHost(host: string): string {
+  const trimmed = host.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Host must not be empty.');
+  }
+  if (trimmed.length > MAX_HOST_LENGTH) {
+    throw new Error(`Host must not exceed ${MAX_HOST_LENGTH} characters (got ${trimmed.length}).`);
+  }
+  return trimmed;
+}
+
+export function validatePort(port: number): number {
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error('Port must be a positive integer.');
+  }
+  if (port < 1 || port > 65535) {
+    throw new Error(`Port must be between 1 and 65535 (got ${port}).`);
+  }
+  return port;
+}
+
+export function validateUsername(username: string): string {
+  const trimmed = username.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Username must not be empty.');
+  }
+  if (trimmed.length > MAX_USERNAME_LENGTH) {
+    throw new Error(
+      `Username must not exceed ${MAX_USERNAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateTunnelId(tunnelId: string): string {
+  const trimmed = tunnelId.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Tunnel ID must not be empty.');
+  }
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+export function buildSshTunnelsUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/ssh-tunnels`;
+}
+
+export function buildTwoStepVerificationUrl(project: string): string {
+  return `/p/${encodeURIComponent(project)}/project-settings/project-two-step`;
+}
+
+// ---------------------------------------------------------------------------
+// Action executor interface + implementations
+// ---------------------------------------------------------------------------
+
+export interface SecuritySettingsActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+class CreateSshTunnelExecutor implements SecuritySettingsActionExecutor {
+  readonly actionType = CREATE_SSH_TUNNEL_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'CreateSshTunnelExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateSshTunnelExecutor implements SecuritySettingsActionExecutor {
+  readonly actionType = UPDATE_SSH_TUNNEL_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateSshTunnelExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DeleteSshTunnelExecutor implements SecuritySettingsActionExecutor {
+  readonly actionType = DELETE_SSH_TUNNEL_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DeleteSshTunnelExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class EnableTwoStepExecutor implements SecuritySettingsActionExecutor {
+  readonly actionType = ENABLE_TWO_STEP_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'EnableTwoStepExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class DisableTwoStepExecutor implements SecuritySettingsActionExecutor {
+  readonly actionType = DISABLE_TWO_STEP_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'DisableTwoStepExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+class UpdateTwoStepExecutor implements SecuritySettingsActionExecutor {
+  readonly actionType = UPDATE_TWO_STEP_ACTION_TYPE;
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    throw new Error(
+      'UpdateTwoStepExecutor: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+}
+
+export function createSecuritySettingsActionExecutors(): Record<
+  string,
+  SecuritySettingsActionExecutor
+> {
+  return {
+    [CREATE_SSH_TUNNEL_ACTION_TYPE]: new CreateSshTunnelExecutor(),
+    [UPDATE_SSH_TUNNEL_ACTION_TYPE]: new UpdateSshTunnelExecutor(),
+    [DELETE_SSH_TUNNEL_ACTION_TYPE]: new DeleteSshTunnelExecutor(),
+    [ENABLE_TWO_STEP_ACTION_TYPE]: new EnableTwoStepExecutor(),
+    [DISABLE_TWO_STEP_ACTION_TYPE]: new DisableTwoStepExecutor(),
+    [UPDATE_TWO_STEP_ACTION_TYPE]: new UpdateTwoStepExecutor(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
+export class BloomreachSecuritySettingsService {
+  private readonly sshTunnelsSettingsUrl: string;
+  private readonly twoStepVerificationSettingsUrl: string;
+
+  constructor(project: string) {
+    const validated = validateProject(project);
+    this.sshTunnelsSettingsUrl = buildSshTunnelsUrl(validated);
+    this.twoStepVerificationSettingsUrl = buildTwoStepVerificationUrl(validated);
+  }
+
+  get sshTunnelsUrl(): string {
+    return this.sshTunnelsSettingsUrl;
+  }
+
+  get twoStepVerificationUrl(): string {
+    return this.twoStepVerificationSettingsUrl;
+  }
+
+  async listSshTunnels(_input?: ListSshTunnelsInput): Promise<BloomreachSshTunnel[]> {
+    throw new Error(
+      'listSshTunnels: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewSshTunnel(_input?: ViewSshTunnelInput): Promise<BloomreachSshTunnel> {
+    throw new Error(
+      'viewSshTunnel: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  async viewTwoStepVerification(
+    _input?: ViewTwoStepVerificationInput,
+  ): Promise<BloomreachTwoStepVerificationSettings> {
+    throw new Error(
+      'viewTwoStepVerification: not yet implemented. Requires browser automation infrastructure.',
+    );
+  }
+
+  prepareCreateSshTunnel(input: CreateSshTunnelInput): PreparedSecuritySettingsAction {
+    const project = validateProject(input.project);
+    const name = validateTunnelName(input.name);
+    const host = validateHost(input.host);
+    const port = validatePort(input.port);
+    const username = validateUsername(input.username);
+    const password = input.password !== undefined ? input.password.trim() : undefined;
+    const hostKey = input.hostKey !== undefined ? input.hostKey.trim() : undefined;
+    const databaseType = input.databaseType !== undefined ? input.databaseType.trim() : undefined;
+
+    const preview = {
+      action: CREATE_SSH_TUNNEL_ACTION_TYPE,
+      project,
+      name,
+      host,
+      port,
+      username,
+      password,
+      hostKey,
+      databaseType,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareUpdateSshTunnel(input: UpdateSshTunnelInput): PreparedSecuritySettingsAction {
+    const project = validateProject(input.project);
+    const tunnelId = validateTunnelId(input.tunnelId);
+    const name = input.name !== undefined ? validateTunnelName(input.name) : undefined;
+    const host = input.host !== undefined ? validateHost(input.host) : undefined;
+    const port = input.port !== undefined ? validatePort(input.port) : undefined;
+    const username = input.username !== undefined ? validateUsername(input.username) : undefined;
+    const password = input.password !== undefined ? input.password.trim() : undefined;
+    const hostKey = input.hostKey !== undefined ? input.hostKey.trim() : undefined;
+
+    if (
+      name === undefined &&
+      host === undefined &&
+      port === undefined &&
+      username === undefined &&
+      password === undefined &&
+      hostKey === undefined
+    ) {
+      throw new Error(
+        'At least one of name, host, port, username, password, or hostKey must be provided for tunnel update.',
+      );
+    }
+
+    const preview = {
+      action: UPDATE_SSH_TUNNEL_ACTION_TYPE,
+      project,
+      tunnelId,
+      name,
+      host,
+      port,
+      username,
+      password,
+      hostKey,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDeleteSshTunnel(input: DeleteSshTunnelInput): PreparedSecuritySettingsAction {
+    const project = validateProject(input.project);
+    const tunnelId = validateTunnelId(input.tunnelId);
+
+    const preview = {
+      action: DELETE_SSH_TUNNEL_ACTION_TYPE,
+      project,
+      tunnelId,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareEnableTwoStep(
+    input: EnableTwoStepVerificationInput,
+  ): PreparedSecuritySettingsAction {
+    const project = validateProject(input.project);
+
+    const preview = {
+      action: ENABLE_TWO_STEP_ACTION_TYPE,
+      project,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+
+  prepareDisableTwoStep(
+    input: DisableTwoStepVerificationInput,
+  ): PreparedSecuritySettingsAction {
+    const project = validateProject(input.project);
+
+    const preview = {
+      action: DISABLE_TWO_STEP_ACTION_TYPE,
+      project,
+      operatorNote: input.operatorNote,
+    };
+
+    return {
+      preparedActionId: `pa_${Date.now()}`,
+      confirmToken: `ct_stub_${Date.now()}`,
+      expiresAtMs: Date.now() + 30 * 60 * 1000,
+      preview,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,8 @@ export * from './bloomreachInitiatives.js';
 export * from './bloomreachIntegrations.js';
 export * from './bloomreachProjectSettings.js';
 export * from './bloomreachChannelSettings.js';
+export * from './bloomreachSecuritySettings.js';
+export * from './bloomreachEvaluationSettings.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary
Add security and evaluation settings feature modules for Bloomreach project configuration, covering SSH tunnels, two-step verification, revenue attribution, currency, evaluation dashboards, and voucher mapping.

Closes #59

## Changes

### New Core Modules
- **`bloomreachSecuritySettings.ts`** — SSH tunnel management (list/view/create/update/delete) and two-step verification (view/enable/disable). 6 action types, 5 validators, 6 action executors, full service class with two-phase commit.
- **`bloomreachEvaluationSettings.ts`** — Revenue attribution configuration, currency settings, evaluation dashboard management, and voucher mapping. 4 action types, 5 validators, 4 action executors, full service class with two-phase commit.

### Tests
- **`bloomreachSecuritySettings.test.ts`** — 64 unit tests covering all constants, validators, URL builders, executor registry, and service methods
- **`bloomreachEvaluationSettings.test.ts`** — 67 unit tests covering all constants, validators, URL builders, executor registry, and service methods

### CLI Commands
- `bloomreach security-settings ssh-tunnels {list|view|create|delete}` — SSH tunnel management
- `bloomreach security-settings two-step {view|enable|disable}` — Two-step verification
- `bloomreach evaluation-settings revenue-attribution {view|configure}` — Revenue attribution
- `bloomreach evaluation-settings currency {view|set}` — Currency settings
- `bloomreach evaluation-settings dashboards {view|configure}` — Evaluation dashboards
- `bloomreach evaluation-settings voucher-mapping {view|configure}` — Voucher mapping

### Updated Files
- `packages/core/src/index.ts` — Added barrel exports for both new modules

## Quality Gates
- ✅ Typecheck: clean
- ✅ Lint: clean
- ✅ Tests: 2472/2472 passing (27 test files)
- ✅ Build: successful

## URL Coverage
| URL Path | Module | Actions |
|----------|--------|---------|
| `/p/{project}/project-settings/ssh-tunnels` | Security | List, Create, Delete |
| `/p/{project}/project-settings/project-two-step` | Security | View, Enable, Disable |
| `/p/{project}/project-settings/project-revenue-attribution` | Evaluation | View, Configure |
| `/p/{project}/project-settings/currency` | Evaluation | View, Set |
| `/p/{project}/project-settings/evaluation-dashboards` | Evaluation | View, Configure |
| `/p/{project}/project-settings/vouchers` | Evaluation | View, Configure |
