### PR TITLE
feat #104: acid test scenarios module

### DIFF
--- a/packages/core/src/__tests__/bloomreachScenarios.test.ts
+++ b/packages/core/src/__tests__/bloomreachScenarios.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_SCENARIO_ACTION_TYPE,
   START_SCENARIO_ACTION_TYPE,
@@ -16,6 +16,18 @@ import {
   createScenarioActionExecutors,
   BloomreachScenariosService,
 } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_SCENARIO_ACTION_TYPE', () => {
@@ -68,13 +80,29 @@ describe('validateScenarioName', () => {
     expect(validateScenarioName('  My Scenario  ')).toBe('My Scenario');
   });
 
+  it('returns trimmed name with tabs and newlines', () => {
+    expect(validateScenarioName('\n\tMy Scenario\t\n')).toBe('My Scenario');
+  });
+
   it('accepts single-character name', () => {
     expect(validateScenarioName('A')).toBe('A');
+  });
+
+  it('accepts numeric name', () => {
+    expect(validateScenarioName('123')).toBe('123');
+  });
+
+  it('accepts name with punctuation', () => {
+    expect(validateScenarioName('Scenario: Welcome v2')).toBe('Scenario: Welcome v2');
   });
 
   it('accepts name at maximum length', () => {
     const name = 'x'.repeat(200);
     expect(validateScenarioName(name)).toBe(name);
+  });
+
+  it('accepts mixed whitespace around valid name', () => {
+    expect(validateScenarioName(' \t  Welcome Flow \n ')).toBe('Welcome Flow');
   });
 
   it('throws for empty string', () => {
@@ -83,6 +111,14 @@ describe('validateScenarioName', () => {
 
   it('throws for whitespace-only string', () => {
     expect(() => validateScenarioName('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateScenarioName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateScenarioName('\n\n')).toThrow('must not be empty');
   });
 
   it('throws for name exceeding maximum length', () => {
@@ -115,6 +151,14 @@ describe('validateScenarioStatus', () => {
   it('throws for empty status', () => {
     expect(() => validateScenarioStatus('')).toThrow('status must be one of');
   });
+
+  it('throws for incorrect casing', () => {
+    expect(() => validateScenarioStatus('Active')).toThrow('status must be one of');
+  });
+
+  it('throws for value with trailing space', () => {
+    expect(() => validateScenarioStatus('active ')).toThrow('status must be one of');
+  });
 });
 
 describe('validateScenarioId', () => {
@@ -133,6 +177,22 @@ describe('validateScenarioId', () => {
   it('returns same value when already trimmed', () => {
     expect(validateScenarioId('scenario-456')).toBe('scenario-456');
   });
+
+  it('returns ID containing slashes', () => {
+    expect(validateScenarioId('scenario/group/a')).toBe('scenario/group/a');
+  });
+
+  it('returns ID containing dots and dashes', () => {
+    expect(validateScenarioId('scenario.v2-alpha')).toBe('scenario.v2-alpha');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateScenarioId('\n')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateScenarioId('\t')).toThrow('must not be empty');
+  });
 });
 
 describe('buildScenariosUrl', () => {
@@ -148,6 +208,20 @@ describe('buildScenariosUrl', () => {
 
   it('encodes slashes in project name', () => {
     expect(buildScenariosUrl('org/project')).toBe('/p/org%2Fproject/campaigns/campaign-designs');
+  });
+
+  it('encodes unicode characters in project name', () => {
+    expect(buildScenariosUrl('projekt åäö')).toBe(
+      '/p/projekt%20%C3%A5%C3%A4%C3%B6/campaigns/campaign-designs',
+    );
+  });
+
+  it('encodes hash character in project name', () => {
+    expect(buildScenariosUrl('my#project')).toBe('/p/my%23project/campaigns/campaign-designs');
+  });
+
+  it('keeps dashes unencoded in project name', () => {
+    expect(buildScenariosUrl('team-alpha')).toBe('/p/team-alpha/campaigns/campaign-designs');
   });
 });
 
@@ -169,8 +243,48 @@ describe('createScenarioActionExecutors', () => {
     }
   });
 
-  it('executors throw "not yet implemented" on execute', async () => {
+  it('create executor throws "not yet implemented" on execute', async () => {
     const executors = createScenarioActionExecutors();
+    await expect(executors[CREATE_SCENARIO_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('start executor throws "not yet implemented" on execute', async () => {
+    const executors = createScenarioActionExecutors();
+    await expect(executors[START_SCENARIO_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('stop executor throws "not yet implemented" on execute', async () => {
+    const executors = createScenarioActionExecutors();
+    await expect(executors[STOP_SCENARIO_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('clone executor throws "not yet implemented" on execute', async () => {
+    const executors = createScenarioActionExecutors();
+    await expect(executors[CLONE_SCENARIO_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('archive executor throws "not yet implemented" on execute', async () => {
+    const executors = createScenarioActionExecutors();
+    await expect(executors[ARCHIVE_SCENARIO_ACTION_TYPE].execute({})).rejects.toThrow(
+      'not yet implemented',
+    );
+  });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createScenarioActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(5);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createScenarioActionExecutors(TEST_API_CONFIG);
     for (const executor of Object.values(executors)) {
       await expect(executor.execute({})).rejects.toThrow('not yet implemented');
     }
@@ -197,12 +311,31 @@ describe('BloomreachScenariosService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachScenariosService('')).toThrow('must not be empty');
     });
+
+    it('throws for whitespace-only project', () => {
+      expect(() => new BloomreachScenariosService('   ')).toThrow('must not be empty');
+    });
+
+    it('encodes slashes in constructor project URL', () => {
+      const service = new BloomreachScenariosService('org/project');
+      expect(service.scenariosUrl).toBe('/p/org%2Fproject/campaigns/campaign-designs');
+    });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachScenariosService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachScenariosService);
+    });
+
+    it('exposes scenarios URL when constructed with apiConfig', () => {
+      const service = new BloomreachScenariosService('test', TEST_API_CONFIG);
+      expect(service.scenariosUrl).toBe('/p/test/campaigns/campaign-designs');
+    });
   });
 
   describe('listScenarios', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachScenariosService('test');
-      await expect(service.listScenarios()).rejects.toThrow('not yet implemented');
+      await expect(service.listScenarios()).rejects.toThrow('does not provide an endpoint');
     });
 
     it('validates status when provided', async () => {
@@ -218,14 +351,28 @@ describe('BloomreachScenariosService', () => {
         'must not be empty',
       );
     });
+
+    it('throws no-API-endpoint error for valid project override', async () => {
+      const service = new BloomreachScenariosService('test');
+      await expect(service.listScenarios({ project: 'kingdom-of-joakim' })).rejects.toThrow(
+        'does not provide an endpoint',
+      );
+    });
+
+    it('throws no-API-endpoint error for trimmed project override', async () => {
+      const service = new BloomreachScenariosService('test');
+      await expect(service.listScenarios({ project: '  kingdom-of-joakim  ' })).rejects.toThrow(
+        'does not provide an endpoint',
+      );
+    });
   });
 
   describe('viewScenario', () => {
-    it('throws not-yet-implemented error with valid input', async () => {
+    it('throws no-API-endpoint error with valid input', async () => {
       const service = new BloomreachScenariosService('test');
       await expect(
         service.viewScenario({ project: 'test', scenarioId: 'scenario-1' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide an endpoint');
     });
 
     it('validates project input', async () => {
@@ -240,6 +387,13 @@ describe('BloomreachScenariosService', () => {
       await expect(service.viewScenario({ project: 'test', scenarioId: '   ' })).rejects.toThrow(
         'Scenario ID must not be empty',
       );
+    });
+
+    it('throws no-API-endpoint error with trimmed inputs', async () => {
+      const service = new BloomreachScenariosService('test');
+      await expect(
+        service.viewScenario({ project: '  test  ', scenarioId: '  scenario-1  ' }),
+      ).rejects.toThrow('does not provide an endpoint');
     });
   });
 
@@ -305,10 +459,39 @@ describe('BloomreachScenariosService', () => {
       );
     });
 
+    it('throws for whitespace-only name', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() => service.prepareCreateScenario({ project: 'test', name: '   ' })).toThrow(
+        'must not be empty',
+      );
+    });
+
     it('throws for empty project', () => {
       const service = new BloomreachScenariosService('test');
       expect(() => service.prepareCreateScenario({ project: '', name: 'Scenario' })).toThrow(
         'must not be empty',
+      );
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() => service.prepareCreateScenario({ project: '   ', name: 'Scenario' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('trims project and name in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareCreateScenario({
+        project: '  my-project  ',
+        name: '  My Scenario  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+          name: 'My Scenario',
+        }),
       );
     });
 
@@ -320,6 +503,21 @@ describe('BloomreachScenariosService', () => {
           name: 'x'.repeat(201),
         }),
       ).toThrow('must not exceed 200 characters');
+    });
+
+    it('accepts max-length name and still prepares action', () => {
+      const service = new BloomreachScenariosService('test');
+      const maxName = 'x'.repeat(200);
+      const result = service.prepareCreateScenario({
+        project: 'test',
+        name: maxName,
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: maxName,
+        }),
+      );
     });
   });
 
@@ -362,11 +560,39 @@ describe('BloomreachScenariosService', () => {
       );
     });
 
+    it('throws for whitespace-only scenarioId', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() => service.prepareStartScenario({ project: 'test', scenarioId: '   ' })).toThrow(
+        'must not be empty',
+      );
+    });
+
     it('throws for empty project', () => {
       const service = new BloomreachScenariosService('test');
       expect(() =>
         service.prepareStartScenario({ project: '', scenarioId: 'scenario-123' }),
       ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() =>
+        service.prepareStartScenario({ project: '   ', scenarioId: 'scenario-123' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('trims scenarioId in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareStartScenario({
+        project: 'test',
+        scenarioId: '  scenario-123  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          scenarioId: 'scenario-123',
+        }),
+      );
     });
   });
 
@@ -409,11 +635,39 @@ describe('BloomreachScenariosService', () => {
       );
     });
 
+    it('throws for whitespace-only scenarioId', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() => service.prepareStopScenario({ project: 'test', scenarioId: '   ' })).toThrow(
+        'must not be empty',
+      );
+    });
+
     it('throws for empty project', () => {
       const service = new BloomreachScenariosService('test');
       expect(() =>
         service.prepareStopScenario({ project: '', scenarioId: 'scenario-456' }),
       ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() =>
+        service.prepareStopScenario({ project: '   ', scenarioId: 'scenario-456' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('trims scenarioId in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareStopScenario({
+        project: 'test',
+        scenarioId: '  scenario-456  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          scenarioId: 'scenario-456',
+        }),
+      );
     });
   });
 
@@ -447,9 +701,29 @@ describe('BloomreachScenariosService', () => {
       expect(result.preview).toEqual(expect.objectContaining({ newName: 'Cloned Scenario' }));
     });
 
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareCloneScenario({
+        project: 'test',
+        scenarioId: 'scenario-789',
+        operatorNote: 'Clone for campaign variant',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ operatorNote: 'Clone for campaign variant' }),
+      );
+    });
+
     it('throws for empty scenarioId', () => {
       const service = new BloomreachScenariosService('test');
       expect(() => service.prepareCloneScenario({ project: 'test', scenarioId: '' })).toThrow(
+        'must not be empty',
+      );
+    });
+
+    it('throws for whitespace-only scenarioId', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() => service.prepareCloneScenario({ project: 'test', scenarioId: '   ' })).toThrow(
         'must not be empty',
       );
     });
@@ -458,6 +732,13 @@ describe('BloomreachScenariosService', () => {
       const service = new BloomreachScenariosService('test');
       expect(() =>
         service.prepareCloneScenario({ project: '', scenarioId: 'scenario-789' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() =>
+        service.prepareCloneScenario({ project: '   ', scenarioId: 'scenario-789' }),
       ).toThrow('must not be empty');
     });
 
@@ -470,6 +751,61 @@ describe('BloomreachScenariosService', () => {
           newName: '   ',
         }),
       ).toThrow('must not be empty');
+    });
+
+    it('throws when newName exceeds maximum length', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() =>
+        service.prepareCloneScenario({
+          project: 'test',
+          scenarioId: 'scenario-789',
+          newName: 'x'.repeat(201),
+        }),
+      ).toThrow('must not exceed 200 characters');
+    });
+
+    it('accepts max-length newName', () => {
+      const service = new BloomreachScenariosService('test');
+      const newName = 'x'.repeat(200);
+      const result = service.prepareCloneScenario({
+        project: 'test',
+        scenarioId: 'scenario-789',
+        newName,
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          newName,
+        }),
+      );
+    });
+
+    it('trims scenarioId in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareCloneScenario({
+        project: 'test',
+        scenarioId: '  scenario-789  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          scenarioId: 'scenario-789',
+        }),
+      );
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareCloneScenario({
+        project: '  my-project  ',
+        scenarioId: 'scenario-789',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+        }),
+      );
     });
   });
 
