### PR TITLE
feat: wire Bloomreach Exports module to REST API (#112)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -5001,7 +5001,8 @@ exportsCmd
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; json?: boolean }) => {
     try {
-      const service = new BloomreachExportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachExportsService(options.project, apiConfig);
       const result = await service.listExports({ project: options.project });
 
       if (options.json) {
@@ -5032,7 +5033,8 @@ exportsCmd
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; exportId: string; json?: boolean }) => {
     try {
-      const service = new BloomreachExportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachExportsService(options.project, apiConfig);
       const result = await service.viewExportStatus({
         project: options.project,
         exportId: options.exportId,
@@ -5062,7 +5064,8 @@ exportsCmd
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; exportId: string; json?: boolean }) => {
     try {
-      const service = new BloomreachExportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachExportsService(options.project, apiConfig);
       const result = await service.viewExportHistory({
         project: options.project,
         exportId: options.exportId,
@@ -5123,7 +5126,8 @@ exportsCmd
           ? (JSON.parse(options.schedule) as ExportSchedule)
           : undefined;
 
-        const service = new BloomreachExportsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachExportsService(options.project, apiConfig);
         const result = service.prepareCreateExport({
           project: options.project,
           name: options.name,
@@ -5161,7 +5165,8 @@ exportsCmd
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; exportId: string; note?: string; json?: boolean }) => {
     try {
-      const service = new BloomreachExportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachExportsService(options.project, apiConfig);
       const result = service.prepareRunExport({
         project: options.project,
         exportId: options.exportId,
@@ -5207,7 +5212,8 @@ exportsCmd
       try {
         const schedule = JSON.parse(options.schedule) as ExportSchedule;
 
-        const service = new BloomreachExportsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachExportsService(options.project, apiConfig);
         const result = service.prepareScheduleExport({
           project: options.project,
           exportId: options.exportId,
@@ -5242,7 +5248,8 @@ exportsCmd
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; exportId: string; note?: string; json?: boolean }) => {
     try {
-      const service = new BloomreachExportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachExportsService(options.project, apiConfig);
       const result = service.prepareDeleteExport({
         project: options.project,
         exportId: options.exportId,

--- a/packages/core/src/__tests__/bloomreachExports.test.ts
+++ b/packages/core/src/__tests__/bloomreachExports.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
 import {
   CREATE_EXPORT_ACTION_TYPE,
   RUN_EXPORT_ACTION_TYPE,
@@ -15,6 +16,17 @@ import {
   BloomreachExportsService,
   type CreateExportInput,
 } from '../index.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function createValidCreateExportInput(overrides: Partial<CreateExportInput> = {}): CreateExportInput {
   return {
@@ -498,11 +510,42 @@ describe('createExportActionExecutors', () => {
     }
   });
 
-  it('each executor throws not yet implemented on execute', async () => {
+  it('executors require API credentials when apiConfig is not provided', async () => {
     const executors = createExportActionExecutors();
     for (const executor of Object.values(executors)) {
-      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+      await expect(executor.execute({})).rejects.toThrow('requires API credentials');
     }
+  });
+
+  it('executors attempt API calls when apiConfig is provided', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const executors = createExportActionExecutors(TEST_API_CONFIG);
+    await executors[CREATE_EXPORT_ACTION_TYPE].execute({
+      name: 'Test Export',
+      exportType: 'customers',
+      dataSelection: { attributes: ['email'] },
+      destination: { type: 'sftp', host: 'sftp.example.com', path: '/exports' },
+    });
+    await executors[RUN_EXPORT_ACTION_TYPE].execute({
+      exportId: 'exp-1',
+    });
+    await executors[SCHEDULE_EXPORT_ACTION_TYPE].execute({
+      exportId: 'exp-2',
+      schedule: { frequency: 'daily', time: '09:00', timezone: 'UTC' },
+    });
+    await executors[DELETE_EXPORT_ACTION_TYPE].execute({
+      exportId: 'exp-3',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -526,12 +569,36 @@ describe('BloomreachExportsService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachExportsService('')).toThrow('must not be empty');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachExportsService('my-project', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachExportsService);
+    });
   });
 
   describe('listExports', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachExportsService('test');
-      await expect(service.listExports()).rejects.toThrow('not yet implemented');
+      await expect(service.listExports()).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns mapped exports when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            { id: 'exp-1', name: 'Daily Export', export_type: 'customers', status: 'active' },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachExportsService('test', TEST_API_CONFIG);
+      const result = await service.listExports({ project: 'test' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('exp-1');
+      expect(result[0].name).toBe('Daily Export');
+      expect(result[0].exportType).toBe('customers');
     });
 
     it('validates project when input provided', async () => {
@@ -541,9 +608,33 @@ describe('BloomreachExportsService', () => {
   });
 
   describe('viewExportStatus', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachExportsService('test');
-      await expect(service.viewExportStatus({ project: 'test', exportId: 'exp-1' })).rejects.toThrow('not yet implemented');
+      await expect(
+        service.viewExportStatus({ project: 'test', exportId: 'exp-1' }),
+      ).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns export status when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            export_id: 'exp-1',
+            status: 'completed',
+            started_at: '2026-01-01T00:00:00Z',
+            completed_at: '2026-01-01T00:05:00Z',
+            record_count: 1500,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachExportsService('test', TEST_API_CONFIG);
+      const result = await service.viewExportStatus({ project: 'test', exportId: 'exp-1' });
+
+      expect(result.exportId).toBe('exp-1');
+      expect(result.status).toBe('completed');
+      expect(result.recordCount).toBe(1500);
     });
 
     it('validates project', async () => {
@@ -558,9 +649,31 @@ describe('BloomreachExportsService', () => {
   });
 
   describe('viewExportHistory', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachExportsService('test');
-      await expect(service.viewExportHistory({ project: 'test', exportId: 'exp-1' })).rejects.toThrow('not yet implemented');
+      await expect(
+        service.viewExportHistory({ project: 'test', exportId: 'exp-1' }),
+      ).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns export history when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            { id: 'run-1', export_id: 'exp-1', status: 'completed', record_count: 1000 },
+            { id: 'run-2', export_id: 'exp-1', status: 'failed' },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachExportsService('test', TEST_API_CONFIG);
+      const result = await service.viewExportHistory({ project: 'test', exportId: 'exp-1' });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('run-1');
+      expect(result[0].status).toBe('completed');
+      expect(result[1].status).toBe('failed');
     });
 
     it('validates project', async () => {

--- a/packages/core/src/bloomreachExports.ts
+++ b/packages/core/src/bloomreachExports.ts
@@ -1,4 +1,6 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
 export const CREATE_EXPORT_ACTION_TYPE = 'exports.create_export';
 export const RUN_EXPORT_ACTION_TYPE = 'exports.run_export';
@@ -413,69 +415,126 @@ export interface ExportActionExecutor {
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 class CreateExportExecutor implements ExportActionExecutor {
   readonly actionType = CREATE_EXPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateExportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'CreateExportExecutor');
+    const path = buildDataPath(config, '/exports');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        name: payload.name,
+        export_type: payload.exportType,
+        data_selection: payload.dataSelection,
+        destination: payload.destination,
+        schedule: payload.schedule,
+      },
+    });
+
+    return { success: true, response };
   }
 }
 
 class RunExportExecutor implements ExportActionExecutor {
   readonly actionType = RUN_EXPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'RunExportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'RunExportExecutor');
+    const exportId = String(payload.exportId ?? '');
+    const path = buildDataPath(config, `/exports/${encodeURIComponent(exportId)}/start`);
+
+    const response = await bloomreachApiFetch(config, path, {});
+
+    return { success: true, response };
   }
 }
 
 class ScheduleExportExecutor implements ExportActionExecutor {
   readonly actionType = SCHEDULE_EXPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ScheduleExportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'ScheduleExportExecutor');
+    const exportId = String(payload.exportId ?? '');
+    const path = buildDataPath(config, `/exports/${encodeURIComponent(exportId)}/schedule`);
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: { schedule: payload.schedule },
+    });
+
+    return { success: true, response };
   }
 }
 
 class DeleteExportExecutor implements ExportActionExecutor {
   readonly actionType = DELETE_EXPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'DeleteExportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'DeleteExportExecutor');
+    const exportId = String(payload.exportId ?? '');
+    const path = buildDataPath(config, `/exports/${encodeURIComponent(exportId)}`);
+
+    const response = await bloomreachApiFetch(config, path, {
+      method: 'POST',
+      body: { command: 'delete' },
+    });
+
+    return { success: true, response };
   }
 }
 
-export function createExportActionExecutors(): Record<string, ExportActionExecutor> {
+export function createExportActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, ExportActionExecutor> {
   return {
-    [CREATE_EXPORT_ACTION_TYPE]: new CreateExportExecutor(),
-    [RUN_EXPORT_ACTION_TYPE]: new RunExportExecutor(),
-    [SCHEDULE_EXPORT_ACTION_TYPE]: new ScheduleExportExecutor(),
-    [DELETE_EXPORT_ACTION_TYPE]: new DeleteExportExecutor(),
+    [CREATE_EXPORT_ACTION_TYPE]: new CreateExportExecutor(apiConfig),
+    [RUN_EXPORT_ACTION_TYPE]: new RunExportExecutor(apiConfig),
+    [SCHEDULE_EXPORT_ACTION_TYPE]: new ScheduleExportExecutor(apiConfig),
+    [DELETE_EXPORT_ACTION_TYPE]: new DeleteExportExecutor(apiConfig),
   };
 }
 
 export class BloomreachExportsService {
   private readonly exportsBaseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     const validatedProject = validateProject(project);
     this.exportsBaseUrl = buildExportsUrl(validatedProject);
+    this.apiConfig = apiConfig;
   }
 
   get exportsUrl(): string {
@@ -487,27 +546,136 @@ export class BloomreachExportsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listExports: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'listExports');
+    const path = buildDataPath(config, '/exports');
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: { command: 'list' },
+    });
+
+    const data = response as Record<string, unknown>;
+    const items = Array.isArray(data.results) ? data.results : Array.isArray(response) ? response : [];
+
+    return items.map((rawItem: unknown) => {
+      const item =
+        typeof rawItem === 'object' && rawItem !== null
+          ? (rawItem as Record<string, unknown>)
+          : {};
+
+      return {
+        id: String(item.id ?? ''),
+        name: String(item.name ?? ''),
+        exportType: String(item.export_type ?? item.exportType ?? ''),
+        dataSelection: (item.data_selection ?? item.dataSelection ?? { attributes: [] }) as DataSelection,
+        destination: (item.destination ?? { type: 'unknown' }) as ExportDestination,
+        schedule: item.schedule as ExportSchedule | undefined,
+        status: String(item.status ?? 'unknown'),
+        createdAt: String(item.created_at ?? item.createdAt ?? ''),
+        updatedAt: String(item.updated_at ?? item.updatedAt ?? ''),
+        url: buildExportDetailUrl(input?.project ?? '', String(item.id ?? '')),
+      };
+    });
   }
 
   async viewExportStatus(input: ViewExportStatusInput): Promise<ExportStatus> {
     validateProject(input.project);
     validateExportId(input.exportId);
 
-    throw new Error(
-      'viewExportStatus: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewExportStatus');
+    const path = buildDataPath(config, `/exports/${encodeURIComponent(input.exportId)}/status`);
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: { export_id: input.exportId },
+    });
+
+    const data = response as Record<string, unknown>;
+
+    return {
+      exportId: String(data.export_id ?? data.exportId ?? input.exportId),
+      status: String(data.status ?? 'unknown'),
+      startedAt:
+        data.started_at !== undefined
+          ? String(data.started_at)
+          : data.startedAt !== undefined
+            ? String(data.startedAt)
+            : undefined,
+      completedAt:
+        data.completed_at !== undefined
+          ? String(data.completed_at)
+          : data.completedAt !== undefined
+            ? String(data.completedAt)
+            : undefined,
+      fileLocation:
+        data.file_location !== undefined
+          ? String(data.file_location)
+          : data.fileLocation !== undefined
+            ? String(data.fileLocation)
+            : undefined,
+      recordCount:
+        typeof data.record_count === 'number'
+          ? data.record_count
+          : typeof data.recordCount === 'number'
+            ? data.recordCount
+            : undefined,
+      errorMessage:
+        data.error_message !== undefined
+          ? String(data.error_message)
+          : data.errorMessage !== undefined
+            ? String(data.errorMessage)
+            : undefined,
+    };
   }
 
   async viewExportHistory(input: ViewExportHistoryInput): Promise<ExportHistoryEntry[]> {
     validateProject(input.project);
     validateExportId(input.exportId);
 
-    throw new Error(
-      'viewExportHistory: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewExportHistory');
+    const path = buildDataPath(config, `/exports/${encodeURIComponent(input.exportId)}/history`);
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: { export_id: input.exportId },
+    });
+
+    const data = response as Record<string, unknown>;
+    const items = Array.isArray(data.results) ? data.results : Array.isArray(response) ? response : [];
+
+    return items.map((rawItem: unknown) => {
+      const item =
+        typeof rawItem === 'object' && rawItem !== null
+          ? (rawItem as Record<string, unknown>)
+          : {};
+
+      return {
+        id: String(item.id ?? ''),
+        exportId: String(item.export_id ?? item.exportId ?? input.exportId),
+        status: String(item.status ?? 'unknown'),
+        startedAt:
+          item.started_at !== undefined
+            ? String(item.started_at)
+            : item.startedAt !== undefined
+              ? String(item.startedAt)
+              : undefined,
+        completedAt:
+          item.completed_at !== undefined
+            ? String(item.completed_at)
+            : item.completedAt !== undefined
+              ? String(item.completedAt)
+              : undefined,
+        fileLocation:
+          item.file_location !== undefined
+            ? String(item.file_location)
+            : item.fileLocation !== undefined
+              ? String(item.fileLocation)
+              : undefined,
+        recordCount:
+          typeof item.record_count === 'number'
+            ? item.record_count
+            : typeof item.recordCount === 'number'
+              ? item.recordCount
+              : undefined,
+      };
+    });
   }
 
   prepareCreateExport(input: CreateExportInput): PreparedExportAction {


### PR DESCRIPTION
## Summary
Wire the Bloomreach Exports module to the REST API, replacing all 7 "not yet implemented" stubs with real API-backed implementations.

## Changes

### Core Service (`packages/core/src/bloomreachExports.ts`)
- Added `BloomreachApiConfig` to constructor and all 4 executor classes
- Implemented `listExports()`, `viewExportStatus()`, `viewExportHistory()` using `bloomreachApiFetch` + `buildDataPath`
- Wired `CreateExport`, `RunExport`, `ScheduleExport`, `DeleteExport` executors to real API endpoints
- Added `requireApiConfig()` guard for clear credential error messages
- Follows the `bloomreachCustomers.ts` reference pattern exactly

### Tests (`packages/core/src/__tests__/bloomreachExports.test.ts`)
- Replaced "not yet implemented" test expectations with API credential requirement tests
- Added `vi.spyOn(globalThis, 'fetch')` integration tests for reads and executors
- Added constructor `apiConfig` parameter coverage
- **93 tests pass** (up from 88)

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- All 7 export subcommands now resolve and pass `apiConfig` to `BloomreachExportsService`
- Pattern matches existing customers commands (`tryResolveApiConfig()`)

## Quality Gates
- ✅ Typecheck (`tsc --build`)
- ✅ Lint (`eslint`)
- ✅ Tests (3630 tests across 36 files)
- ✅ Build (`tsup`)
- ✅ Manual QA: CLI help, read commands with/without creds, write prepare commands

Closes #112
