### PR TITLE
feat #100: wire segmentations module to Bloomreach REST API

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -9168,8 +9168,10 @@ const segmentations = program
 
 segmentations
   .command('list')
-  .description('List all segmentations in the project')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .description(
+    'List all segmentations in the project (note: requires browser automation — not yet available via API)',
+  )
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; json?: boolean }) => {
     try {
@@ -9200,11 +9202,15 @@ segmentations
   .command('view-size')
   .description('View the number of customers matching a segmentation')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--segmentation-id <id>', 'Segmentation ID')
+  .requiredOption(
+    '--segmentation-id <id>',
+    'Segmentation analysis ID (hex string from Bloomreach UI URL, e.g. "606488856f8cf6f848b20af8")',
+  )
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; segmentationId: string; json?: boolean }) => {
     try {
-      const service = new BloomreachSegmentationsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachSegmentationsService(options.project, apiConfig);
       const result = await service.viewSegmentSize({
         project: options.project,
         segmentationId: options.segmentationId,
@@ -9227,9 +9233,13 @@ segmentations
   .command('view-customers')
   .description('Browse customers matching a segmentation')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--segmentation-id <id>', 'Segmentation ID')
+  .requiredOption(
+    '--segmentation-id <id>',
+    'Segmentation analysis ID (hex string from Bloomreach UI URL, e.g. "606488856f8cf6f848b20af8")',
+  )
   .option('--limit <n>', 'Maximum number of customers to return')
   .option('--offset <n>', 'Offset for pagination')
+  .option('--format <format>', 'Output format: table (default) or csv', 'table')
   .option('--json', 'Output as JSON')
   .action(
     async (options: {
@@ -9237,10 +9247,12 @@ segmentations
       segmentationId: string;
       limit?: string;
       offset?: string;
+      format: string;
       json?: boolean;
     }) => {
       try {
-        const service = new BloomreachSegmentationsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachSegmentationsService(options.project, apiConfig);
         const result = await service.viewSegmentCustomers({
           project: options.project,
           segmentationId: options.segmentationId,
@@ -9250,6 +9262,13 @@ segmentations
 
         if (options.json) {
           printJson(result);
+        } else if (options.format.toLowerCase() === 'csv') {
+          console.log('customerId,attributes');
+          for (const customer of result.customers) {
+            const escapedCustomerId = customer.customerId.replaceAll('"', '""');
+            const attributesJson = JSON.stringify(customer.attributes ?? {}).replaceAll('"', '""');
+            console.log(`"${escapedCustomerId}","${attributesJson}"`);
+          }
         } else {
           console.log(`Segment Customers: ${result.segmentationId}`);
           console.log(`  Total:  ${result.total}`);
@@ -9273,7 +9292,7 @@ segmentations
   .requiredOption('--name <name>', 'Segmentation name')
   .requiredOption(
     '--conditions <json>',
-    'JSON array of conditions [{type, attribute, operator, value?}]',
+    'JSON array of conditions, e.g. [{"type":"customer_attribute","attribute":"email","operator":"is_set"}]',
   )
   .option('--operator <op>', 'Logical operator for conditions (and, or)', 'and')
   .option('--start-date <date>', 'Start date for event conditions (YYYY-MM-DD)')
@@ -9331,7 +9350,10 @@ segmentations
   .command('clone')
   .description('Prepare cloning a segmentation (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--segmentation-id <id>', 'Segmentation ID to clone')
+  .requiredOption(
+    '--segmentation-id <id>',
+    'Segmentation analysis ID (hex string from Bloomreach UI URL, e.g. "606488856f8cf6f848b20af8")',
+  )
   .option('--new-name <name>', 'Name for the cloned segmentation')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
@@ -9375,7 +9397,10 @@ segmentations
   .command('archive')
   .description('Prepare archiving a segmentation (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--segmentation-id <id>', 'Segmentation ID')
+  .requiredOption(
+    '--segmentation-id <id>',
+    'Segmentation analysis ID (hex string from Bloomreach UI URL, e.g. "606488856f8cf6f848b20af8")',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(

--- a/packages/core/src/__tests__/bloomreachSegmentations.test.ts
+++ b/packages/core/src/__tests__/bloomreachSegmentations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_SEGMENTATION_ACTION_TYPE,
   CLONE_SEGMENTATION_ACTION_TYPE,
@@ -22,6 +22,18 @@ import {
   BloomreachSegmentationsService,
 } from '../index.js';
 import type { SegmentCondition } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_SEGMENTATION_ACTION_TYPE', () => {
@@ -588,6 +600,24 @@ describe('createSegmentationActionExecutors', () => {
       'not yet implemented',
     );
   });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createSegmentationActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(3);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createSegmentationActionExecutors(TEST_API_CONFIG);
+    await expect(executors[CREATE_SEGMENTATION_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+    await expect(executors[CLONE_SEGMENTATION_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+    await expect(executors[ARCHIVE_SEGMENTATION_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
 });
 
 describe('BloomreachSegmentationsService', () => {
@@ -597,8 +627,18 @@ describe('BloomreachSegmentationsService', () => {
       expect(service).toBeInstanceOf(BloomreachSegmentationsService);
     });
 
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachSegmentationsService('kingdom-of-joakim', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachSegmentationsService);
+    });
+
     it('exposes the segmentations URL', () => {
       const service = new BloomreachSegmentationsService('kingdom-of-joakim');
+      expect(service.segmentationsUrl).toBe('/p/kingdom-of-joakim/analytics/segmentations');
+    });
+
+    it('exposes segmentations URL when constructed with apiConfig', () => {
+      const service = new BloomreachSegmentationsService('kingdom-of-joakim', TEST_API_CONFIG);
       expect(service.segmentationsUrl).toBe('/p/kingdom-of-joakim/analytics/segmentations');
     });
 
@@ -622,9 +662,9 @@ describe('BloomreachSegmentationsService', () => {
   });
 
   describe('listSegmentations', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws unsupported list endpoint error', async () => {
       const service = new BloomreachSegmentationsService('test');
-      await expect(service.listSegmentations()).rejects.toThrow('not yet implemented');
+      await expect(service.listSegmentations()).rejects.toThrow('does not provide a list endpoint');
     });
 
     it('validates project when input is provided', async () => {
@@ -639,37 +679,27 @@ describe('BloomreachSegmentationsService', () => {
       );
     });
 
-    it('throws not-yet-implemented error for valid project override', async () => {
+    it('throws unsupported list endpoint error for valid project override', async () => {
       const service = new BloomreachSegmentationsService('test');
       await expect(service.listSegmentations({ project: 'kingdom-of-joakim' })).rejects.toThrow(
-        'not yet implemented',
+        'does not provide a list endpoint',
       );
     });
 
-    it('throws not-yet-implemented error for trimmed project override', async () => {
+    it('throws unsupported list endpoint error for trimmed project override', async () => {
       const service = new BloomreachSegmentationsService('test');
       await expect(service.listSegmentations({ project: '  kingdom-of-joakim  ' })).rejects.toThrow(
-        'not yet implemented',
+        'does not provide a list endpoint',
       );
     });
   });
 
   describe('viewSegmentSize', () => {
-    it('throws not-yet-implemented error with valid minimal input', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachSegmentationsService('test');
       await expect(
         service.viewSegmentSize({ project: 'test', segmentationId: 'seg-1' }),
-      ).rejects.toThrow('not yet implemented');
-    });
-
-    it('throws not-yet-implemented error with valid full input', async () => {
-      const service = new BloomreachSegmentationsService('test');
-      await expect(
-        service.viewSegmentSize({
-          project: '  test  ',
-          segmentationId: '  seg-1  ',
-        }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
     });
 
     it('validates project input', async () => {
@@ -707,32 +737,68 @@ describe('BloomreachSegmentationsService', () => {
       ).rejects.toThrow('Segmentation ID must not be empty');
     });
 
-    it('accepts trimmed segmentationId and reaches not-yet-implemented', async () => {
-      const service = new BloomreachSegmentationsService('test');
+    it('returns segment size from API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['segment', '#'],
+            rows: [['online buyers', 42], ['offline buyers', 18]],
+            success: true,
+            name: 'test segmentation',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachSegmentationsService('test', TEST_API_CONFIG);
+      const result = await service.viewSegmentSize({
+        project: 'test',
+        segmentationId: 'seg-abc',
+      });
+
+      expect(result.segmentationId).toBe('seg-abc');
+      expect(result.customerCount).toBe(60);
+      expect(result.computedAt).toBeDefined();
+    });
+
+    it('returns zero customer count for empty rows', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({ header: ['segment', '#'], rows: [], success: true }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachSegmentationsService('test', TEST_API_CONFIG);
+      const result = await service.viewSegmentSize({
+        project: 'test',
+        segmentationId: 'seg-empty',
+      });
+
+      expect(result.customerCount).toBe(0);
+    });
+
+    it('throws on unsuccessful API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({ success: false, errors: { _global: ['Not found'] } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachSegmentationsService('test', TEST_API_CONFIG);
       await expect(
-        service.viewSegmentSize({ project: 'test', segmentationId: '  seg-99  ' }),
-      ).rejects.toThrow('not yet implemented');
+        service.viewSegmentSize({ project: 'test', segmentationId: 'bad-id' }),
+      ).rejects.toThrow('unexpected API response format');
     });
   });
 
   describe('viewSegmentCustomers', () => {
-    it('throws not-yet-implemented error with valid minimal input', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachSegmentationsService('test');
       await expect(
         service.viewSegmentCustomers({ project: 'test', segmentationId: 'seg-1' }),
-      ).rejects.toThrow('not yet implemented');
-    });
-
-    it('throws not-yet-implemented error with valid full input', async () => {
-      const service = new BloomreachSegmentationsService('test');
-      await expect(
-        service.viewSegmentCustomers({
-          project: 'test',
-          segmentationId: 'seg-1',
-          limit: 50,
-          offset: 10,
-        }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
     });
 
     it('validates project input', async () => {
@@ -798,28 +864,69 @@ describe('BloomreachSegmentationsService', () => {
       ).rejects.toThrow('non-negative integer');
     });
 
-    it('accepts undefined limit and offset and reaches not-yet-implemented', async () => {
-      const service = new BloomreachSegmentationsService('test');
-      await expect(
-        service.viewSegmentCustomers({
-          project: 'test',
-          segmentationId: 'seg-1',
-          limit: undefined,
-          offset: undefined,
-        }),
-      ).rejects.toThrow('not yet implemented');
+    it('returns customers from API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            { registered: 'cust-1', email_id: 'one@example.com', tier: 'gold' },
+            { registered: 'cust-2', cookie: 'cookie-2', tier: 'silver' },
+            { registered: 'cust-3', tier: 'bronze' },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachSegmentationsService('test', TEST_API_CONFIG);
+      const result = await service.viewSegmentCustomers({
+        project: 'test',
+        segmentationId: 'seg-abc',
+        limit: 2,
+        offset: 0,
+      });
+
+      expect(result.segmentationId).toBe('seg-abc');
+      expect(result.total).toBe(3);
+      expect(result.customers).toHaveLength(2);
+      expect(result.limit).toBe(2);
+      expect(result.offset).toBe(0);
+      expect(result.customers[0].customerId).toBe('cust-1');
+      expect(result.customers[1].customerId).toBe('cust-2');
     });
 
-    it('accepts valid limit and offset and reaches not-yet-implemented', async () => {
-      const service = new BloomreachSegmentationsService('test');
-      await expect(
-        service.viewSegmentCustomers({
-          project: 'test',
-          segmentationId: 'seg-1',
-          limit: 1,
-          offset: 0,
+    it('returns empty list when no customers match', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
         }),
-      ).rejects.toThrow('not yet implemented');
+      );
+
+      const service = new BloomreachSegmentationsService('test', TEST_API_CONFIG);
+      const result = await service.viewSegmentCustomers({
+        project: 'test',
+        segmentationId: 'seg-empty',
+      });
+
+      expect(result.customers).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('applies default limit and offset when not specified', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify([{ registered: 'cust-1' }]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const service = new BloomreachSegmentationsService('test', TEST_API_CONFIG);
+      const result = await service.viewSegmentCustomers({
+        project: 'test',
+        segmentationId: 'seg-1',
+      });
+
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
     });
   });
 

--- a/packages/core/src/bloomreachSegmentations.ts
+++ b/packages/core/src/bloomreachSegmentations.ts
@@ -1,6 +1,8 @@
 import { validateProject } from './bloomreachDashboards.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
 export const CREATE_SEGMENTATION_ACTION_TYPE = 'segmentations.create_segmentation';
 export const CLONE_SEGMENTATION_ACTION_TYPE = 'segmentations.clone_segmentation';
@@ -229,49 +231,87 @@ export interface SegmentationActionExecutor {
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 class CreateSegmentationExecutor implements SegmentationActionExecutor {
   readonly actionType = CREATE_SEGMENTATION_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateSegmentationExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateSegmentationExecutor: not yet implemented. ' +
+        'Segmentation creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CloneSegmentationExecutor implements SegmentationActionExecutor {
   readonly actionType = CLONE_SEGMENTATION_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CloneSegmentationExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CloneSegmentationExecutor: not yet implemented. ' +
+        'Segmentation cloning is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ArchiveSegmentationExecutor implements SegmentationActionExecutor {
   readonly actionType = ARCHIVE_SEGMENTATION_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ArchiveSegmentationExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ArchiveSegmentationExecutor: not yet implemented. ' +
+        'Segmentation archiving is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createSegmentationActionExecutors(): Record<string, SegmentationActionExecutor> {
+export function createSegmentationActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, SegmentationActionExecutor> {
   return {
-    [CREATE_SEGMENTATION_ACTION_TYPE]: new CreateSegmentationExecutor(),
-    [CLONE_SEGMENTATION_ACTION_TYPE]: new CloneSegmentationExecutor(),
-    [ARCHIVE_SEGMENTATION_ACTION_TYPE]: new ArchiveSegmentationExecutor(),
+    [CREATE_SEGMENTATION_ACTION_TYPE]: new CreateSegmentationExecutor(apiConfig),
+    [CLONE_SEGMENTATION_ACTION_TYPE]: new CloneSegmentationExecutor(apiConfig),
+    [ARCHIVE_SEGMENTATION_ACTION_TYPE]: new ArchiveSegmentationExecutor(apiConfig),
   };
 }
 
 export class BloomreachSegmentationsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildSegmentationsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get segmentationsUrl(): string {
@@ -284,28 +324,97 @@ export class BloomreachSegmentationsService {
     }
 
     throw new Error(
-      'listSegmentations: not yet implemented. Requires browser automation infrastructure.',
+      'listSegmentations: the Bloomreach API does not provide a list endpoint for segmentations. ' +
+        'Segmentation IDs must be obtained from the Bloomreach Engagement UI ' +
+        '(found in the URL when editing a segmentation, e.g. "606488856f8cf6f848b20af8").',
     );
   }
 
   async viewSegmentSize(input: ViewSegmentSizeInput): Promise<SegmentSize> {
     validateProject(input.project);
-    validateSegmentationId(input.segmentationId);
+    const segmentationId = validateSegmentationId(input.segmentationId);
 
-    throw new Error(
-      'viewSegmentSize: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewSegmentSize');
+    const path = buildDataPath(config, '/analyses/segmentation');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        analysis_id: segmentationId,
+        format: 'table_json',
+      },
+    });
+
+    const data = response as { header?: string[]; rows?: unknown[][]; success?: boolean };
+    if (!data.success || !Array.isArray(data.rows)) {
+      throw new Error('viewSegmentSize: unexpected API response format.');
+    }
+
+    const hashIndex = Array.isArray(data.header) ? data.header.indexOf('#') : -1;
+    const countIndex = hashIndex >= 0 ? hashIndex : (data.header?.length ?? 1) - 1;
+
+    let totalCustomers = 0;
+    for (const row of data.rows) {
+      const val = row[countIndex];
+      if (typeof val === 'number') {
+        totalCustomers += val;
+      }
+    }
+
+    return {
+      segmentationId,
+      customerCount: totalCustomers,
+      computedAt: new Date().toISOString(),
+    };
   }
 
   async viewSegmentCustomers(input: ViewSegmentCustomersInput): Promise<SegmentCustomerList> {
     validateProject(input.project);
-    validateSegmentationId(input.segmentationId);
-    validateCustomerListLimit(input.limit);
-    validateCustomerListOffset(input.offset);
+    const segmentationId = validateSegmentationId(input.segmentationId);
+    const limit = validateCustomerListLimit(input.limit);
+    const offset = validateCustomerListOffset(input.offset);
 
-    throw new Error(
-      'viewSegmentCustomers: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewSegmentCustomers');
+    const path = buildDataPath(config, '/customers/export');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        filter: {
+          type: 'segment',
+          segmentation_id: segmentationId,
+          segment_index: 0,
+        },
+        attributes: { type: 'properties_and_ids' },
+        format: 'table_json',
+      },
+    });
+
+    const rows = Array.isArray(response)
+      ? response
+      : response && typeof response === 'object' && Array.isArray((response as { data?: unknown[] }).data)
+        ? ((response as { data: unknown[] }).data as Array<Record<string, unknown>>)
+        : [];
+    const effectiveOffset = offset ?? 0;
+    const effectiveLimit = limit ?? 20;
+    const sliced = rows.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+
+    const customers: SegmentCustomer[] = sliced.map((row: Record<string, unknown>) => {
+      const customerId = String(row.registered ?? row.cookie ?? row.email_id ?? 'unknown');
+      const attributes: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(row)) {
+        if (key !== 'registered' && key !== 'cookie' && key !== 'email_id') {
+          attributes[key] = value;
+        }
+      }
+      return { customerId, attributes };
+    });
+
+    return {
+      segmentationId,
+      customers,
+      total: rows.length,
+      limit: effectiveLimit,
+      offset: effectiveOffset,
+    };
   }
 
   prepareCreateSegmentation(input: CreateSegmentationInput): PreparedSegmentationAction {


### PR DESCRIPTION
## Summary

Wire the Segmentations module to the Bloomreach REST API, matching the established Customers/Catalogs pattern. Add comprehensive tests and CLI improvements.

**Closes #100**

## Changes

### Core (`packages/core/src/bloomreachSegmentations.ts`)
- **API Config**: `BloomreachSegmentationsService` now accepts optional `apiConfig` parameter (matching `BloomreachCustomersService` / `BloomreachCatalogsService` pattern)
- **`viewSegmentSize`**: Now calls `POST /data/v2/projects/{token}/analyses/segmentation` with `analysis_id` and `format: "table_json"`, sums customer counts from the `#` column
- **`viewSegmentCustomers`**: Now calls `POST /data/v2/projects/{token}/customers/export` with segment filter (`filter.type: "segment"`), maps customer IDs/attributes, supports pagination
- **`listSegmentations`**: Updated error message — the Bloomreach API has no list endpoint; IDs must come from the UI
- **Action Executors**: Accept optional `apiConfig` (still stubs — create/clone/archive are UI-only operations)

### Tests (`packages/core/src/__tests__/bloomreachSegmentations.test.ts`)
- 179 tests total (up from 174) — all passing
- New: API-backed `viewSegmentSize` (mock fetch — success, empty rows, error responses)
- New: API-backed `viewSegmentCustomers` (mock fetch — success, empty results, default pagination)
- New: Missing API credentials error for read methods
- New: Constructor with `apiConfig` parameter
- New: Executor `apiConfig` acceptance
- Updated: `listSegmentations` error message expectations

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- `view-size` and `view-customers` now use `tryResolveApiConfig()` for real API calls
- Better `--segmentation-id` descriptions (explain hex string format from UI URL)
- Added `--format` option to `view-customers` (table or csv output)
- Improved `--conditions` help text with JSON example
- `list` command description notes API limitation

## Quality Gates

| Gate | Status |
|------|--------|
| `npm run typecheck` | ✅ Pass |
| `npm run lint` | ✅ Pass |
| `npm test` | ✅ 36 files, 3190 tests pass |
| `npm run build` | ✅ Success |

## Acid Test Status

| Command | Status | Notes |
|---------|--------|-------|
| `segmentations list` | ⚠️ No REST API | Clear error message directing users to UI |
| `segmentations view-size` | ✅ API-backed | Uses `/analyses/segmentation` endpoint |
| `segmentations view-customers` | ✅ API-backed | Uses `/customers/export` with segment filter |
| `segmentations create` | ✅ Prepare works | Executor stub (UI-only operation) |
| `segmentations clone` | ✅ Prepare works | Executor stub (UI-only operation) |
| `segmentations archive` | ✅ Prepare works | Executor stub (UI-only operation) |
| JSON output | ✅ All commands | `--json` flag supported |
| Error handling | ✅ Comprehensive | Validation, missing config, API errors |
