### PR TITLE
feat #111: acid test SQL reports module

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -9566,9 +9566,11 @@ const sqlReports = program
 
 sqlReports
   .command('list')
-  .description('List all SQL reports in the project')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .option('--status <status>', 'Filter by status (saved, running, completed, failed, archived)')
+  .description(
+    'List all SQL reports in the project (note: the Bloomreach API does not provide a SQL reports endpoint — requires browser automation)',
+  )
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .option('--status <status>', 'Filter by report status: saved, running, completed, failed, archived')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; status?: string; json?: boolean }) => {
     try {
@@ -9603,9 +9605,11 @@ sqlReports
 
 sqlReports
   .command('view')
-  .description('View details of a specific SQL report')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'SQL report ID')
+  .description(
+    'View details of a specific SQL report (note: the Bloomreach API does not provide a SQL reports endpoint — requires browser automation)',
+  )
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .requiredOption('--report-id <id>', 'SQL report ID (identifier from Bloomreach UI URL)')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; reportId: string; json?: boolean }) => {
     try {
@@ -9632,11 +9636,14 @@ sqlReports
 
 sqlReports
   .command('create')
-  .description('Prepare creation of a new SQL report (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--name <name>', 'Report name')
-  .requiredOption('--query <sql>', 'SQL query string')
-  .option('--parameters <json>', 'JSON object of query parameters')
+  .description('Prepare creation of a new SQL report (two-phase commit, UI-only)')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .requiredOption('--name <name>', 'Report name (max 200 characters)')
+  .requiredOption('--query <sql>', 'SQL query string (e.g. "SELECT customer_id, email FROM customers LIMIT 100")')
+  .option(
+    '--parameters <json>',
+    'Query parameters as JSON (e.g. \'{"start_date":"2026-01-01","end_date":"2026-01-31"}\')',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -9682,10 +9689,16 @@ sqlReports
 
 sqlReports
   .command('execute')
-  .description('Prepare execution of a SQL report (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'SQL report ID')
-  .option('--parameters <json>', 'JSON object of query parameters')
+  .description('Prepare execution of a SQL report (two-phase commit, UI-only)')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .requiredOption(
+    '--report-id <id>',
+    'SQL report ID to execute (identifier from Bloomreach UI URL)',
+  )
+  .option(
+    '--parameters <json>',
+    'Query parameters as JSON (e.g. \'{"start_date":"2026-01-01","end_date":"2026-01-31"}\')',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -9729,10 +9742,13 @@ sqlReports
 
 sqlReports
   .command('export-results')
-  .description('Prepare export of SQL report results (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'SQL report ID')
-  .option('--format <format>', 'Export format (json, csv)', 'json')
+  .description('Prepare export of SQL report results (two-phase commit, UI-only)')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .requiredOption(
+    '--report-id <id>',
+    'SQL report ID whose results to export (identifier from Bloomreach UI URL)',
+  )
+  .option('--format <format>', 'Export format: json or csv (default: json)', 'json')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -9773,9 +9789,9 @@ sqlReports
 
 sqlReports
   .command('clone')
-  .description('Prepare cloning a SQL report (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'SQL report ID to clone')
+  .description('Prepare cloning a SQL report (two-phase commit, UI-only)')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .requiredOption('--report-id <id>', 'SQL report ID to clone (identifier from Bloomreach UI URL)')
   .option('--new-name <name>', 'Name for the cloned report')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
@@ -9817,9 +9833,9 @@ sqlReports
 
 sqlReports
   .command('archive')
-  .description('Prepare archiving a SQL report (two-phase commit)')
-  .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--report-id <id>', 'SQL report ID')
+  .description('Prepare archiving a SQL report (two-phase commit, UI-only)')
+  .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
+  .requiredOption('--report-id <id>', 'SQL report ID (identifier from Bloomreach UI URL)')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; reportId: string; note?: string; json?: boolean }) => {

--- a/packages/core/src/__tests__/bloomreachSqlReports.test.ts
+++ b/packages/core/src/__tests__/bloomreachSqlReports.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
 import {
   CREATE_SQL_REPORT_ACTION_TYPE,
   EXECUTE_SQL_REPORT_ACTION_TYPE,
@@ -20,6 +21,17 @@ import {
   createSqlReportActionExecutors,
   BloomreachSqlReportsService,
 } from '../index.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_SQL_REPORT_ACTION_TYPE', () => {
@@ -107,6 +119,24 @@ describe('validateSqlReportName', () => {
     const name = 'x'.repeat(201);
     expect(() => validateSqlReportName(name)).toThrow('must not exceed 200 characters');
   });
+
+  it('accepts mixed whitespace around valid name', () => {
+    expect(validateSqlReportName(' \t  Monthly Report \n ')).toBe('Monthly Report');
+  });
+
+  it('preserves internal spacing in valid name', () => {
+    expect(validateSqlReportName('Monthly   Report')).toBe('Monthly   Report');
+  });
+
+  it('accepts punctuation-heavy name after trim', () => {
+    expect(validateSqlReportName('  [Q1] Revenue Report (v2)  ')).toBe('[Q1] Revenue Report (v2)');
+  });
+
+  it('throws for too-long name even with surrounding whitespace', () => {
+    expect(() => validateSqlReportName(`  ${'x'.repeat(201)}  `)).toThrow(
+      'must not exceed 200 characters',
+    );
+  });
 });
 
 describe('validateSqlReportId', () => {
@@ -124,6 +154,30 @@ describe('validateSqlReportId', () => {
 
   it('returns same value when already trimmed', () => {
     expect(validateSqlReportId('report-456')).toBe('report-456');
+  });
+
+  it('returns ID containing dots and dashes', () => {
+    expect(validateSqlReportId('report.v2-alpha')).toBe('report.v2-alpha');
+  });
+
+  it('returns ID containing colons', () => {
+    expect(validateSqlReportId('report:daily:1')).toBe('report:daily:1');
+  });
+
+  it('returns trimmed ID with mixed whitespace', () => {
+    expect(validateSqlReportId(' \n\treport-789\t ')).toBe('report-789');
+  });
+
+  it('returns unicode ID', () => {
+    expect(validateSqlReportId('rapport-åäö')).toBe('rapport-åäö');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateSqlReportId('\t')).toThrow('must not be empty');
+  });
+
+  it('throws for mixed-whitespace-only string', () => {
+    expect(() => validateSqlReportId(' \n\t ')).toThrow('must not be empty');
   });
 });
 
@@ -152,6 +206,22 @@ describe('validateSqlQuery', () => {
   it('throws for query exceeding maximum length', () => {
     const query = 'x'.repeat(10001);
     expect(() => validateSqlQuery(query)).toThrow('must not exceed 10000 characters');
+  });
+
+  it('accepts mixed whitespace around valid query', () => {
+    expect(validateSqlQuery(' \t  SELECT * FROM users \n ')).toBe('SELECT * FROM users');
+  });
+
+  it('preserves internal whitespace in query', () => {
+    expect(validateSqlQuery('SELECT *\n  FROM users\n  WHERE id = 1')).toBe(
+      'SELECT *\n  FROM users\n  WHERE id = 1',
+    );
+  });
+
+  it('throws for too-long query even with surrounding whitespace', () => {
+    expect(() => validateSqlQuery(`  ${'x'.repeat(10001)}  `)).toThrow(
+      'must not exceed 10000 characters',
+    );
   });
 });
 
@@ -241,6 +311,123 @@ describe('createSqlReportActionExecutors', () => {
       await expect(executor.execute({})).rejects.toThrow('not yet implemented');
     }
   });
+
+  it('create executor mentions UI-only in error', async () => {
+    const executors = createSqlReportActionExecutors();
+    await expect(executors[CREATE_SQL_REPORT_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('execute executor mentions UI-only in error', async () => {
+    const executors = createSqlReportActionExecutors();
+    await expect(executors[EXECUTE_SQL_REPORT_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('export executor mentions UI-only in error', async () => {
+    const executors = createSqlReportActionExecutors();
+    await expect(executors[EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('clone executor mentions UI-only in error', async () => {
+    const executors = createSqlReportActionExecutors();
+    await expect(executors[CLONE_SQL_REPORT_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('archive executor mentions UI-only in error', async () => {
+    const executors = createSqlReportActionExecutors();
+    await expect(executors[ARCHIVE_SQL_REPORT_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createSqlReportActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(5);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createSqlReportActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+
+  it('returns identical action keys with or without apiConfig', () => {
+    const withoutConfig = Object.keys(createSqlReportActionExecutors()).sort();
+    const withConfig = Object.keys(createSqlReportActionExecutors(TEST_API_CONFIG)).sort();
+    expect(withConfig).toEqual(withoutConfig);
+  });
+
+  it('preserves actionType mapping with apiConfig', () => {
+    const executors = createSqlReportActionExecutors(TEST_API_CONFIG);
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
+
+  it('returns expected action keys', () => {
+    const keys = Object.keys(createSqlReportActionExecutors()).sort();
+    expect(keys).toEqual(
+      [
+        ARCHIVE_SQL_REPORT_ACTION_TYPE,
+        CLONE_SQL_REPORT_ACTION_TYPE,
+        CREATE_SQL_REPORT_ACTION_TYPE,
+        EXECUTE_SQL_REPORT_ACTION_TYPE,
+        EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE,
+      ].sort(),
+    );
+  });
+
+  it('returns new executor instances on each call', () => {
+    const first = createSqlReportActionExecutors(TEST_API_CONFIG);
+    const second = createSqlReportActionExecutors(TEST_API_CONFIG);
+    expect(first[CREATE_SQL_REPORT_ACTION_TYPE]).not.toBe(second[CREATE_SQL_REPORT_ACTION_TYPE]);
+    expect(first[EXECUTE_SQL_REPORT_ACTION_TYPE]).not.toBe(second[EXECUTE_SQL_REPORT_ACTION_TYPE]);
+    expect(first[EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE]).not.toBe(
+      second[EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE],
+    );
+    expect(first[CLONE_SQL_REPORT_ACTION_TYPE]).not.toBe(second[CLONE_SQL_REPORT_ACTION_TYPE]);
+    expect(first[ARCHIVE_SQL_REPORT_ACTION_TYPE]).not.toBe(second[ARCHIVE_SQL_REPORT_ACTION_TYPE]);
+  });
+
+  it('all executors mention UI-only guidance with apiConfig', async () => {
+    const executors = createSqlReportActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow(
+        'only available through the Bloomreach Engagement UI',
+      );
+    }
+  });
+
+  it('uses independent executor maps for configured and unconfigured calls', () => {
+    const withoutConfig = createSqlReportActionExecutors();
+    const withConfig = createSqlReportActionExecutors(TEST_API_CONFIG);
+    expect(withoutConfig).not.toBe(withConfig);
+  });
+
+  it('supports custom apiConfig values without changing key set', () => {
+    const executors = createSqlReportActionExecutors({
+      ...TEST_API_CONFIG,
+      baseUrl: 'https://api-alt.test.com',
+      projectToken: 'another-token',
+    });
+    expect(Object.keys(executors).sort()).toEqual(
+      [
+        CREATE_SQL_REPORT_ACTION_TYPE,
+        EXECUTE_SQL_REPORT_ACTION_TYPE,
+        EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE,
+        CLONE_SQL_REPORT_ACTION_TYPE,
+        ARCHIVE_SQL_REPORT_ACTION_TYPE,
+      ].sort(),
+    );
+  });
 });
 
 describe('BloomreachSqlReportsService', () => {
@@ -263,12 +450,74 @@ describe('BloomreachSqlReportsService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachSqlReportsService('')).toThrow('must not be empty');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachSqlReportsService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachSqlReportsService);
+    });
+
+    it('exposes sql reports URL when constructed with apiConfig', () => {
+      const service = new BloomreachSqlReportsService('test', TEST_API_CONFIG);
+      expect(service.sqlReportsUrl).toBe('/p/test/analytics/sqlreports');
+    });
+
+    it('encodes unicode project name in constructor URL', () => {
+      const service = new BloomreachSqlReportsService('projekt åäö');
+      expect(service.sqlReportsUrl).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/analytics/sqlreports');
+    });
+
+    it('encodes hash in constructor URL', () => {
+      const service = new BloomreachSqlReportsService('my#project');
+      expect(service.sqlReportsUrl).toBe('/p/my%23project/analytics/sqlreports');
+    });
+
+    it('trims and encodes unicode project in constructor URL', () => {
+      const service = new BloomreachSqlReportsService('  projekt åäö  ');
+      expect(service.sqlReportsUrl).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/analytics/sqlreports');
+    });
+
+    it('encodes plus sign in constructor URL', () => {
+      const service = new BloomreachSqlReportsService('project+beta');
+      expect(service.sqlReportsUrl).toBe('/p/project%2Bbeta/analytics/sqlreports');
+    });
+
+    it('returns stable sqlReportsUrl with apiConfig across reads', () => {
+      const service = new BloomreachSqlReportsService('alpha', TEST_API_CONFIG);
+      expect(service.sqlReportsUrl).toBe('/p/alpha/analytics/sqlreports');
+      expect(service.sqlReportsUrl).toBe('/p/alpha/analytics/sqlreports');
+    });
   });
 
   describe('listSqlReports', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachSqlReportsService('test');
-      await expect(service.listSqlReports()).rejects.toThrow('not yet implemented');
+      await expect(service.listSqlReports()).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error when service has apiConfig', async () => {
+      const service = new BloomreachSqlReportsService('test', TEST_API_CONFIG);
+      await expect(service.listSqlReports()).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error for unicode project override', async () => {
+      const service = new BloomreachSqlReportsService('test');
+      await expect(service.listSqlReports({ project: 'projekt åäö' })).rejects.toThrow(
+        'does not provide an endpoint',
+      );
+    });
+
+    it('throws no-API-endpoint error for valid project override', async () => {
+      const service = new BloomreachSqlReportsService('test');
+      await expect(service.listSqlReports({ project: 'kingdom-of-joakim' })).rejects.toThrow(
+        'does not provide an endpoint',
+      );
+    });
+
+    it('throws no-API-endpoint error for trimmed project override', async () => {
+      const service = new BloomreachSqlReportsService('test');
+      await expect(service.listSqlReports({ project: '  kingdom-of-joakim  ' })).rejects.toThrow(
+        'does not provide an endpoint',
+      );
     });
 
     it('validates status when provided', async () => {
@@ -287,11 +536,39 @@ describe('BloomreachSqlReportsService', () => {
   });
 
   describe('viewSqlReport', () => {
-    it('throws not-yet-implemented error with valid input', async () => {
+    it('throws no-API-endpoint error with valid input', async () => {
       const service = new BloomreachSqlReportsService('test');
       await expect(
         service.viewSqlReport({ project: 'test', reportId: 'report-1' }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error when service has apiConfig', async () => {
+      const service = new BloomreachSqlReportsService('test', TEST_API_CONFIG);
+      await expect(
+        service.viewSqlReport({ project: 'test', reportId: 'report-1' }),
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error with trimmed project and reportId', async () => {
+      const service = new BloomreachSqlReportsService('test');
+      await expect(
+        service.viewSqlReport({ project: '  test  ', reportId: '  report-1  ' }),
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error for encoded-looking reportId', async () => {
+      const service = new BloomreachSqlReportsService('test');
+      await expect(
+        service.viewSqlReport({ project: 'test', reportId: 'report%2Fencoded' }),
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('accepts trimmed reportId and reaches no-API-endpoint error', async () => {
+      const service = new BloomreachSqlReportsService('test');
+      await expect(
+        service.viewSqlReport({ project: 'test', reportId: '  report-99  ' }),
+      ).rejects.toThrow('does not provide an endpoint');
     });
 
     it('validates project input', async () => {

--- a/packages/core/src/bloomreachSqlReports.ts
+++ b/packages/core/src/bloomreachSqlReports.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SQL_REPORT_ACTION_TYPE = 'sql_reports.create_report';
 export const EXECUTE_SQL_REPORT_ACTION_TYPE = 'sql_reports.execute_report';
@@ -158,6 +159,21 @@ export function buildSqlReportsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/analytics/sqlreports`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
+void requireApiConfig;
+
 export interface SqlReportActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -165,82 +181,121 @@ export interface SqlReportActionExecutor {
 
 class CreateSqlReportExecutor implements SqlReportActionExecutor {
   readonly actionType = CREATE_SQL_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateSqlReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateSqlReportExecutor: not yet implemented. ' +
+        'SQL report creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ExecuteSqlReportExecutor implements SqlReportActionExecutor {
   readonly actionType = EXECUTE_SQL_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ExecuteSqlReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ExecuteSqlReportExecutor: not yet implemented. ' +
+        'SQL report execution is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ExportSqlReportResultsExecutor implements SqlReportActionExecutor {
   readonly actionType = EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ExportSqlReportResultsExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ExportSqlReportResultsExecutor: not yet implemented. ' +
+        'SQL report results export is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CloneSqlReportExecutor implements SqlReportActionExecutor {
   readonly actionType = CLONE_SQL_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CloneSqlReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CloneSqlReportExecutor: not yet implemented. ' +
+        'SQL report cloning is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class ArchiveSqlReportExecutor implements SqlReportActionExecutor {
   readonly actionType = ARCHIVE_SQL_REPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'ArchiveSqlReportExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'ArchiveSqlReportExecutor: not yet implemented. ' +
+        'SQL report archiving is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createSqlReportActionExecutors(): Record<
+export function createSqlReportActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<
   string,
   SqlReportActionExecutor
 > {
   return {
-    [CREATE_SQL_REPORT_ACTION_TYPE]: new CreateSqlReportExecutor(),
-    [EXECUTE_SQL_REPORT_ACTION_TYPE]: new ExecuteSqlReportExecutor(),
-    [EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE]: new ExportSqlReportResultsExecutor(),
-    [CLONE_SQL_REPORT_ACTION_TYPE]: new CloneSqlReportExecutor(),
-    [ARCHIVE_SQL_REPORT_ACTION_TYPE]: new ArchiveSqlReportExecutor(),
+    [CREATE_SQL_REPORT_ACTION_TYPE]: new CreateSqlReportExecutor(apiConfig),
+    [EXECUTE_SQL_REPORT_ACTION_TYPE]: new ExecuteSqlReportExecutor(apiConfig),
+    [EXPORT_SQL_REPORT_RESULTS_ACTION_TYPE]: new ExportSqlReportResultsExecutor(apiConfig),
+    [CLONE_SQL_REPORT_ACTION_TYPE]: new CloneSqlReportExecutor(apiConfig),
+    [ARCHIVE_SQL_REPORT_ACTION_TYPE]: new ArchiveSqlReportExecutor(apiConfig),
   };
 }
 
 export class BloomreachSqlReportsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildSqlReportsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get sqlReportsUrl(): string {
@@ -248,6 +303,7 @@ export class BloomreachSqlReportsService {
   }
 
   async listSqlReports(input?: ListSqlReportsInput): Promise<BloomreachSqlReport[]> {
+    void this.apiConfig;
     if (input !== undefined) {
       validateProject(input.project);
       if (input.status !== undefined) {
@@ -256,16 +312,21 @@ export class BloomreachSqlReportsService {
     }
 
     throw new Error(
-      'listSqlReports: not yet implemented. Requires browser automation infrastructure.',
+      'listSqlReports: the Bloomreach API does not provide an endpoint for SQL reports. ' +
+        'SQL report data must be obtained from the Bloomreach Engagement UI ' +
+        '(navigate to Analytics > SQL Reports in your project).',
     );
   }
 
   async viewSqlReport(input: ViewSqlReportInput): Promise<BloomreachSqlReport> {
+    void this.apiConfig;
     validateProject(input.project);
     validateSqlReportId(input.reportId);
 
     throw new Error(
-      'viewSqlReport: not yet implemented. Requires browser automation infrastructure.',
+      'viewSqlReport: the Bloomreach API does not provide an endpoint for SQL report details. ' +
+        'SQL report details must be viewed in the Bloomreach Engagement UI ' +
+        '(navigate to Analytics > SQL Reports and open the report).',
     );
   }
 


### PR DESCRIPTION
## Summary

Acid test for the SQL Reports module — applies the standard acid test pattern (matching Flows #145, Trends #144, Surveys #106) to improve error clarity, add API config readiness, and expand test coverage.

## Changes

### Core Module (`bloomreachSqlReports.ts`)
- Import `BloomreachApiConfig` type and add `requireApiConfig()` helper for future API credential support
- All 5 executor classes now accept optional `apiConfig` constructor param with UI-only error messages
- `createSqlReportActionExecutors()` accepts optional `apiConfig` parameter
- `BloomreachSqlReportsService` constructor accepts optional `apiConfig` second parameter
- Read methods (`listSqlReports`, `viewSqlReport`) now throw descriptive "API does not provide an endpoint" errors with UI navigation guidance instead of generic "not yet implemented"

### Tests (`bloomreachSqlReports.test.ts`)
- Added `BloomreachApiConfig` test fixtures and `vi.restoreAllMocks()` teardown
- Added validator edge cases: mixed whitespace, unicode, special characters, punctuation
- Added 14 executor tests: UI-only error messages, apiConfig support, key-set parity, fresh instances
- Added 7 service constructor tests: apiConfig support, URL encoding (unicode, hash, plus sign)
- Updated read method tests from "not yet implemented" to "does not provide an endpoint"
- Added 8 new read method tests: apiConfig support, unicode projects, encoded IDs

### CLI (`bloomreach.ts`)
- Updated all 7 sql-reports command descriptions with "UI-only" / "requires browser automation" notes
- Improved `--project` descriptions to "project token (UUID from Settings > Project)"
- Added concrete examples to `--query`, `--parameters`, and format options
- Added "identifier from Bloomreach UI URL" hints to all `--report-id` options

## Quality Gates
- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 7334 tests pass (72 test files)
- ✅ `npm run build` — success

Closes #111
