### PR TITLE
feat #103: wire retentions module to Bloomreach REST API (acid test)

### DIFF
--- a/packages/core/src/__tests__/bloomreachRetentions.test.ts
+++ b/packages/core/src/__tests__/bloomreachRetentions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_RETENTION_ACTION_TYPE,
   CLONE_RETENTION_ACTION_TYPE,
@@ -15,6 +15,18 @@ import {
   createRetentionActionExecutors,
   BloomreachRetentionsService,
 } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_RETENTION_ACTION_TYPE', () => {
@@ -365,6 +377,18 @@ describe('createRetentionActionExecutors', () => {
       'not yet implemented',
     );
   });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createRetentionActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(3);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createRetentionActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
 });
 
 describe('BloomreachRetentionsService', () => {
@@ -396,12 +420,24 @@ describe('BloomreachRetentionsService', () => {
       const service = new BloomreachRetentionsService('org/project');
       expect(service.retentionsUrl).toBe('/p/org%2Fproject/analytics/retentions');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachRetentionsService);
+    });
+
+    it('exposes retentions URL when constructed with apiConfig', () => {
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      expect(service.retentionsUrl).toBe('/p/test/analytics/retentions');
+    });
   });
 
   describe('listRetentionAnalyses', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachRetentionsService('test');
-      await expect(service.listRetentionAnalyses()).rejects.toThrow('not yet implemented');
+      await expect(service.listRetentionAnalyses()).rejects.toThrow(
+        'does not provide a list endpoint',
+      );
     });
 
     it('validates project when input is provided', async () => {
@@ -418,92 +454,220 @@ describe('BloomreachRetentionsService', () => {
       );
     });
 
-    it('throws not-yet-implemented error for valid project override', async () => {
+    it('throws no-API-endpoint error for valid project override', async () => {
       const service = new BloomreachRetentionsService('test');
       await expect(
         service.listRetentionAnalyses({ project: 'kingdom-of-joakim' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide a list endpoint');
     });
 
-    it('throws not-yet-implemented error for trimmed project override', async () => {
+    it('throws no-API-endpoint error for trimmed project override', async () => {
       const service = new BloomreachRetentionsService('test');
       await expect(
         service.listRetentionAnalyses({ project: '  kingdom-of-joakim  ' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide a list endpoint');
     });
   });
 
   describe('viewRetentionResults', () => {
-    it('throws not-yet-implemented error with valid minimal input', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachRetentionsService('test');
       await expect(
         service.viewRetentionResults({ project: 'test', analysisId: 'retention-1' }),
-      ).rejects.toThrow('not yet implemented');
-    });
-
-    it('throws not-yet-implemented error with valid granularity', async () => {
-      const service = new BloomreachRetentionsService('test');
-      await expect(
-        service.viewRetentionResults({
-          project: 'test',
-          analysisId: 'retention-1',
-          granularity: 'daily',
-        }),
-      ).rejects.toThrow('not yet implemented');
-    });
-
-    it('throws not-yet-implemented error with valid date range', async () => {
-      const service = new BloomreachRetentionsService('test');
-      await expect(
-        service.viewRetentionResults({
-          project: 'test',
-          analysisId: 'retention-1',
-          startDate: '2025-01-01',
-          endDate: '2025-01-31',
-        }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('requires API credentials');
     });
 
     it('validates project input', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({ project: '', analysisId: 'retention-1' }),
       ).rejects.toThrow('must not be empty');
     });
 
     it('validates whitespace-only project input', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({ project: '   ', analysisId: 'retention-1' }),
       ).rejects.toThrow('must not be empty');
     });
 
     it('validates analysisId input', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({ project: 'test', analysisId: '   ' }),
       ).rejects.toThrow('Retention analysis ID must not be empty');
     });
 
     it('validates empty analysisId input', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({ project: 'test', analysisId: '' }),
       ).rejects.toThrow('Retention analysis ID must not be empty');
     });
 
-    it('accepts trimmed analysisId and reaches not-yet-implemented', async () => {
-      const service = new BloomreachRetentionsService('test');
-      await expect(
-        service.viewRetentionResults({
-          project: 'test',
-          analysisId: '  retention-99  ',
+    it('returns retention results from API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['cohort_date', 'cohort_size', 'period_0', 'period_1', 'period_2'],
+            rows: [
+              ['2024-01-01', 500, 1.0, 0.75, 0.6],
+              ['2024-01-08', 300, 1.0, 0.8, 0.65],
+            ],
+            success: true,
+            name: 'Weekly Retention',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      const result = await service.viewRetentionResults({
+        project: 'test',
+        analysisId: 'retention-1',
+      });
+
+      expect(result).toEqual({
+        analysisId: 'retention-1',
+        analysisName: 'Weekly Retention',
+        cohortEvent: '',
+        returnEvent: '',
+        granularity: 'daily',
+        startDate: '',
+        endDate: '',
+        cohorts: [
+          {
+            cohortDate: '2024-01-01',
+            cohortSize: 500,
+            retentionByPeriod: [1.0, 0.75, 0.6],
+          },
+          {
+            cohortDate: '2024-01-08',
+            cohortSize: 300,
+            retentionByPeriod: [1.0, 0.8, 0.65],
+          },
+        ],
+      });
+    });
+
+    it('handles empty rows in API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['cohort_date', 'cohort_size', 'period_0', 'period_1'],
+            rows: [],
+            success: true,
+            name: 'Empty Retention',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      const result = await service.viewRetentionResults({
+        project: 'test',
+        analysisId: 'retention-1',
+      });
+
+      expect(result.cohorts).toEqual([]);
+    });
+
+    it('throws on unsuccessful API response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ success: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
         }),
-      ).rejects.toThrow('not yet implemented');
+      );
+
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      await expect(
+        service.viewRetentionResults({ project: 'test', analysisId: 'retention-1' }),
+      ).rejects.toThrow('unexpected API response format');
+    });
+
+    it('handles null cell values in rows', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['cohort_date', 'cohort_size', 'period_0', 'period_1'],
+            rows: [
+              [null, null, null, null],
+              ['2024-01-08', 300, 1.0, 0.8],
+            ],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      const result = await service.viewRetentionResults({
+        project: 'test',
+        analysisId: 'retention-1',
+      });
+
+      expect(result.cohorts[0]).toEqual({
+        cohortDate: '',
+        cohortSize: 0,
+        retentionByPeriod: [0, 0],
+      });
+      expect(result.cohorts[1]).toEqual({
+        cohortDate: '2024-01-08',
+        cohortSize: 300,
+        retentionByPeriod: [1.0, 0.8],
+      });
+    });
+
+    it('uses analysisId as analysisName when name is missing', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['cohort_date', 'cohort_size', 'period_0'],
+            rows: [['2024-01-01', 100, 1.0]],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      const result = await service.viewRetentionResults({
+        project: 'test',
+        analysisId: 'retention-xyz',
+      });
+
+      expect(result.analysisName).toBe('retention-xyz');
+    });
+
+    it('includes date range from input in results', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            header: ['cohort_date', 'cohort_size', 'period_0'],
+            rows: [['2024-01-01', 100, 1.0]],
+            success: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
+      const result = await service.viewRetentionResults({
+        project: 'test',
+        analysisId: 'retention-1',
+        granularity: 'weekly',
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      expect(result.granularity).toBe('weekly');
+      expect(result.startDate).toBe('2024-01-01');
+      expect(result.endDate).toBe('2024-01-31');
     });
 
     it('validates granularity when provided', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({
           project: 'test',
@@ -514,7 +678,7 @@ describe('BloomreachRetentionsService', () => {
     });
 
     it('validates startDate format when date range is provided', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({
           project: 'test',
@@ -525,7 +689,7 @@ describe('BloomreachRetentionsService', () => {
     });
 
     it('validates endDate format when date range is provided', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({
           project: 'test',
@@ -536,7 +700,7 @@ describe('BloomreachRetentionsService', () => {
     });
 
     it('validates date ordering when both dates are provided', async () => {
-      const service = new BloomreachRetentionsService('test');
+      const service = new BloomreachRetentionsService('test', TEST_API_CONFIG);
       await expect(
         service.viewRetentionResults({
           project: 'test',

--- a/packages/core/src/bloomreachRetentions.ts
+++ b/packages/core/src/bloomreachRetentions.ts
@@ -1,6 +1,8 @@
 import { validateProject } from './bloomreachDashboards.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
 export const CREATE_RETENTION_ACTION_TYPE = 'retentions.create_retention';
 export const CLONE_RETENTION_ACTION_TYPE = 'retentions.clone_retention';
@@ -144,6 +146,19 @@ export function buildRetentionsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/analytics/retentions`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 export interface RetentionActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -151,56 +166,78 @@ export interface RetentionActionExecutor {
 
 class CreateRetentionExecutor implements RetentionActionExecutor {
   readonly actionType = CREATE_RETENTION_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateRetentionExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateRetentionExecutor: not yet implemented. ' +
+        'Retention creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CloneRetentionExecutor implements RetentionActionExecutor {
   readonly actionType = CLONE_RETENTION_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CloneRetentionExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CloneRetentionExecutor: not yet implemented. ' +
+        'Retention cloning is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ArchiveRetentionExecutor implements RetentionActionExecutor {
   readonly actionType = ARCHIVE_RETENTION_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ArchiveRetentionExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ArchiveRetentionExecutor: not yet implemented. ' +
+        'Retention archiving is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createRetentionActionExecutors(): Record<
-  string,
-  RetentionActionExecutor
-> {
+export function createRetentionActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, RetentionActionExecutor> {
   return {
-    [CREATE_RETENTION_ACTION_TYPE]: new CreateRetentionExecutor(),
-    [CLONE_RETENTION_ACTION_TYPE]: new CloneRetentionExecutor(),
-    [ARCHIVE_RETENTION_ACTION_TYPE]: new ArchiveRetentionExecutor(),
+    [CREATE_RETENTION_ACTION_TYPE]: new CreateRetentionExecutor(apiConfig),
+    [CLONE_RETENTION_ACTION_TYPE]: new CloneRetentionExecutor(apiConfig),
+    [ARCHIVE_RETENTION_ACTION_TYPE]: new ArchiveRetentionExecutor(apiConfig),
   };
 }
 
 export class BloomreachRetentionsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildRetentionsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get retentionsUrl(): string {
@@ -215,7 +252,9 @@ export class BloomreachRetentionsService {
     }
 
     throw new Error(
-      'listRetentionAnalyses: not yet implemented. Requires browser automation infrastructure.',
+      'listRetentionAnalyses: the Bloomreach API does not provide a list endpoint for retentions. ' +
+        'Retention analysis IDs must be obtained from the Bloomreach Engagement UI ' +
+        '(found in the URL when viewing a retention analysis, e.g. "606488856f8cf6f848b20af8").',
     );
   }
 
@@ -223,7 +262,7 @@ export class BloomreachRetentionsService {
     input: ViewRetentionResultsInput,
   ): Promise<RetentionResults> {
     validateProject(input.project);
-    validateRetentionAnalysisId(input.analysisId);
+    const analysisId = validateRetentionAnalysisId(input.analysisId);
 
     if (input.granularity !== undefined) {
       validateRetentionGranularity(input.granularity);
@@ -237,9 +276,66 @@ export class BloomreachRetentionsService {
       validateDateRange(dateRange);
     }
 
-    throw new Error(
-      'viewRetentionResults: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewRetentionResults');
+    const path = buildDataPath(config, '/analyses/retentions');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        analysis_id: analysisId,
+        format: 'table_json',
+      },
+    });
+
+    const data = response as {
+      header?: string[];
+      rows?: unknown[][];
+      success?: boolean;
+      name?: string;
+    };
+    if (!data.success || !Array.isArray(data.rows)) {
+      throw new Error('viewRetentionResults: unexpected API response format.');
+    }
+
+    const header = Array.isArray(data.header) ? data.header : [];
+    const cohortDateIdx = header.indexOf('cohort_date');
+    const cohortSizeIdx = header.indexOf('cohort_size');
+
+    const periodIndices: number[] = [];
+    for (let i = 0; i < header.length; i++) {
+      if (i !== cohortDateIdx && i !== cohortSizeIdx) {
+        periodIndices.push(i);
+      }
+    }
+
+    const cohorts: RetentionCohortRow[] = data.rows.map((row) => {
+      const toNum = (idx: number): number => {
+        if (idx < 0 || idx >= row.length) return 0;
+        const val = row[idx];
+        return typeof val === 'number' ? val : 0;
+      };
+      const toStr = (idx: number): string => {
+        if (idx < 0 || idx >= row.length) return '';
+        const val = row[idx];
+        return val === null || val === undefined ? '' : String(val);
+      };
+
+      return {
+        cohortDate: toStr(cohortDateIdx),
+        cohortSize: toNum(cohortSizeIdx),
+        retentionByPeriod: periodIndices.map((idx) => toNum(idx)),
+      };
+    });
+
+    return {
+      analysisId,
+      analysisName: data.name ?? analysisId,
+      cohortEvent: '',
+      returnEvent: '',
+      granularity: (input.granularity as RetentionGranularity) ?? 'daily',
+      startDate: input.startDate ?? '',
+      endDate: input.endDate ?? '',
+      cohorts,
+    };
   }
 
   prepareCreateRetentionAnalysis(


### PR DESCRIPTION
## Summary

Wire the retentions module to the Bloomreach REST API, following the exact pattern established by funnels (#102), reports (#101), segmentations (#100), catalogs (#99), and customers (#98) acid tests.

## Changes

### `packages/core/src/bloomreachRetentions.ts`
- Added `BloomreachApiConfig` imports and `requireApiConfig()` helper
- Updated `BloomreachRetentionsService` constructor to accept optional `apiConfig` parameter
- **Implemented `viewRetentionResults()`** — real API call to `POST /analyses/retentions` with response parsing into `RetentionCohortRow[]`
- Updated `listRetentionAnalyses()` error message to explain there's no list API endpoint (matching funnels pattern)
- Updated all 3 executor classes (Create/Clone/Archive) to accept `apiConfig` with improved error messages
- Updated `createRetentionActionExecutors()` to accept `apiConfig`

### `packages/core/src/__tests__/bloomreachRetentions.test.ts`
- Added `vi`/`afterEach` imports and `TEST_API_CONFIG` constant for fetch mocking
- Added constructor tests for `apiConfig` parameter
- Updated `listRetentionAnalyses` test expectations for new "no list endpoint" message
- Added full `viewRetentionResults` API tests: credential validation, successful response parsing, empty rows, unsuccessful responses, null cell handling, missing name fallback, date range propagation
- Added executor `apiConfig` parameter tests

## Quality Gates
- ✅ Tests: 6430 passed (72 test files)
- ✅ Lint: Clean
- ✅ Typecheck: Clean
- ✅ Build: Clean

Closes #103