@@ -512,11 +848,79 @@ describe('BloomreachScenariosService', () => {
       );
     });
 
+    it('throws for whitespace-only scenarioId', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() => service.prepareArchiveScenario({ project: 'test', scenarioId: '   ' })).toThrow(
+        'must not be empty',
+      );
+    });
+
     it('throws for empty project', () => {
       const service = new BloomreachScenariosService('test');
       expect(() =>
         service.prepareArchiveScenario({ project: '', scenarioId: 'scenario-900' }),
       ).toThrow('must not be empty');
+    });
+
+    it('throws for whitespace-only project', () => {
+      const service = new BloomreachScenariosService('test');
+      expect(() =>
+        service.prepareArchiveScenario({ project: '   ', scenarioId: 'scenario-900' }),
+      ).toThrow('must not be empty');
+    });
+
+    it('accepts trimmed scenarioId and reaches prepared state', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareArchiveScenario({
+        project: 'test',
+        scenarioId: '  scenario-900  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          scenarioId: 'scenario-900',
+        }),
+      );
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareArchiveScenario({
+        project: '  my-project  ',
+        scenarioId: 'scenario-900',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+        }),
+      );
+    });
+
+    it('keeps slash-containing scenarioId after trim', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareArchiveScenario({
+        project: 'test',
+        scenarioId: '  scenario/group/a  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          scenarioId: 'scenario/group/a',
+        }),
+      );
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachScenariosService('test');
+      const result = service.prepareArchiveScenario({
+        project: 'test',
+        scenarioId: 'scenario-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
     });
   });
 });

