### PR TITLE
feat: wire customers module to Bloomreach REST API (#98)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -35,8 +35,10 @@ import {
   BloomreachTrendsService,
   BloomreachVouchersService,
   BloomreachWeblayersService,
+  resolveApiConfig,
 } from '@bloomreach-buddy/core';
 import type {
+  BloomreachApiConfig,
   CustomerIds,
   DataSelection,
   EmailCampaignABTestConfig,
@@ -76,6 +78,16 @@ import type {
 
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
+}
+
+function tryResolveApiConfig(projectToken?: string): BloomreachApiConfig | undefined {
+  try {
+    return resolveApiConfig(
+      projectToken ? { projectToken } : undefined,
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 const program = new Command();
@@ -2564,18 +2576,28 @@ geoAnalyses
     },
   );
 
-const customers = program.command('customers').description('Manage Bloomreach customer profiles');
+const customers = program
+  .command('customers')
+  .description(
+    'Manage Bloomreach customer profiles.\n\n' +
+      'Requires API credentials via environment variables:\n' +
+      '  BLOOMREACH_PROJECT_TOKEN  — Project token (UUID)\n' +
+      '  BLOOMREACH_API_KEY_ID     — API key identifier\n' +
+      '  BLOOMREACH_API_SECRET     — API secret\n' +
+      '  BLOOMREACH_API_BASE_URL   — Optional (default: https://api.exponea.com)',
+  );
 
 customers
   .command('list')
   .description('List customer profiles in the project')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .option('--limit <limit>', 'Maximum number of customers to return', '50')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID)')
+  .option('--limit <limit>', 'Maximum number of customers to return (1-1000)', '50')
   .option('--offset <offset>', 'Offset for pagination', '0')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; limit: string; offset: string; json?: boolean }) => {
     try {
-      const service = new BloomreachCustomersService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachCustomersService(options.project, apiConfig);
       const result = await service.listCustomers({
         project: options.project,
         limit: parseInt(options.limit, 10),
@@ -2606,10 +2628,10 @@ customers
 
 customers
   .command('search')
-  .description('Search customer profiles by query')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--query <query>', 'Search query')
-  .option('--limit <limit>', 'Maximum number of customers to return', '50')
+  .description('Search for a customer profile by identifier')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID)')
+  .requiredOption('--query <query>', 'Customer identifier value to search for (e.g. email address)')
+  .option('--limit <limit>', 'Maximum number of customers to return (1-1000)', '50')
   .option('--offset <offset>', 'Offset for pagination', '0')
   .option('--json', 'Output as JSON')
   .action(
@@ -2621,7 +2643,8 @@ customers
       json?: boolean;
     }) => {
       try {
-        const service = new BloomreachCustomersService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachCustomersService(options.project, apiConfig);
         const result = await service.searchCustomers({
           project: options.project,
           query: options.query,
@@ -2654,15 +2677,20 @@ customers
 
 customers
   .command('view')
-  .description('View details for a customer profile')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .description('View full profile for a customer')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID)')
   .requiredOption('--customer-id <customerId>', 'Customer identifier value')
-  .option('--id-type <idType>', 'Identifier type', 'registered')
+  .option(
+    '--id-type <idType>',
+    'Type of the customer identifier: registered (default), cookie, or email',
+    'registered',
+  )
   .option('--json', 'Output as JSON')
   .action(
     async (options: { project: string; customerId: string; idType: string; json?: boolean }) => {
       try {
-        const service = new BloomreachCustomersService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachCustomersService(options.project, apiConfig);
         const result = await service.viewCustomer({
           project: options.project,
           customerId: options.customerId,
@@ -2692,9 +2720,15 @@ customers
 customers
   .command('create')
   .description('Prepare creation of a customer profile (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--customer-ids <json>', 'JSON object of customer identifiers')
-  .requiredOption('--properties <json>', 'JSON object of customer properties')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID)')
+  .requiredOption(
+    '--customer-ids <json>',
+    'JSON object of customer identifiers, e.g. \'{"registered":"user@example.com"}\'',
+  )
+  .requiredOption(
+    '--properties <json>',
+    'JSON object of customer properties, e.g. \'{"first_name":"Jane"}\'',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -2709,7 +2743,8 @@ customers
         const customerIds = JSON.parse(options.customerIds) as CustomerIds;
         const properties = JSON.parse(options.properties) as Record<string, unknown>;
 
-        const service = new BloomreachCustomersService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachCustomersService(options.project, apiConfig);
         const result = service.prepareCreateCustomer({
           project: options.project,
           customerIds,
@@ -2737,10 +2772,17 @@ customers
 customers
   .command('update')
   .description('Prepare update of a customer profile (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID)')
   .requiredOption('--customer-id <customerId>', 'Customer identifier value')
-  .requiredOption('--properties <json>', 'JSON object of customer properties')
-  .option('--id-type <idType>', 'Identifier type', 'registered')
+  .requiredOption(
+    '--properties <json>',
+    'JSON object of customer properties to update, e.g. \'{"tier":"gold"}\'',
+  )
+  .option(
+    '--id-type <idType>',
+    'Type of the customer identifier: registered (default), cookie, or email',
+    'registered',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -2755,7 +2797,8 @@ customers
       try {
         const properties = JSON.parse(options.properties) as Record<string, unknown>;
 
-        const service = new BloomreachCustomersService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachCustomersService(options.project, apiConfig);
         const result = service.prepareUpdateCustomer({
           project: options.project,
           customerId: options.customerId,
@@ -2784,10 +2827,17 @@ customers
 
 customers
   .command('delete')
-  .description('Prepare deletion of a customer profile (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .description(
+    'Prepare deletion (anonymization) of a customer profile (two-phase commit).\n' +
+      'Bloomreach does not hard-delete customers; this anonymizes PII via the GDPR API.',
+  )
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID)')
   .requiredOption('--customer-id <customerId>', 'Customer identifier value')
-  .option('--id-type <idType>', 'Identifier type', 'registered')
+  .option(
+    '--id-type <idType>',
+    'Type of the customer identifier: registered (default), cookie, or email',
+    'registered',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -2799,7 +2849,8 @@ customers
       json?: boolean;
     }) => {
       try {
-        const service = new BloomreachCustomersService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachCustomersService(options.project, apiConfig);
         const result = service.prepareDeleteCustomer({
           project: options.project,
           customerId: options.customerId,
@@ -2810,7 +2861,7 @@ customers
         if (options.json) {
           printJson(result);
         } else {
-          console.log('Customer deletion prepared.');
+          console.log('Customer deletion (anonymization) prepared.');
           console.log(`  Customer: ${options.customerId}`);
           console.log(`  Token:    ${result.confirmToken}`);
           console.log(`  Expires:  ${new Date(result.expiresAtMs).toISOString()}`);

--- a/packages/core/src/__tests__/bloomreachApiClient.test.ts
+++ b/packages/core/src/__tests__/bloomreachApiClient.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  resolveApiConfig,
+  buildAuthHeader,
+  bloomreachApiFetch,
+  buildTrackingPath,
+  buildDataPath,
+  BloomreachApiError,
+} from '../bloomreachApiClient.js';
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('resolveApiConfig', () => {
+  it('returns config when all values are provided explicitly', () => {
+    const result = resolveApiConfig({
+      projectToken: 'project-1',
+      apiKeyId: 'key-1',
+      apiSecret: 'secret-1',
+      baseUrl: 'https://api.test.com',
+    });
+
+    expect(result).toEqual({
+      projectToken: 'project-1',
+      apiKeyId: 'key-1',
+      apiSecret: 'secret-1',
+      baseUrl: 'https://api.test.com',
+    });
+  });
+
+  it('falls back to environment variables', () => {
+    process.env.BLOOMREACH_PROJECT_TOKEN = 'env-project';
+    process.env.BLOOMREACH_API_KEY_ID = 'env-key';
+    process.env.BLOOMREACH_API_SECRET = 'env-secret';
+    process.env.BLOOMREACH_API_BASE_URL = 'https://env.test.com';
+
+    const result = resolveApiConfig();
+
+    expect(result).toEqual({
+      projectToken: 'env-project',
+      apiKeyId: 'env-key',
+      apiSecret: 'env-secret',
+      baseUrl: 'https://env.test.com',
+    });
+  });
+
+  it('throws when projectToken is missing', () => {
+    process.env.BLOOMREACH_PROJECT_TOKEN = '';
+    process.env.BLOOMREACH_API_KEY_ID = 'env-key';
+    process.env.BLOOMREACH_API_SECRET = 'env-secret';
+
+    expect(() => resolveApiConfig()).toThrow('Bloomreach project token is required');
+  });
+
+  it('throws when apiKeyId is missing', () => {
+    process.env.BLOOMREACH_PROJECT_TOKEN = 'env-project';
+    process.env.BLOOMREACH_API_KEY_ID = '';
+    process.env.BLOOMREACH_API_SECRET = 'env-secret';
+
+    expect(() => resolveApiConfig()).toThrow('Bloomreach API key ID is required');
+  });
+
+  it('throws when apiSecret is missing', () => {
+    process.env.BLOOMREACH_PROJECT_TOKEN = 'env-project';
+    process.env.BLOOMREACH_API_KEY_ID = 'env-key';
+    process.env.BLOOMREACH_API_SECRET = '';
+
+    expect(() => resolveApiConfig()).toThrow('Bloomreach API secret is required');
+  });
+
+  it('trims whitespace from values', () => {
+    const result = resolveApiConfig({
+      projectToken: '  project-1  ',
+      apiKeyId: '  key-1  ',
+      apiSecret: '  secret-1  ',
+      baseUrl: 'https://api.test.com',
+    });
+
+    expect(result.projectToken).toBe('project-1');
+    expect(result.apiKeyId).toBe('key-1');
+    expect(result.apiSecret).toBe('secret-1');
+  });
+
+  it('strips trailing slash from baseUrl', () => {
+    const result = resolveApiConfig({
+      projectToken: 'project-1',
+      apiKeyId: 'key-1',
+      apiSecret: 'secret-1',
+      baseUrl: 'https://api.test.com///',
+    });
+
+    expect(result.baseUrl).toBe('https://api.test.com');
+  });
+
+  it('uses default baseUrl when not provided', () => {
+    const result = resolveApiConfig({
+      projectToken: 'project-1',
+      apiKeyId: 'key-1',
+      apiSecret: 'secret-1',
+    });
+
+    expect(result.baseUrl).toBe('https://api.exponea.com');
+  });
+});
+
+describe('buildAuthHeader', () => {
+  it('returns correct Basic auth format', () => {
+    const header = buildAuthHeader({
+      projectToken: 'project-1',
+      apiKeyId: 'my-key',
+      apiSecret: 'my-secret',
+      baseUrl: 'https://api.test.com',
+    });
+
+    expect(header.startsWith('Basic ')).toBe(true);
+  });
+
+  it('base64 encodes apiKeyId:apiSecret correctly', () => {
+    const header = buildAuthHeader({
+      projectToken: 'project-1',
+      apiKeyId: 'my-key',
+      apiSecret: 'my-secret',
+      baseUrl: 'https://api.test.com',
+    });
+
+    expect(header).toBe(`Basic ${Buffer.from('my-key:my-secret').toString('base64')}`);
+  });
+});
+
+describe('bloomreachApiFetch', () => {
+  it('makes request with correct URL, method, headers, and body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const config = {
+      projectToken: 'project-1',
+      apiKeyId: 'my-key',
+      apiSecret: 'my-secret',
+      baseUrl: 'https://api.test.com',
+    };
+
+    await bloomreachApiFetch(config, '/track/v2/projects/project-1/customers', {
+      method: 'PUT',
+      body: { customer_ids: { registered: 'cust-1' } },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.test.com/track/v2/projects/project-1/customers',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: `Basic ${Buffer.from('my-key:my-secret').toString('base64')}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        }),
+        body: JSON.stringify({ customer_ids: { registered: 'cust-1' } }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('returns parsed JSON on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, id: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await bloomreachApiFetch(
+      {
+        projectToken: 'project-1',
+        apiKeyId: 'my-key',
+        apiSecret: 'my-secret',
+        baseUrl: 'https://api.test.com',
+      },
+      '/data/v2/projects/project-1/customers/export',
+    );
+
+    expect(result).toEqual({ ok: true, id: 1 });
+  });
+
+  it('throws BloomreachApiError on non-2xx responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'bad request' }), {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      bloomreachApiFetch(
+        {
+          projectToken: 'project-1',
+          apiKeyId: 'my-key',
+          apiSecret: 'my-secret',
+          baseUrl: 'https://api.test.com',
+        },
+        '/track/v2/projects/project-1/customers',
+      ),
+    ).rejects.toBeInstanceOf(BloomreachApiError);
+  });
+
+  it('handles timeout and aborts the request', async () => {
+    vi.useFakeTimers();
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+
+    const request = bloomreachApiFetch(
+      {
+        projectToken: 'project-1',
+        apiKeyId: 'my-key',
+        apiSecret: 'my-secret',
+        baseUrl: 'https://api.test.com',
+      },
+      '/track/v2/projects/project-1/customers',
+      { timeoutMs: 10 },
+    );
+
+    const assertion = expect(request).rejects.toThrow('timed out after 10ms');
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    await assertion;
+  });
+});
+
+describe('buildTrackingPath and buildDataPath', () => {
+  it('returns correctly formatted tracking path', () => {
+    const result = buildTrackingPath(
+      {
+        projectToken: 'project-1',
+        apiKeyId: 'my-key',
+        apiSecret: 'my-secret',
+        baseUrl: 'https://api.test.com',
+      },
+      '/customers',
+    );
+
+    expect(result).toBe('/track/v2/projects/project-1/customers');
+  });
+
+  it('returns correctly formatted data path', () => {
+    const result = buildDataPath(
+      {
+        projectToken: 'project-1',
+        apiKeyId: 'my-key',
+        apiSecret: 'my-secret',
+        baseUrl: 'https://api.test.com',
+      },
+      '/customers/export',
+    );
+
+    expect(result).toBe('/data/v2/projects/project-1/customers/export');
+  });
+
+  it('encodes special characters in project token', () => {
+    const config = {
+      projectToken: 'proj/with space',
+      apiKeyId: 'my-key',
+      apiSecret: 'my-secret',
+      baseUrl: 'https://api.test.com',
+    };
+
+    expect(buildTrackingPath(config, '/customers')).toBe(
+      '/track/v2/projects/proj%2Fwith%20space/customers',
+    );
+    expect(buildDataPath(config, '/customers/export')).toBe(
+      '/data/v2/projects/proj%2Fwith%20space/customers/export',
+    );
+  });
+});
+
+describe('BloomreachApiError', () => {
+  it('stores statusCode and responseBody', () => {
+    const error = new BloomreachApiError('failed', 500, { error: 'internal' });
+
+    expect(error.statusCode).toBe(500);
+    expect(error.responseBody).toEqual({ error: 'internal' });
+  });
+
+  it('has correct name property', () => {
+    const error = new BloomreachApiError('failed', 500, { error: 'internal' });
+
+    expect(error.name).toBe('BloomreachApiError');
+  });
+});

--- a/packages/core/src/__tests__/bloomreachCustomers.test.ts
+++ b/packages/core/src/__tests__/bloomreachCustomers.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
 import {
   CREATE_CUSTOMER_ACTION_TYPE,
   UPDATE_CUSTOMER_ACTION_TYPE,
@@ -18,6 +19,17 @@ import {
   createCustomerActionExecutors,
   BloomreachCustomersService,
 } from '../index.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_CUSTOMER_ACTION_TYPE', () => {
@@ -234,11 +246,39 @@ describe('createCustomerActionExecutors', () => {
     }
   });
 
-  it('executors throw not yet implemented on execute', async () => {
+  it('executors require API credentials when apiConfig is not provided', async () => {
     const executors = createCustomerActionExecutors();
     for (const executor of Object.values(executors)) {
-      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+      await expect(executor.execute({})).rejects.toThrow('requires API credentials');
     }
+  });
+
+  it('executors attempt API calls when apiConfig is provided', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const executors = createCustomerActionExecutors(TEST_API_CONFIG);
+    await executors[CREATE_CUSTOMER_ACTION_TYPE].execute({
+      customerIds: { registered: 'cust-1' },
+      properties: { tier: 'gold' },
+    });
+    await executors[UPDATE_CUSTOMER_ACTION_TYPE].execute({
+      customerId: 'cust-2',
+      idType: 'registered',
+      properties: { tier: 'platinum' },
+    });
+    await executors[DELETE_CUSTOMER_ACTION_TYPE].execute({
+      customerId: 'cust-3',
+      idType: 'registered',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -262,12 +302,43 @@ describe('BloomreachCustomersService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachCustomersService('')).toThrow('must not be empty');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachCustomersService('my-project', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachCustomersService);
+    });
   });
 
   describe('listCustomers', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachCustomersService('test');
-      await expect(service.listCustomers()).rejects.toThrow('not yet implemented');
+      await expect(service.listCustomers()).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns mapped customers when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            { registered: 'cust-1', email_id: 'one@example.com', tier: 'gold' },
+            { registered: 'cust-2', cookie: 'cookie-2', tier: 'silver' },
+          ]),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+      const service = new BloomreachCustomersService('test', TEST_API_CONFIG);
+      const result = await service.listCustomers({ project: 'test', limit: 1, offset: 1 });
+
+      expect(result).toEqual([
+        {
+          customerIds: { registered: 'cust-2', cookie: 'cookie-2' },
+          properties: { tier: 'silver' },
+          url: '',
+        },
+      ]);
     });
 
     it('validates limit when input is provided', async () => {
@@ -293,11 +364,51 @@ describe('BloomreachCustomersService', () => {
   });
 
   describe('searchCustomers', () => {
-    it('throws not-yet-implemented error with valid input', async () => {
+    it('throws API credential error with valid input when apiConfig is not provided', async () => {
       const service = new BloomreachCustomersService('test');
       await expect(
         service.searchCustomers({ project: 'test', query: 'shoes', limit: 10, offset: 0 }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns mapped search result when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            results: [
+              { success: true, value: 'Jane' },
+              { success: true, value: 'Doe' },
+              { success: true, value: 'jane@example.com' },
+              { success: true, value: 'cust-10' },
+              { success: true, value: 'cookie-10' },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+      const service = new BloomreachCustomersService('test', TEST_API_CONFIG);
+      const result = await service.searchCustomers({
+        project: 'test',
+        query: 'shoes',
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result).toEqual([
+        {
+          customerIds: { registered: 'cust-10', cookie: 'cookie-10' },
+          properties: {
+            first_name: 'Jane',
+            last_name: 'Doe',
+            email: 'jane@example.com',
+          },
+          url: '',
+        },
+      ]);
     });
 
     it('validates query', async () => {
@@ -316,11 +427,56 @@ describe('BloomreachCustomersService', () => {
   });
 
   describe('viewCustomer', () => {
-    it('throws not-yet-implemented error with valid input', async () => {
+    it('throws API credential error with valid input when apiConfig is not provided', async () => {
       const service = new BloomreachCustomersService('test');
       await expect(
         service.viewCustomer({ project: 'test', customerId: 'customer-1', idType: 'registered' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns customer profile when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            results: [
+              { success: true, value: 'John' },
+              { success: true, value: 'Smith' },
+              { success: true, value: 'john@example.com' },
+              { success: true, value: '+123' },
+              { success: true, value: 'registered-1' },
+              { success: true, value: 'cookie-1' },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+      const service = new BloomreachCustomersService('test', TEST_API_CONFIG);
+      const result = await service.viewCustomer({
+        project: 'test',
+        customerId: 'customer-1',
+        idType: 'registered',
+      });
+
+      expect(result).toEqual({
+        customerIds: { registered: 'registered-1', cookie: 'cookie-1' },
+        properties: {
+          first_name: 'John',
+          last_name: 'Smith',
+          email: 'john@example.com',
+          phone: '+123',
+        },
+        url: '',
+        firstName: 'John',
+        lastName: 'Smith',
+        email: 'john@example.com',
+        phone: '+123',
+        events: [],
+        segments: [],
+      });
     });
 
     it('validates customerId', async () => {

--- a/packages/core/src/bloomreachApiClient.ts
+++ b/packages/core/src/bloomreachApiClient.ts
@@ -1,0 +1,146 @@
+export interface BloomreachApiConfig {
+  projectToken: string;
+  apiKeyId: string;
+  apiSecret: string;
+  baseUrl?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://api.exponea.com';
+
+/**
+ * Resolve API config from explicit values merged with environment variables.
+ * Explicit values take precedence. Required: projectToken, apiKeyId, apiSecret.
+ */
+export function resolveApiConfig(
+  explicit?: Partial<BloomreachApiConfig>,
+): BloomreachApiConfig {
+  const projectToken =
+    explicit?.projectToken ?? process.env.BLOOMREACH_PROJECT_TOKEN ?? '';
+  const apiKeyId =
+    explicit?.apiKeyId ?? process.env.BLOOMREACH_API_KEY_ID ?? '';
+  const apiSecret =
+    explicit?.apiSecret ?? process.env.BLOOMREACH_API_SECRET ?? '';
+  const baseUrl =
+    explicit?.baseUrl ??
+    process.env.BLOOMREACH_API_BASE_URL ??
+    DEFAULT_BASE_URL;
+
+  if (projectToken.trim().length === 0) {
+    throw new Error(
+      'Bloomreach project token is required. Set BLOOMREACH_PROJECT_TOKEN or pass --project-token.',
+    );
+  }
+  if (apiKeyId.trim().length === 0) {
+    throw new Error(
+      'Bloomreach API key ID is required. Set BLOOMREACH_API_KEY_ID or pass --api-key-id.',
+    );
+  }
+  if (apiSecret.trim().length === 0) {
+    throw new Error(
+      'Bloomreach API secret is required. Set BLOOMREACH_API_SECRET or pass --api-secret.',
+    );
+  }
+
+  return {
+    projectToken: projectToken.trim(),
+    apiKeyId: apiKeyId.trim(),
+    apiSecret: apiSecret.trim(),
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+  };
+}
+
+export function buildAuthHeader(config: BloomreachApiConfig): string {
+  const credentials = `${config.apiKeyId}:${config.apiSecret}`;
+  return `Basic ${Buffer.from(credentials).toString('base64')}`;
+}
+
+export class BloomreachApiError extends Error {
+  readonly statusCode: number;
+  readonly responseBody: unknown;
+
+  constructor(message: string, statusCode: number, responseBody: unknown) {
+    super(message);
+    this.name = 'BloomreachApiError';
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+}
+
+export interface BloomreachFetchOptions {
+  method?: string;
+  body?: unknown;
+  timeoutMs?: number;
+}
+
+/**
+ * Make an authenticated request to the Bloomreach REST API.
+ * @throws {BloomreachApiError} On non-2xx responses.
+ */
+export async function bloomreachApiFetch(
+  config: BloomreachApiConfig,
+  path: string,
+  options: BloomreachFetchOptions = {},
+): Promise<unknown> {
+  const { method = 'POST', body, timeoutMs = 30_000 } = options;
+  const url = `${config.baseUrl}${path}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: buildAuthHeader(config),
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    const text = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+
+    if (!response.ok) {
+      throw new BloomreachApiError(
+        `Bloomreach API error ${response.status}: ${response.statusText}`,
+        response.status,
+        parsed,
+      );
+    }
+
+    return parsed;
+  } catch (error) {
+    if (error instanceof BloomreachApiError) {
+      throw error;
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error(
+        `Bloomreach API request timed out after ${timeoutMs}ms: ${method} ${path}`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function buildTrackingPath(
+  config: BloomreachApiConfig,
+  suffix: string,
+): string {
+  return `/track/v2/projects/${encodeURIComponent(config.projectToken)}${suffix}`;
+}
+
+export function buildDataPath(
+  config: BloomreachApiConfig,
+  suffix: string,
+): string {
+  return `/data/v2/projects/${encodeURIComponent(config.projectToken)}${suffix}`;
+}

--- a/packages/core/src/bloomreachCustomers.ts
+++ b/packages/core/src/bloomreachCustomers.ts
@@ -1,10 +1,15 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import {
+  bloomreachApiFetch,
+  buildDataPath,
+  buildTrackingPath,
+} from './bloomreachApiClient.js';
 
 export const CREATE_CUSTOMER_ACTION_TYPE = 'customers.create_customer';
 export const UPDATE_CUSTOMER_ACTION_TYPE = 'customers.update_customer';
 export const DELETE_CUSTOMER_ACTION_TYPE = 'customers.delete_customer';
 
-/** Rate limit window for customer operations (1 hour in ms). */
 export const CUSTOMER_RATE_LIMIT_WINDOW_MS = 3_600_000;
 export const CUSTOMER_CREATE_RATE_LIMIT = 50;
 export const CUSTOMER_UPDATE_RATE_LIMIT = 100;
@@ -190,58 +195,135 @@ export interface CustomerActionExecutor {
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 class CreateCustomerExecutor implements CustomerActionExecutor {
   readonly actionType = CREATE_CUSTOMER_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateCustomerExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'CreateCustomerExecutor');
+    const customerIds = payload.customerIds as CustomerIds;
+    const properties = payload.properties as Record<string, unknown>;
+
+    const path = buildTrackingPath(config, '/customers');
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        customer_ids: customerIds,
+        properties,
+      },
+    });
+
+    return { success: true, response };
   }
 }
 
 class UpdateCustomerExecutor implements CustomerActionExecutor {
   readonly actionType = UPDATE_CUSTOMER_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UpdateCustomerExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'UpdateCustomerExecutor');
+    const customerId = payload.customerId as string;
+    const idType = (payload.idType as string | undefined) ?? 'registered';
+    const properties = payload.properties as Record<string, unknown>;
+
+    const path = buildTrackingPath(config, '/customers');
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        customer_ids: { [idType]: customerId },
+        properties,
+      },
+    });
+
+    return { success: true, response };
   }
 }
 
 class DeleteCustomerExecutor implements CustomerActionExecutor {
   readonly actionType = DELETE_CUSTOMER_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'DeleteCustomerExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'DeleteCustomerExecutor');
+    const customerId = payload.customerId as string;
+    const idType = (payload.idType as string | undefined) ?? 'registered';
+
+    const path = buildDataPath(config, '/customers/anonymize');
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        customer_ids: { [idType]: customerId },
+      },
+    });
+
+    return { success: true, response };
   }
 }
 
-export function createCustomerActionExecutors(): Record<
-  string,
-  CustomerActionExecutor
-> {
+export function createCustomerActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, CustomerActionExecutor> {
   return {
-    [CREATE_CUSTOMER_ACTION_TYPE]: new CreateCustomerExecutor(),
-    [UPDATE_CUSTOMER_ACTION_TYPE]: new UpdateCustomerExecutor(),
-    [DELETE_CUSTOMER_ACTION_TYPE]: new DeleteCustomerExecutor(),
+    [CREATE_CUSTOMER_ACTION_TYPE]: new CreateCustomerExecutor(apiConfig),
+    [UPDATE_CUSTOMER_ACTION_TYPE]: new UpdateCustomerExecutor(apiConfig),
+    [DELETE_CUSTOMER_ACTION_TYPE]: new DeleteCustomerExecutor(apiConfig),
+  };
+}
+
+interface ExportResponseRow {
+  [key: string]: unknown;
+}
+
+function parseExportedCustomer(row: ExportResponseRow): BloomreachCustomer {
+  const customerIds: CustomerIds = {};
+  const properties: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(row)) {
+    if (key === 'registered' || key === 'cookie' || key === 'email_id') {
+      const idKey = key === 'email_id' ? 'email' : key;
+      customerIds[idKey] = typeof value === 'string' ? value : String(value ?? '');
+    } else {
+      properties[key] = value;
+    }
+  }
+
+  return {
+    customerIds,
+    properties,
+    url: '',
   };
 }
 
 export class BloomreachCustomersService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildCustomersUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get customersUrl(): string {
@@ -255,9 +337,23 @@ export class BloomreachCustomersService {
       validateListOffset(input.offset);
     }
 
-    throw new Error(
-      'listCustomers: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'listCustomers');
+    const path = buildDataPath(config, '/customers/export');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        format: 'table_json',
+        attributes: { type: 'properties_and_ids' },
+      },
+    });
+
+    const rows = Array.isArray(response) ? response : [];
+    const limit = input?.limit ?? DEFAULT_LIST_LIMIT;
+    const offset = input?.offset ?? 0;
+
+    return rows
+      .slice(offset, offset + limit)
+      .map((row: ExportResponseRow) => parseExportedCustomer(row));
   }
 
   async searchCustomers(input: SearchCustomersInput): Promise<BloomreachCustomer[]> {
@@ -266,19 +362,112 @@ export class BloomreachCustomersService {
     validateListLimit(input.limit);
     validateListOffset(input.offset);
 
-    throw new Error(
-      'searchCustomers: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'searchCustomers');
+    const path = buildDataPath(config, '/customers/attributes');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        customer_ids: { registered: input.query },
+        attributes: [
+          { type: 'property', property: 'first_name' },
+          { type: 'property', property: 'last_name' },
+          { type: 'property', property: 'email' },
+          { type: 'id', id: 'registered' },
+          { type: 'id', id: 'cookie' },
+        ],
+      },
+    });
+
+    const data = response as Record<string, unknown>;
+    if (!data.results || !Array.isArray(data.results)) {
+      return [];
+    }
+
+    const results = data.results as Array<{ success: boolean; value: unknown }>;
+    const properties: Record<string, unknown> = {};
+    const customerIds: CustomerIds = {};
+    const attrNames = ['first_name', 'last_name', 'email', 'registered', 'cookie'];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.success && result.value !== undefined && result.value !== null) {
+        const name = attrNames[i];
+        if (name === 'registered' || name === 'cookie') {
+          customerIds[name] = String(result.value);
+        } else {
+          properties[name] = result.value;
+        }
+      }
+    }
+
+    if (Object.keys(customerIds).length === 0 && Object.keys(properties).length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        customerIds,
+        properties,
+        url: '',
+      },
+    ];
   }
 
   async viewCustomer(input: ViewCustomerInput): Promise<CustomerProfile> {
     validateProject(input.project);
     validateCustomerId(input.customerId);
-    validateIdType(input.idType);
+    const idType = validateIdType(input.idType);
 
-    throw new Error(
-      'viewCustomer: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewCustomer');
+    const path = buildDataPath(config, '/customers/attributes');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        customer_ids: { [idType]: input.customerId },
+        attributes: [
+          { type: 'property', property: 'first_name' },
+          { type: 'property', property: 'last_name' },
+          { type: 'property', property: 'email' },
+          { type: 'property', property: 'phone' },
+          { type: 'id', id: 'registered' },
+          { type: 'id', id: 'cookie' },
+        ],
+      },
+    });
+
+    const data = response as Record<string, unknown>;
+    const results = (data.results ?? []) as Array<{ success: boolean; value: unknown }>;
+
+    const getValue = (index: number): string | undefined => {
+      const r = results[index];
+      if (r?.success && r.value !== undefined && r.value !== null) {
+        return String(r.value);
+      }
+      return undefined;
+    };
+
+    const customerIds: CustomerIds = { [idType]: input.customerId };
+    const registeredVal = getValue(4);
+    if (registeredVal) customerIds.registered = registeredVal;
+    const cookieVal = getValue(5);
+    if (cookieVal) customerIds.cookie = cookieVal;
+
+    return {
+      customerIds,
+      properties: {
+        first_name: getValue(0),
+        last_name: getValue(1),
+        email: getValue(2),
+        phone: getValue(3),
+      },
+      url: '',
+      firstName: getValue(0),
+      lastName: getValue(1),
+      email: getValue(2),
+      phone: getValue(3),
+      events: [],
+      segments: [],
+    };
   }
 
   prepareCreateCustomer(input: CreateCustomerInput): PreparedCustomerAction {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export * from './bloomreachEvaluationSettings.js';
 export * from './bloomreachWeblayers.js';
 export * from './bloomreachUseCases.js';
 export * from './bloomreachAccessManagement.js';
+export * from './bloomreachApiClient.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Wire the customers module to the Bloomreach REST API, replacing all "not yet implemented" stubs with real HTTP calls.

- **New `bloomreachApiClient.ts`** — Shared HTTP client with Basic auth, env-var config resolution (`BLOOMREACH_PROJECT_TOKEN`, `BLOOMREACH_API_KEY_ID`, `BLOOMREACH_API_SECRET`), timeout handling, and `BloomreachApiError` for structured API error responses
- **Read operations implemented** — `listCustomers` → export API, `searchCustomers` → attributes API, `viewCustomer` → attributes API
- **Write executors implemented** — `CreateCustomerExecutor` → tracking API (`POST /track/v2/.../customers`), `UpdateCustomerExecutor` → tracking API, `DeleteCustomerExecutor` → GDPR anonymize API (`POST /data/v2/.../customers/anonymize`)
- **CLI improved** — API config resolved from env vars, better help text for `--id-type` (explains registered/cookie/email), delete command clarifies GDPR anonymization
- **94 tests** — 75 customer tests + 19 API client tests, all passing with mocked fetch

## Quality Gates

| Gate | Status |
|------|--------|
| TypeScript | ✅ Clean |
| ESLint | ✅ Clean |
| Tests | ✅ 6,358 pass (72 files) |
| Build | ✅ Success |

## Environment Variables (new)

```
BLOOMREACH_PROJECT_TOKEN  — Project token (UUID)
BLOOMREACH_API_KEY_ID     — API key identifier
BLOOMREACH_API_SECRET     — API secret
BLOOMREACH_API_BASE_URL   — Optional (default: https://api.exponea.com)
```

Closes #98
