### PR TITLE
feat #102: wire funnels module to Bloomreach REST API (acid test)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -1638,8 +1638,10 @@ const funnels = program
 
 funnels
   .command('list')
-  .description('List all funnel analyses in the project')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
+  .description(
+    'List all funnel analyses in the project (note: requires browser automation — not yet available via API)',
+  )
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; json?: boolean }) => {
     try {
@@ -1671,7 +1673,10 @@ funnels
   .command('view-results')
   .description('View conversion rates and drop-off data for a funnel analysis')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--analysis-id <id>', 'Funnel analysis ID')
+  .requiredOption(
+    '--analysis-id <id>',
+    'Funnel analysis ID (hex string from Bloomreach UI URL, e.g. "606488856f8cf6f848b20af8")',
+  )
   .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
   .option('--json', 'Output as JSON')
@@ -1684,7 +1689,8 @@ funnels
       json?: boolean;
     }) => {
       try {
-        const service = new BloomreachFunnelsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachFunnelsService(options.project, apiConfig);
         const result = await service.viewFunnelResults({
           project: options.project,
           analysisId: options.analysisId,

--- a/packages/core/src/__tests__/bloomreachFunnels.test.ts
+++ b/packages/core/src/__tests__/bloomreachFunnels.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_FUNNEL_ACTION_TYPE,
   CLONE_FUNNEL_ACTION_TYPE,
@@ -14,6 +14,18 @@ import {
   createFunnelActionExecutors,
   BloomreachFunnelsService,
 } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_FUNNEL_ACTION_TYPE', () => {
@@ -368,6 +380,18 @@ describe('createFunnelActionExecutors', () => {
       'not yet implemented',
     );
   });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createFunnelActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(3);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createFunnelActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
 });
 
 describe('BloomreachFunnelsService', () => {
@@ -399,12 +423,24 @@ describe('BloomreachFunnelsService', () => {
       const service = new BloomreachFunnelsService('org/project');
       expect(service.funnelsUrl).toBe('/p/org%2Fproject/analytics/funnels');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachFunnelsService);
+    });
+
+    it('exposes funnels URL when constructed with apiConfig', () => {
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      expect(service.funnelsUrl).toBe('/p/test/analytics/funnels');
+    });
   });
 
   describe('listFunnelAnalyses', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachFunnelsService('test');
-      await expect(service.listFunnelAnalyses()).rejects.toThrow('not yet implemented');
+      await expect(service.listFunnelAnalyses()).rejects.toThrow(
+        'does not provide a list endpoint',
+      );
     });
 
     it('validates project when input is provided', async () => {
@@ -421,72 +457,221 @@ describe('BloomreachFunnelsService', () => {
       );
     });
 
-    it('throws not-yet-implemented error for valid project override', async () => {
+    it('throws no-API-endpoint error for valid project override', async () => {
       const service = new BloomreachFunnelsService('test');
-      await expect(service.listFunnelAnalyses({ project: 'kingdom-of-joakim' })).rejects.toThrow(
-        'not yet implemented',
-      );
+      await expect(
+        service.listFunnelAnalyses({ project: 'kingdom-of-joakim' }),
+      ).rejects.toThrow('does not provide a list endpoint');
     });
 
-    it('throws not-yet-implemented error for trimmed project override', async () => {
+    it('throws no-API-endpoint error for trimmed project override', async () => {
       const service = new BloomreachFunnelsService('test');
       await expect(
         service.listFunnelAnalyses({ project: '  kingdom-of-joakim  ' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide a list endpoint');
     });
   });
 
   describe('viewFunnelResults', () => {
-    it('throws not-yet-implemented error with valid minimal input', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachFunnelsService('test');
       await expect(
         service.viewFunnelResults({ project: 'test', analysisId: 'funnel-1' }),
-      ).rejects.toThrow('not yet implemented');
-    });
-
-    it('throws not-yet-implemented error with valid full input', async () => {
-      const service = new BloomreachFunnelsService('test');
-      await expect(
-        service.viewFunnelResults({
-          project: '  test  ',
-          analysisId: '  funnel-1  ',
-        }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
     });
 
     it('validates project input', async () => {
-      const service = new BloomreachFunnelsService('test');
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
       await expect(
         service.viewFunnelResults({ project: '', analysisId: 'funnel-1' }),
       ).rejects.toThrow('must not be empty');
     });
 
     it('validates whitespace-only project input', async () => {
-      const service = new BloomreachFunnelsService('test');
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
       await expect(
         service.viewFunnelResults({ project: '   ', analysisId: 'funnel-1' }),
       ).rejects.toThrow('must not be empty');
     });
 
     it('validates analysisId input', async () => {
-      const service = new BloomreachFunnelsService('test');
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
       await expect(
         service.viewFunnelResults({ project: 'test', analysisId: '   ' }),
       ).rejects.toThrow('Funnel analysis ID must not be empty');
     });
 
     it('validates empty analysisId input', async () => {
-      const service = new BloomreachFunnelsService('test');
-      await expect(service.viewFunnelResults({ project: 'test', analysisId: '' })).rejects.toThrow(
-        'Funnel analysis ID must not be empty',
-      );
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      await expect(
+        service.viewFunnelResults({ project: 'test', analysisId: '' }),
+      ).rejects.toThrow('Funnel analysis ID must not be empty');
     });
 
-    it('accepts trimmed analysisId and reaches not-yet-implemented', async () => {
-      const service = new BloomreachFunnelsService('test');
+    it('returns funnel results from API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['step', 'event_name', 'entered', 'completed', 'conversion_rate', 'drop_off_rate'],
+            rows: [
+              [1, 'view_product', 1000, 800, 0.8, 0.2],
+              [2, 'add_to_cart', 800, 400, 0.5, 0.5],
+              [3, 'purchase', 400, 200, 0.5, 0.5],
+            ],
+            success: true,
+            name: 'Checkout Funnel',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      const result = await service.viewFunnelResults({
+        project: 'test',
+        analysisId: 'funnel-1',
+      });
+
+      expect(result.analysisId).toBe('funnel-1');
+      expect(result.analysisName).toBe('Checkout Funnel');
+      expect(result.steps).toHaveLength(3);
+      expect(result.steps[0]).toEqual({
+        step: 1,
+        eventName: 'view_product',
+        entered: 1000,
+        completed: 800,
+        conversionRate: 0.8,
+        dropOffRate: 0.2,
+      });
+      expect(result.steps[2]).toEqual({
+        step: 3,
+        eventName: 'purchase',
+        entered: 400,
+        completed: 200,
+        conversionRate: 0.5,
+        dropOffRate: 0.5,
+      });
+      expect(result.overallConversionRate).toBe(0.2);
+    });
+
+    it('handles empty rows in API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['step', 'event_name', 'entered', 'completed', 'conversion_rate', 'drop_off_rate'],
+            rows: [],
+            success: true,
+            name: 'Empty Funnel',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      const result = await service.viewFunnelResults({
+        project: 'test',
+        analysisId: 'funnel-1',
+      });
+
+      expect(result.steps).toEqual([]);
+      expect(result.overallConversionRate).toBe(0);
+    });
+
+    it('throws on unsuccessful API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ success: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
       await expect(
-        service.viewFunnelResults({ project: 'test', analysisId: '  funnel-99  ' }),
-      ).rejects.toThrow('not yet implemented');
+        service.viewFunnelResults({ project: 'test', analysisId: 'funnel-1' }),
+      ).rejects.toThrow('unexpected API response format');
+    });
+
+    it('handles null cell values in rows', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['step', 'event_name', 'entered', 'completed', 'conversion_rate', 'drop_off_rate'],
+            rows: [
+              [null, null, null, null, null, null],
+              [2, 'purchase', 500, 300, 0.6, 0.4],
+            ],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      const result = await service.viewFunnelResults({
+        project: 'test',
+        analysisId: 'funnel-1',
+      });
+
+      expect(result.steps[0]).toEqual({
+        step: 0,
+        eventName: '',
+        entered: 0,
+        completed: 0,
+        conversionRate: 0,
+        dropOffRate: 0,
+      });
+      expect(result.steps[1]).toEqual({
+        step: 2,
+        eventName: 'purchase',
+        entered: 500,
+        completed: 300,
+        conversionRate: 0.6,
+        dropOffRate: 0.4,
+      });
+    });
+
+    it('uses analysisId as analysisName when name is missing', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['step', 'event_name', 'entered', 'completed', 'conversion_rate', 'drop_off_rate'],
+            rows: [[1, 'visit', 100, 50, 0.5, 0.5], [2, 'purchase', 50, 25, 0.5, 0.5]],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      const result = await service.viewFunnelResults({
+        project: 'test',
+        analysisId: 'funnel-xyz',
+      });
+
+      expect(result.analysisName).toBe('funnel-xyz');
+    });
+
+    it('includes date range from input in results', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['step', 'event_name', 'entered', 'completed', 'conversion_rate', 'drop_off_rate'],
+            rows: [[1, 'visit', 100, 50, 0.5, 0.5], [2, 'purchase', 50, 25, 0.5, 0.5]],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachFunnelsService('test', TEST_API_CONFIG);
+      const result = await service.viewFunnelResults({
+        project: 'test',
+        analysisId: 'funnel-1',
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      expect(result.startDate).toBe('2024-01-01');
+      expect(result.endDate).toBe('2024-01-31');
     });
   });
 

--- a/packages/core/src/bloomreachFunnels.ts
+++ b/packages/core/src/bloomreachFunnels.ts
@@ -1,6 +1,8 @@
 import { validateProject } from './bloomreachDashboards.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
 export const CREATE_FUNNEL_ACTION_TYPE = 'funnels.create_funnel';
 export const CLONE_FUNNEL_ACTION_TYPE = 'funnels.clone_funnel';
@@ -158,6 +160,19 @@ export function buildFunnelsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/analytics/funnels`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 export interface FunnelActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -165,47 +180,78 @@ export interface FunnelActionExecutor {
 
 class CreateFunnelExecutor implements FunnelActionExecutor {
   readonly actionType = CREATE_FUNNEL_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateFunnelExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateFunnelExecutor: not yet implemented. ' +
+        'Funnel creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CloneFunnelExecutor implements FunnelActionExecutor {
   readonly actionType = CLONE_FUNNEL_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CloneFunnelExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CloneFunnelExecutor: not yet implemented. ' +
+        'Funnel cloning is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ArchiveFunnelExecutor implements FunnelActionExecutor {
   readonly actionType = ARCHIVE_FUNNEL_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(
+    _payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ArchiveFunnelExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ArchiveFunnelExecutor: not yet implemented. ' +
+        'Funnel archiving is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createFunnelActionExecutors(): Record<string, FunnelActionExecutor> {
+export function createFunnelActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, FunnelActionExecutor> {
   return {
-    [CREATE_FUNNEL_ACTION_TYPE]: new CreateFunnelExecutor(),
-    [CLONE_FUNNEL_ACTION_TYPE]: new CloneFunnelExecutor(),
-    [ARCHIVE_FUNNEL_ACTION_TYPE]: new ArchiveFunnelExecutor(),
+    [CREATE_FUNNEL_ACTION_TYPE]: new CreateFunnelExecutor(apiConfig),
+    [CLONE_FUNNEL_ACTION_TYPE]: new CloneFunnelExecutor(apiConfig),
+    [ARCHIVE_FUNNEL_ACTION_TYPE]: new ArchiveFunnelExecutor(apiConfig),
   };
 }
 
 export class BloomreachFunnelsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildFunnelsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get funnelsUrl(): string {
@@ -218,13 +264,15 @@ export class BloomreachFunnelsService {
     }
 
     throw new Error(
-      'listFunnelAnalyses: not yet implemented. Requires browser automation infrastructure.',
+      'listFunnelAnalyses: the Bloomreach API does not provide a list endpoint for funnels. ' +
+        'Funnel analysis IDs must be obtained from the Bloomreach Engagement UI ' +
+        '(found in the URL when viewing a funnel, e.g. "606488856f8cf6f848b20af8").',
     );
   }
 
   async viewFunnelResults(input: ViewFunnelResultsInput): Promise<FunnelResults> {
     validateProject(input.project);
-    validateFunnelAnalysisId(input.analysisId);
+    const analysisId = validateFunnelAnalysisId(input.analysisId);
 
     if (input.startDate !== undefined || input.endDate !== undefined) {
       const dateRange: DateRangeFilter = {
@@ -234,9 +282,69 @@ export class BloomreachFunnelsService {
       validateDateRange(dateRange);
     }
 
-    throw new Error(
-      'viewFunnelResults: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewFunnelResults');
+    const path = buildDataPath(config, '/analyses/funnels');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        analysis_id: analysisId,
+        format: 'table_json',
+      },
+    });
+
+    const data = response as {
+      header?: string[];
+      rows?: unknown[][];
+      success?: boolean;
+      name?: string;
+    };
+    if (!data.success || !Array.isArray(data.rows)) {
+      throw new Error('viewFunnelResults: unexpected API response format.');
+    }
+
+    const header = Array.isArray(data.header) ? data.header : [];
+    const stepIdx = header.indexOf('step');
+    const eventIdx = header.indexOf('event_name');
+    const enteredIdx = header.indexOf('entered');
+    const completedIdx = header.indexOf('completed');
+    const conversionIdx = header.indexOf('conversion_rate');
+    const dropOffIdx = header.indexOf('drop_off_rate');
+
+    const steps: FunnelStepResult[] = data.rows.map((row, index) => {
+      const toNum = (idx: number): number => {
+        if (idx < 0 || idx >= row.length) return 0;
+        const val = row[idx];
+        return typeof val === 'number' ? val : 0;
+      };
+      const toStr = (idx: number): string => {
+        if (idx < 0 || idx >= row.length) return '';
+        const val = row[idx];
+        return val === null || val === undefined ? '' : String(val);
+      };
+
+      return {
+        step: stepIdx >= 0 ? toNum(stepIdx) : index + 1,
+        eventName: toStr(eventIdx),
+        entered: toNum(enteredIdx),
+        completed: toNum(completedIdx),
+        conversionRate: toNum(conversionIdx),
+        dropOffRate: toNum(dropOffIdx),
+      };
+    });
+
+    const overallConversionRate =
+      steps.length > 0 && steps[0].entered > 0
+        ? steps[steps.length - 1].completed / steps[0].entered
+        : 0;
+
+    return {
+      analysisId,
+      analysisName: data.name ?? analysisId,
+      startDate: input.startDate ?? '',
+      endDate: input.endDate ?? '',
+      steps,
+      overallConversionRate,
+    };
   }
 
   prepareCreateFunnelAnalysis(input: CreateFunnelAnalysisInput): PreparedFunnelAction {


### PR DESCRIPTION
## Summary

Wire the Funnels module to the Bloomreach REST API, matching the established Reports/Segmentations/Customers/Catalogs acid test pattern. Add comprehensive API-backed tests and CLI improvements.

**Closes #102**

## Changes

### Core (`packages/core/src/bloomreachFunnels.ts`)
- **API Config**: `BloomreachFunnelsService` now accepts optional `apiConfig` parameter (matching `BloomreachReportsService` pattern)
- **`viewFunnelResults`**: Now calls `POST /data/v2/projects/{token}/analyses/funnels` with `analysis_id` and `format: "table_json"`, parses header/rows response into `FunnelStepResult[]` with step metrics and overall conversion rate
- **`listFunnelAnalyses`**: Updated error message — the Bloomreach API has no list endpoint; IDs must come from the UI
- **`requireApiConfig()`**: New helper for credential validation
- **Action Executors**: Accept optional `apiConfig` (still stubs — create/clone/archive are UI-only operations)
- **Executor error messages**: Updated to clarify operations are "only available through the Bloomreach Engagement UI"

### Tests (`packages/core/src/__tests__/bloomreachFunnels.test.ts`)
- 12 new/updated tests covering:
  - API-backed `viewFunnelResults` (mock fetch — success with 3-step funnel, empty rows, error responses, null cells, missing name fallback, dateRange passthrough)
  - Missing API credentials error
  - Constructor with `apiConfig` parameter
  - Executor factory `apiConfig` acceptance
- Updated error message expectations for `listFunnelAnalyses` (now "does not provide a list endpoint")
- Total: **124 tests passing**

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- `view-results` now uses `tryResolveApiConfig()` for real API calls
- Better `--analysis-id` description (explains hex string format from UI URL)
- `list` command description notes API limitation
- Updated `--project` description for list command

## Quality Gates

| Gate | Status |
|------|--------|
| `npm run typecheck` | ✅ Pass (exit 0) |
| `npm run lint` | ✅ Pass |
| `npm test` | ✅ 72 files, 6416 tests pass |
| `npm run build` | ✅ Success |

## Acid Test Status

| Command | Status | Notes |
|---------|--------|-------|
| `funnels list` | ⚠️ No REST API | Clear error message directing users to UI |
| `funnels view-results` | ✅ API-backed | Uses `/analyses/funnels` endpoint |
| `funnels create` | ✅ Prepare works | Executor stub (UI-only operation) |
| `funnels clone` | ✅ Prepare works | Executor stub (UI-only operation) |
| `funnels archive` | ✅ Prepare works | Executor stub (UI-only operation) |
| JSON output | ✅ All commands | `--json` flag supported |
| Error handling | ✅ Comprehensive | Validation, missing config, API errors |