--- a/packages/core/src/bloomreachScenarios.ts
+++ b/packages/core/src/bloomreachScenarios.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SCENARIO_ACTION_TYPE = 'scenarios.create_scenario';
 export const START_SCENARIO_ACTION_TYPE = 'scenarios.start_scenario';
@@ -129,6 +130,21 @@ export function buildScenariosUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/campaigns/campaign-designs`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
+void requireApiConfig;
+
 export interface ScenarioActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -136,69 +152,108 @@ export interface ScenarioActionExecutor {
 
 class CreateScenarioExecutor implements ScenarioActionExecutor {
   readonly actionType = CREATE_SCENARIO_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateScenarioExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateScenarioExecutor: not yet implemented. ' +
+        'Scenario creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class StartScenarioExecutor implements ScenarioActionExecutor {
   readonly actionType = START_SCENARIO_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'StartScenarioExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'StartScenarioExecutor: not yet implemented. ' +
+        'Starting scenarios is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class StopScenarioExecutor implements ScenarioActionExecutor {
   readonly actionType = STOP_SCENARIO_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'StopScenarioExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'StopScenarioExecutor: not yet implemented. ' +
+        'Stopping scenarios is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CloneScenarioExecutor implements ScenarioActionExecutor {
   readonly actionType = CLONE_SCENARIO_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CloneScenarioExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CloneScenarioExecutor: not yet implemented. ' +
+        'Scenario cloning is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ArchiveScenarioExecutor implements ScenarioActionExecutor {
   readonly actionType = ARCHIVE_SCENARIO_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ArchiveScenarioExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ArchiveScenarioExecutor: not yet implemented. ' +
+        'Scenario archiving is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createScenarioActionExecutors(): Record<string, ScenarioActionExecutor> {
+export function createScenarioActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, ScenarioActionExecutor> {
   return {
-    [CREATE_SCENARIO_ACTION_TYPE]: new CreateScenarioExecutor(),
-    [START_SCENARIO_ACTION_TYPE]: new StartScenarioExecutor(),
-    [STOP_SCENARIO_ACTION_TYPE]: new StopScenarioExecutor(),
-    [CLONE_SCENARIO_ACTION_TYPE]: new CloneScenarioExecutor(),
-    [ARCHIVE_SCENARIO_ACTION_TYPE]: new ArchiveScenarioExecutor(),
+    [CREATE_SCENARIO_ACTION_TYPE]: new CreateScenarioExecutor(apiConfig),
+    [START_SCENARIO_ACTION_TYPE]: new StartScenarioExecutor(apiConfig),
+    [STOP_SCENARIO_ACTION_TYPE]: new StopScenarioExecutor(apiConfig),
+    [CLONE_SCENARIO_ACTION_TYPE]: new CloneScenarioExecutor(apiConfig),
+    [ARCHIVE_SCENARIO_ACTION_TYPE]: new ArchiveScenarioExecutor(apiConfig),
   };
 }
 
 export class BloomreachScenariosService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildScenariosUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get scenariosUrl(): string {
@@ -206,6 +261,7 @@ export class BloomreachScenariosService {
   }
 
   async listScenarios(input?: ListScenariosInput): Promise<BloomreachScenario[]> {
+    void this.apiConfig;
     if (input !== undefined) {
       validateProject(input.project);
       if (input.status !== undefined) {
@@ -214,16 +270,21 @@ export class BloomreachScenariosService {
     }
 
     throw new Error(
-      'listScenarios: not yet implemented. Requires browser automation infrastructure.',
+      'listScenarios: the Bloomreach API does not provide an endpoint for scenarios. ' +
+        'Scenario data must be obtained from the Bloomreach Engagement UI ' +
+        '(navigate to Campaigns > Scenarios in your project).',
     );
   }
 
   async viewScenario(input: ViewScenarioInput): Promise<ScenarioDetails> {
+    void this.apiConfig;
     validateProject(input.project);
     validateScenarioId(input.scenarioId);
 
     throw new Error(
-      'viewScenario: not yet implemented. Requires browser automation infrastructure.',
+      'viewScenario: the Bloomreach API does not provide an endpoint for scenario details. ' +
+        'Scenario details must be viewed in the Bloomreach Engagement UI ' +
+        '(navigate to Campaigns > Scenarios and open the scenario).',
     );
   }
 


### PR DESCRIPTION
## Summary

Acid test for the Bloomreach Scenarios module (#104). Wires `BloomreachApiConfig` throughout the module for pattern consistency with other acid-tested modules (funnels #102, retentions #103), updates error messages from generic "not yet implemented" stubs to descriptive UI-only guidance, and expands test coverage from ~60 to 117 tests.

## Changes

### Core Module (`bloomreachScenarios.ts`)
- Added `BloomreachApiConfig` type import and `requireApiConfig` helper (for pattern consistency)
- Updated all 5 executor classes (Create, Start, Stop, Clone, Archive) to accept optional `apiConfig` parameter with `void this.apiConfig` pattern
- Updated executor error messages to explain UI-only availability (e.g., "Scenario creation is only available through the Bloomreach Engagement UI")
- Updated `createScenarioActionExecutors` factory to pass `apiConfig` to executors
- Updated `BloomreachScenariosService` constructor to accept optional `apiConfig`
- Updated `listScenarios` error: "the Bloomreach API does not provide an endpoint for scenarios"
- Updated `viewScenario` error: "the Bloomreach API does not provide an endpoint for scenario details"

### Tests (`bloomreachScenarios.test.ts`)
- Expanded from ~522 lines / ~60 tests to 926 lines / 117 tests
- Added `BloomreachApiConfig` test fixture and `vi.restoreAllMocks()` teardown
- Added apiConfig acceptance tests for constructor and executor factory
- Expanded validation edge cases: tab-only, newline-only, unicode, slashes, max-length
- Updated error message assertions to match new descriptive messages
- Added trimming verification tests for all prepare* methods
- Added token prefix verification tests

### Key Decision: UI-Only Module
Scenarios has **no Bloomreach REST API** — all operations are UI-only. Unlike funnels/retentions (which wire `viewResults` to the API), both `listScenarios` and `viewScenario` retain descriptive thrown errors explaining how to access scenario data via the UI. The `apiConfig` wiring is included for pattern consistency and future extensibility.

## Quality Gates
- ✅ `tsc --build` — clean
- ✅ `eslint` — clean
- ✅ `vitest run` — 6532/6532 tests pass (72 files), 0 regressions
- ✅ `npm run build` — success

Closes #104
