### PR TITLE
feat #101: wire reports module to Bloomreach REST API

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -8793,8 +8793,10 @@ const reports = program
 
 reports
   .command('list')
-  .description('List all reports in the project')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .description(
+    'List all reports in the project (note: requires browser automation — not yet available via API)',
+  )
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .option('--json', 'Output as JSON')
   .action(
     async (options: {
@@ -8833,12 +8835,16 @@ reports
   .command('view-results')
   .description('View results of a specific report')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'Report ID')
+  .requiredOption(
+    '--report-id <id>',
+    'Report analysis ID (hex string from Bloomreach UI URL, e.g. "606488856f8cf6f848b20af8")',
+  )
   .option('--start-date <date>', 'Start date (ISO-8601)')
   .option('--end-date <date>', 'End date (ISO-8601)')
   .option('--sort-column <column>', 'Column to sort by')
   .option('--sort-order <order>', 'Sort order (asc or desc)')
   .option('--limit <n>', 'Maximum rows to return')
+  .option('--format <format>', 'Output format: table (default) or csv', 'table')
   .option('--json', 'Output as JSON')
   .action(
     async (options: {
@@ -8849,10 +8855,12 @@ reports
       sortColumn?: string;
       sortOrder?: string;
       limit?: string;
+      format: string;
       json?: boolean;
     }) => {
       try {
-        const service = new BloomreachReportsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachReportsService(options.project, apiConfig);
         const input: {
           project: string;
           reportId: string;
@@ -8886,10 +8894,18 @@ reports
 
         if (options.json) {
           printJson(result);
+        } else if (options.format === 'csv') {
+          console.log(result.columns.join(','));
+          for (const row of result.rows) {
+            console.log(row.join(','));
+          }
         } else {
           console.log(`Report: ${result.reportName}`);
           console.log(`  Columns: ${result.columns.join(', ')}`);
           console.log(`  Rows:    ${result.rows.length} (total: ${result.totalRows})`);
+          if (result.dateRange) {
+            console.log(`  Date range: ${result.dateRange.startDate ?? '?'} – ${result.dateRange.endDate ?? '?'}`);
+          }
         }
       } catch (error) {
         console.error(
@@ -9004,7 +9020,10 @@ reports
   .command('export')
   .description('Prepare export of a report (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'Report ID')
+  .requiredOption(
+    '--report-id <id>',
+    'Report analysis ID (hex string from Bloomreach UI URL)',
+  )
   .requiredOption('--format <format>', 'Export format (csv or xlsx)')
   .option('--start-date <date>', 'Start date (ISO-8601)')
   .option('--end-date <date>', 'End date (ISO-8601)')
@@ -9078,7 +9097,10 @@ reports
   .command('clone')
   .description('Prepare cloning of a report (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'Report ID')
+  .requiredOption(
+    '--report-id <id>',
+    'Report analysis ID (hex string from Bloomreach UI URL)',
+  )
   .option('--new-name <name>', 'Name for the cloned report')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
@@ -9124,7 +9146,10 @@ reports
   .command('archive')
   .description('Prepare archiving of a report (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'Report ID')
+  .requiredOption(
+    '--report-id <id>',
+    'Report analysis ID (hex string from Bloomreach UI URL)',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(

--- a/packages/core/src/__tests__/bloomreachReports.test.ts
+++ b/packages/core/src/__tests__/bloomreachReports.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_REPORT_ACTION_TYPE,
   CLONE_REPORT_ACTION_TYPE,
@@ -20,6 +20,18 @@ import {
   createReportActionExecutors,
   BloomreachReportsService,
 } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_REPORT_ACTION_TYPE', () => {
@@ -230,6 +242,18 @@ describe('createReportActionExecutors', () => {
       await expect(executor.execute({})).rejects.toThrow('not yet implemented');
     }
   });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createReportActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(4);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createReportActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
 });
 
 describe('BloomreachReportsService', () => {
@@ -252,12 +276,22 @@ describe('BloomreachReportsService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachReportsService('')).toThrow('must not be empty');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachReportsService);
+    });
+
+    it('exposes reports URL when constructed with apiConfig', () => {
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      expect(service.reportsUrl).toBe('/p/test/analytics/reports');
+    });
   });
 
   describe('listReports', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachReportsService('test');
-      await expect(service.listReports()).rejects.toThrow('not yet implemented');
+      await expect(service.listReports()).rejects.toThrow('does not provide a list endpoint');
     });
 
     it('validates project when input is provided', async () => {
@@ -269,36 +303,36 @@ describe('BloomreachReportsService', () => {
   });
 
   describe('viewReportResults', () => {
-    it('throws not-yet-implemented error with valid input', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachReportsService('test');
       await expect(
         service.viewReportResults({ project: 'test', reportId: 'report-1' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
     });
 
     it('validates project input', async () => {
-      const service = new BloomreachReportsService('test');
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
       await expect(
         service.viewReportResults({ project: '', reportId: 'report-1' }),
       ).rejects.toThrow('must not be empty');
     });
 
     it('validates reportId input', async () => {
-      const service = new BloomreachReportsService('test');
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
       await expect(
         service.viewReportResults({ project: 'test', reportId: '   ' }),
       ).rejects.toThrow('Report ID must not be empty');
     });
 
     it('validates limit when provided', async () => {
-      const service = new BloomreachReportsService('test');
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
       await expect(
         service.viewReportResults({ project: 'test', reportId: 'report-1', limit: 0 }),
       ).rejects.toThrow('Limit must be an integer between 1 and 10000');
     });
 
     it('validates sort order when provided', async () => {
-      const service = new BloomreachReportsService('test');
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
       await expect(
         service.viewReportResults({
           project: 'test',
@@ -306,6 +340,148 @@ describe('BloomreachReportsService', () => {
           sort: { column: 'count', order: 'invalid' as unknown as 'asc' },
         }),
       ).rejects.toThrow('Sort order must be one of');
+    });
+
+    it('returns report results from API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['event_type', 'count'],
+            rows: [
+              ['purchase', 42],
+              ['session_start', 100],
+            ],
+            success: true,
+            name: 'Revenue Report',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      const result = await service.viewReportResults({
+        project: 'test',
+        reportId: 'report-1',
+      });
+
+      expect(result.reportId).toBe('report-1');
+      expect(result.reportName).toBe('Revenue Report');
+      expect(result.columns).toEqual(['event_type', 'count']);
+      expect(result.rows).toEqual([
+        ['purchase', '42'],
+        ['session_start', '100'],
+      ]);
+      expect(result.totalRows).toBe(2);
+    });
+
+    it('handles empty rows in API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['event_type', 'count'],
+            rows: [],
+            success: true,
+            name: 'Empty Report',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      const result = await service.viewReportResults({
+        project: 'test',
+        reportId: 'report-1',
+      });
+
+      expect(result.rows).toEqual([]);
+      expect(result.totalRows).toBe(0);
+    });
+
+    it('throws on unsuccessful API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ success: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      await expect(
+        service.viewReportResults({ project: 'test', reportId: 'report-1' }),
+      ).rejects.toThrow('unexpected API response format');
+    });
+
+    it('handles null cell values in rows', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['name', 'value'],
+            rows: [
+              [null, 'test'],
+              ['foo', null],
+            ],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      const result = await service.viewReportResults({
+        project: 'test',
+        reportId: 'report-1',
+      });
+
+      expect(result.rows).toEqual([
+        ['', 'test'],
+        ['foo', ''],
+      ]);
+    });
+
+    it('uses reportId as reportName when name is missing', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['col1'],
+            rows: [['val1']],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      const result = await service.viewReportResults({
+        project: 'test',
+        reportId: 'report-xyz',
+      });
+
+      expect(result.reportName).toBe('report-xyz');
+    });
+
+    it('includes dateRange from input in results', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['col1'],
+            rows: [['val1']],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachReportsService('test', TEST_API_CONFIG);
+      const result = await service.viewReportResults({
+        project: 'test',
+        reportId: 'report-1',
+        dateRange: { startDate: '2024-01-01', endDate: '2024-01-31' },
+      });
+
+      expect(result.dateRange).toEqual({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
     });
   });
 

--- a/packages/core/src/bloomreachReports.ts
+++ b/packages/core/src/bloomreachReports.ts
@@ -1,4 +1,6 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
 export const CREATE_REPORT_ACTION_TYPE = 'reports.create_report';
 export const CLONE_REPORT_ACTION_TYPE = 'reports.clone_report';
@@ -209,6 +211,19 @@ export function buildReportsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/analytics/reports`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 /**
  * Executor for a confirmed report mutation.
  * Execute methods require browser automation infrastructure (not yet built).
@@ -220,61 +235,91 @@ export interface ReportActionExecutor {
 
 class CreateReportExecutor implements ReportActionExecutor {
   readonly actionType = CREATE_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateReportExecutor: not yet implemented. ' +
+        'Report creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CloneReportExecutor implements ReportActionExecutor {
   readonly actionType = CLONE_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CloneReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CloneReportExecutor: not yet implemented. ' +
+        'Report cloning is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ArchiveReportExecutor implements ReportActionExecutor {
   readonly actionType = ARCHIVE_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ArchiveReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ArchiveReportExecutor: not yet implemented. ' +
+        'Report archiving is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ExportReportExecutor implements ReportActionExecutor {
   readonly actionType = EXPORT_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ExportReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ExportReportExecutor: not yet implemented. ' +
+        'Report export is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createReportActionExecutors(): Record<
+export function createReportActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<
   string,
   ReportActionExecutor
 > {
   return {
-    [CREATE_REPORT_ACTION_TYPE]: new CreateReportExecutor(),
-    [CLONE_REPORT_ACTION_TYPE]: new CloneReportExecutor(),
-    [ARCHIVE_REPORT_ACTION_TYPE]: new ArchiveReportExecutor(),
-    [EXPORT_REPORT_ACTION_TYPE]: new ExportReportExecutor(),
+    [CREATE_REPORT_ACTION_TYPE]: new CreateReportExecutor(apiConfig),
+    [CLONE_REPORT_ACTION_TYPE]: new CloneReportExecutor(apiConfig),
+    [ARCHIVE_REPORT_ACTION_TYPE]: new ArchiveReportExecutor(apiConfig),
+    [EXPORT_REPORT_ACTION_TYPE]: new ExportReportExecutor(apiConfig),
   };
 }
 
@@ -286,9 +331,11 @@ export function createReportActionExecutors(): Record<
  */
 export class BloomreachReportsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildReportsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get reportsUrl(): string {
@@ -302,7 +349,9 @@ export class BloomreachReportsService {
     }
 
     throw new Error(
-      'listReports: not yet implemented. Requires browser automation infrastructure.',
+      'listReports: the Bloomreach API does not provide a list endpoint for reports. ' +
+        'Report IDs must be obtained from the Bloomreach Engagement UI ' +
+        '(found in the URL when viewing a report, e.g. "606488856f8cf6f848b20af8").',
     );
   }
 
@@ -311,7 +360,7 @@ export class BloomreachReportsService {
     input: ViewReportResultsInput,
   ): Promise<ReportResults> {
     validateProject(input.project);
-    validateReportId(input.reportId);
+    const reportId = validateReportId(input.reportId);
     if (input.limit !== undefined) {
       validateLimit(input.limit);
     }
@@ -319,9 +368,39 @@ export class BloomreachReportsService {
       validateSortOrder(input.sort.order);
     }
 
-    throw new Error(
-      'viewReportResults: not yet implemented. Requires browser automation infrastructure.',
+    const config = requireApiConfig(this.apiConfig, 'viewReportResults');
+    const path = buildDataPath(config, '/analyses/reports');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        analysis_id: reportId,
+        format: 'table_json',
+      },
+    });
+
+    const data = response as {
+      header?: string[];
+      rows?: unknown[][];
+      success?: boolean;
+      name?: string;
+    };
+    if (!data.success || !Array.isArray(data.rows)) {
+      throw new Error('viewReportResults: unexpected API response format.');
+    }
+
+    const columns = Array.isArray(data.header) ? data.header : [];
+    const rows = data.rows.map((row) =>
+      row.map((cell) => (cell === null || cell === undefined ? '' : String(cell))),
     );
+
+    return {
+      reportId,
+      reportName: data.name ?? reportId,
+      columns,
+      rows,
+      totalRows: rows.length,
+      dateRange: input.dateRange,
+    };
   }
 
   /** @throws {Error} If input validation fails. */


### PR DESCRIPTION
## Summary

Wire the Reports module to the Bloomreach REST API, matching the established Segmentations/Customers/Catalogs pattern. Add comprehensive tests and CLI improvements.

**Closes #101**

## Changes

### Core (`packages/core/src/bloomreachReports.ts`)
- **API Config**: `BloomreachReportsService` now accepts optional `apiConfig` parameter (matching `BloomreachSegmentationsService` pattern)
- **`viewReportResults`**: Now calls `POST /data/v2/projects/{token}/analyses/reports` with `analysis_id` and `format: "table_json"`, parses header/rows response, coerces cells to strings
- **`listReports`**: Updated error message — the Bloomreach API has no list endpoint; IDs must come from the UI
- **`requireApiConfig()`**: New helper for credential validation
- **Action Executors**: Accept optional `apiConfig` (still stubs — create/clone/archive/export are UI-only operations)
- **Executor error messages**: Updated to clarify operations are "only available through the Bloomreach Engagement UI"

### Tests (`packages/core/src/__tests__/bloomreachReports.test.ts`)
- 10 new tests added covering:
  - API-backed `viewReportResults` (mock fetch — success, empty rows, error responses, null cells, missing name fallback, dateRange passthrough)
  - Missing API credentials error
  - Constructor with `apiConfig` parameter
  - Executor factory `apiConfig` acceptance
- Updated error message expectations for `listReports` and executors

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- `view-results` now uses `tryResolveApiConfig()` for real API calls
- Better `--report-id` descriptions (explain hex string format from UI URL)
- Added `--format` option to `view-results` (table or csv output)
- `list` command description notes API limitation
- Added date range display in table output

## Quality Gates

| Gate | Status |
|------|--------|
| `npm run typecheck` | ✅ Pass |
| `npm run lint` | ✅ Pass |
| `npm test` | ✅ 36 files, 3200 tests pass |
| `npm run build` | ✅ Success |

## Acid Test Status

| Command | Status | Notes |
|---------|--------|-------|
| `reports list` | ⚠️ No REST API | Clear error message directing users to UI |
| `reports view-results` | ✅ API-backed | Uses `/analyses/reports` endpoint |
| `reports create` | ✅ Prepare works | Executor stub (UI-only operation) |
| `reports export` | ✅ Prepare works | Executor stub (UI-only operation) |
| `reports clone` | ✅ Prepare works | Executor stub (UI-only operation) |
| `reports archive` | ✅ Prepare works | Executor stub (UI-only operation) |
| JSON output | ✅ All commands | `--json` flag supported |
| CSV output | ✅ view-results | `--format csv` supported |
| Error handling | ✅ Comprehensive | Validation, missing config, API errors |
