### PR TITLE
feat: wire Bloomreach Imports module to REST API (#113)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -10164,7 +10164,8 @@ imports
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; status?: string; type?: string; json?: boolean }) => {
     try {
-      const service = new BloomreachImportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachImportsService(options.project, apiConfig);
       const input: { project: string; status?: string; type?: string } = {
         project: options.project,
       };
@@ -10206,7 +10207,8 @@ imports
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; importId: string; json?: boolean }) => {
     try {
-      const service = new BloomreachImportsService(options.project);
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachImportsService(options.project, apiConfig);
       const result = await service.viewImportStatus({
         project: options.project,
         importId: options.importId,
@@ -10267,7 +10269,8 @@ imports
       try {
         const mapping = JSON.parse(options.mapping) as ImportMapping[];
 
-        const service = new BloomreachImportsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachImportsService(options.project, apiConfig);
         const result = service.prepareCreateImport({
           project: options.project,
           name: options.name,
@@ -10335,7 +10338,8 @@ imports
           isActive: true,
         };
 
-        const service = new BloomreachImportsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachImportsService(options.project, apiConfig);
         const result = service.prepareScheduleImport({
           project: options.project,
           name: options.name,
@@ -10378,7 +10382,8 @@ imports
   .action(
     async (options: { project: string; importId: string; note?: string; json?: boolean }) => {
       try {
-        const service = new BloomreachImportsService(options.project);
+        const apiConfig = tryResolveApiConfig(options.project);
+        const service = new BloomreachImportsService(options.project, apiConfig);
         const result = service.prepareCancelImport({
           project: options.project,
           importId: options.importId,

--- a/packages/core/src/__tests__/bloomreachImports.test.ts
+++ b/packages/core/src/__tests__/bloomreachImports.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
 import {
   CREATE_IMPORT_ACTION_TYPE,
   SCHEDULE_IMPORT_ACTION_TYPE,
@@ -8,9 +9,21 @@ import {
   IMPORTS_SCHEDULE_RATE_LIMIT,
   IMPORTS_CANCEL_RATE_LIMIT,
   buildImportsUrl,
+  buildImportDetailUrl,
   createImportsActionExecutors,
   BloomreachImportsService,
 } from '../index.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_IMPORT_ACTION_TYPE as imports.create_import', () => {
@@ -543,6 +556,16 @@ describe('buildImportsUrl', () => {
   });
 });
 
+describe('buildImportDetailUrl', () => {
+  it('builds URL with project and import ID', () => {
+    expect(buildImportDetailUrl('my-project', 'import-123')).toBe('/p/my-project/data/imports/import-123');
+  });
+
+  it('encodes spaces in project and import ID', () => {
+    expect(buildImportDetailUrl('my project', 'import 123')).toBe('/p/my%20project/data/imports/import%20123');
+  });
+});
+
 describe('createImportsActionExecutors', () => {
   it('returns executors for all 3 action types', () => {
     const executors = createImportsActionExecutors();
@@ -559,11 +582,43 @@ describe('createImportsActionExecutors', () => {
     }
   });
 
-  it('each executor throws not yet implemented on execute', async () => {
+  it('executors require API credentials when apiConfig is not provided', async () => {
     const executors = createImportsActionExecutors();
     for (const executor of Object.values(executors)) {
-      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+      await expect(executor.execute({})).rejects.toThrow('requires API credentials');
     }
+  });
+
+  it('executors attempt API calls when apiConfig is provided', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const executors = createImportsActionExecutors(TEST_API_CONFIG);
+    await executors[CREATE_IMPORT_ACTION_TYPE].execute({
+      name: 'Test Import',
+      type: 'csv',
+      source: 'https://example.com/data.csv',
+      mapping: [{ sourceColumn: 'email', targetProperty: 'customer_email' }],
+    });
+    await executors[SCHEDULE_IMPORT_ACTION_TYPE].execute({
+      importId: 'imp-1',
+      name: 'Scheduled Import',
+      type: 'api',
+      source: 'https://api.example.com/data',
+      mapping: [{ sourceColumn: 'id', targetProperty: 'customer_id' }],
+      schedule: { frequency: 'daily', isActive: true },
+    });
+    await executors[CANCEL_IMPORT_ACTION_TYPE].execute({
+      importId: 'imp-2',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -584,15 +639,50 @@ describe('BloomreachImportsService', () => {
       expect(service.importsUrl).toBe('/p/my-project/data/imports');
     });
 
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachImportsService('my-project', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachImportsService);
+    });
+
     it('throws for empty project', () => {
       expect(() => new BloomreachImportsService('')).toThrow('must not be empty');
     });
   });
 
   describe('listImports', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachImportsService('test');
-      await expect(service.listImports()).rejects.toThrow('not yet implemented');
+      await expect(service.listImports()).rejects.toThrow('requires API credentials');
+    });
+
+    it('returns mapped imports when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              id: 'imp-1',
+              name: 'Customer Import',
+              type: 'csv',
+              status: 'completed',
+              source: 'https://example.com/data.csv',
+              rows_processed: 100,
+              rows_total: 100,
+              errors: 0,
+              warnings: 2,
+            },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachImportsService('test', TEST_API_CONFIG);
+      const result = await service.listImports({ project: 'test' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('imp-1');
+      expect(result[0].name).toBe('Customer Import');
+      expect(result[0].type).toBe('csv');
+      expect(result[0].rowsProcessed).toBe(100);
     });
 
     it('validates project when input provided', async () => {
@@ -602,11 +692,41 @@ describe('BloomreachImportsService', () => {
   });
 
   describe('viewImportStatus', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws API credential error when apiConfig is not provided', async () => {
       const service = new BloomreachImportsService('test');
       await expect(service.viewImportStatus({ project: 'test', importId: 'import-123' })).rejects.toThrow(
-        'not yet implemented',
+        'requires API credentials',
       );
+    });
+
+    it('returns import status when apiConfig is provided', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            import_id: 'imp-1',
+            name: 'Customer Import',
+            status: 'processing',
+            type: 'csv',
+            source: 'https://example.com/data.csv',
+            rows_processed: 50,
+            rows_total: 100,
+            errors: 0,
+            warnings: 1,
+            created_at: '2026-01-01T00:00:00Z',
+            started_at: '2026-01-01T00:01:00Z',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      const service = new BloomreachImportsService('test', TEST_API_CONFIG);
+      const result = await service.viewImportStatus({ project: 'test', importId: 'imp-1' });
+
+      expect(result.importId).toBe('imp-1');
+      expect(result.name).toBe('Customer Import');
+      expect(result.status).toBe('processing');
+      expect(result.rowsProcessed).toBe(50);
+      expect(result.rowsTotal).toBe(100);
     });
 
     it('validates project', async () => {

--- a/packages/core/src/bloomreachImports.ts
+++ b/packages/core/src/bloomreachImports.ts
@@ -1,4 +1,6 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
 export const CREATE_IMPORT_ACTION_TYPE = 'imports.create_import';
 export const SCHEDULE_IMPORT_ACTION_TYPE = 'imports.schedule_import';
@@ -348,61 +350,114 @@ export function buildImportsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/data/imports`;
 }
 
+export function buildImportDetailUrl(project: string, importId: string): string {
+  return `/p/${encodeURIComponent(project)}/data/imports/${encodeURIComponent(importId)}`;
+}
+
 export interface ImportsActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
 class CreateImportExecutor implements ImportsActionExecutor {
   readonly actionType = CREATE_IMPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateImportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'CreateImportExecutor');
+    const path = buildDataPath(config, '/imports');
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        name: payload.name,
+        type: payload.type,
+        source: payload.source,
+        mapping: payload.mapping,
+      },
+    });
+    return { success: true, response };
   }
 }
 
 class ScheduleImportExecutor implements ImportsActionExecutor {
   readonly actionType = SCHEDULE_IMPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ScheduleImportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'ScheduleImportExecutor');
+    const importId = String(payload.importId ?? '');
+    const path = buildDataPath(config, `/imports/${encodeURIComponent(importId)}/schedule`);
+    const response = await bloomreachApiFetch(config, path, {
+      body: {
+        name: payload.name,
+        type: payload.type,
+        source: payload.source,
+        mapping: payload.mapping,
+        schedule: payload.schedule,
+      },
+    });
+    return { success: true, response };
   }
 }
 
 class CancelImportExecutor implements ImportsActionExecutor {
   readonly actionType = CANCEL_IMPORT_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CancelImportExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const config = requireApiConfig(this.apiConfig, 'CancelImportExecutor');
+    const importId = String(payload.importId ?? '');
+    const path = buildDataPath(config, `/imports/${encodeURIComponent(importId)}`);
+    const response = await bloomreachApiFetch(config, path, {
+      method: 'POST',
+      body: { command: 'cancel' },
+    });
+    return { success: true, response };
   }
 }
 
-export function createImportsActionExecutors(): Record<string, ImportsActionExecutor> {
+export function createImportsActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, ImportsActionExecutor> {
   return {
-    [CREATE_IMPORT_ACTION_TYPE]: new CreateImportExecutor(),
-    [SCHEDULE_IMPORT_ACTION_TYPE]: new ScheduleImportExecutor(),
-    [CANCEL_IMPORT_ACTION_TYPE]: new CancelImportExecutor(),
+    [CREATE_IMPORT_ACTION_TYPE]: new CreateImportExecutor(apiConfig),
+    [SCHEDULE_IMPORT_ACTION_TYPE]: new ScheduleImportExecutor(apiConfig),
+    [CANCEL_IMPORT_ACTION_TYPE]: new CancelImportExecutor(apiConfig),
   };
 }
 
 export class BloomreachImportsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     const validatedProject = validateProject(project);
     this.baseUrl = buildImportsUrl(validatedProject);
+    this.apiConfig = apiConfig;
   }
 
   get importsUrl(): string {
@@ -422,18 +477,91 @@ export class BloomreachImportsService {
       }
     }
 
-    throw new Error(
-      'listImports: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'listImports');
+    const path = buildDataPath(config, '/imports');
+
+    const body: Record<string, unknown> = { command: 'list' };
+    if (input?.status !== undefined) body.status = input.status;
+    if (input?.type !== undefined) body.type = input.type;
+
+    const response = await bloomreachApiFetch(config, path, { body });
+
+    const data = response as Record<string, unknown>;
+    const items = Array.isArray(data.results) ? data.results : Array.isArray(response) ? response : [];
+
+    return items.map((rawItem: unknown) => {
+      const item =
+        typeof rawItem === 'object' && rawItem !== null
+          ? (rawItem as Record<string, unknown>)
+          : {};
+
+      return {
+        id: String(item.id ?? ''),
+        name: String(item.name ?? ''),
+        status: String(item.status ?? 'unknown'),
+        type: String(item.type ?? ''),
+        source: String(item.source ?? ''),
+        rowsProcessed: typeof item.rows_processed === 'number' ? item.rows_processed : typeof item.rowsProcessed === 'number' ? item.rowsProcessed : 0,
+        rowsTotal: typeof item.rows_total === 'number' ? item.rows_total : typeof item.rowsTotal === 'number' ? item.rowsTotal : 0,
+        errors: typeof item.errors === 'number' ? item.errors : 0,
+        warnings: typeof item.warnings === 'number' ? item.warnings : 0,
+        createdAt: String(item.created_at ?? item.createdAt ?? ''),
+        completedAt: item.completed_at !== undefined ? String(item.completed_at) : item.completedAt !== undefined ? String(item.completedAt) : undefined,
+        url: buildImportDetailUrl(input?.project ?? '', String(item.id ?? '')),
+      };
+    });
   }
 
   async viewImportStatus(input: ViewImportStatusInput): Promise<ImportStatusDetail> {
     validateProject(input.project);
     validateImportId(input.importId);
 
-    throw new Error(
-      'viewImportStatus: not yet implemented. Requires browser automation infrastructure.',
-    );
+    const config = requireApiConfig(this.apiConfig, 'viewImportStatus');
+    const path = buildDataPath(config, `/imports/${encodeURIComponent(input.importId)}/status`);
+
+    const response = await bloomreachApiFetch(config, path, {
+      body: { import_id: input.importId },
+    });
+
+    const data = response as Record<string, unknown>;
+
+    return {
+      importId: String(data.import_id ?? data.importId ?? input.importId),
+      name: String(data.name ?? ''),
+      status: String(data.status ?? 'unknown'),
+      type: String(data.type ?? ''),
+      source: String(data.source ?? ''),
+      rowsProcessed: typeof data.rows_processed === 'number' ? data.rows_processed : typeof data.rowsProcessed === 'number' ? data.rowsProcessed : 0,
+      rowsTotal: typeof data.rows_total === 'number' ? data.rows_total : typeof data.rowsTotal === 'number' ? data.rowsTotal : 0,
+      errors: typeof data.errors === 'number' ? data.errors : 0,
+      warnings: typeof data.warnings === 'number' ? data.warnings : 0,
+      errorDetails: Array.isArray(data.error_details ?? data.errorDetails)
+        ? ((data.error_details ?? data.errorDetails) as unknown[]).map((e: unknown) => {
+            const entry = typeof e === 'object' && e !== null ? (e as Record<string, unknown>) : {};
+            return {
+              row: typeof entry.row === 'number' ? entry.row : 0,
+              column: String(entry.column ?? ''),
+              message: String(entry.message ?? ''),
+            };
+          })
+        : [],
+      warningDetails: Array.isArray(data.warning_details ?? data.warningDetails)
+        ? ((data.warning_details ?? data.warningDetails) as unknown[]).map((e: unknown) => {
+            const entry = typeof e === 'object' && e !== null ? (e as Record<string, unknown>) : {};
+            return {
+              row: typeof entry.row === 'number' ? entry.row : 0,
+              column: String(entry.column ?? ''),
+              message: String(entry.message ?? ''),
+            };
+          })
+        : [],
+      createdAt: String(data.created_at ?? data.createdAt ?? ''),
+      startedAt: data.started_at !== undefined ? String(data.started_at) : data.startedAt !== undefined ? String(data.startedAt) : undefined,
+      completedAt: data.completed_at !== undefined ? String(data.completed_at) : data.completedAt !== undefined ? String(data.completedAt) : undefined,
+      schedule: data.schedule as ImportScheduleConfig | undefined,
+      mapping: Array.isArray(data.mapping) ? data.mapping as ImportMapping[] : [],
+      url: buildImportDetailUrl(input.project, input.importId),
+    };
   }
 
   prepareCreateImport(input: CreateImportInput): PreparedImportsAction {


### PR DESCRIPTION
## Summary

Wires the Bloomreach Imports module (`bloomreachImports.ts`) to the REST API, replacing all 5 "not yet implemented" stubs with real API calls via `bloomreachApiFetch`. Follows the established pattern from the fully-implemented exports module (`bloomreachExports.ts`).

## Changes

### Core Service (`packages/core/src/bloomreachImports.ts`)
- Added `BloomreachApiConfig` support to `BloomreachImportsService` constructor
- Implemented `listImports()` — POST to `/data/v2/projects/{token}/imports` with response normalization
- Implemented `viewImportStatus()` — POST to `/data/v2/projects/{token}/imports/{id}/status` with full detail parsing
- Wired `CreateImportExecutor` — POST import definition to API
- Wired `ScheduleImportExecutor` — POST schedule config to `/imports/{id}/schedule`
- Wired `CancelImportExecutor` — POST cancel command to `/imports/{id}`
- Added `requireApiConfig()` guard and `buildImportDetailUrl()` helper
- Updated `createImportsActionExecutors()` to accept and pass `apiConfig`

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- Updated all 5 imports commands (`list`, `view-status`, `create`, `schedule`, `cancel`) to resolve API credentials via `tryResolveApiConfig()` and pass them to the service constructor

### Tests (`packages/core/src/__tests__/bloomreachImports.test.ts`)
- Added `BloomreachApiConfig` test fixture and `afterEach` mock cleanup
- Added `buildImportDetailUrl` tests
- Replaced "not yet implemented" executor tests with API credential and mock fetch tests
- Added `listImports()` and `viewImportStatus()` API integration tests with response mapping verification
- Added constructor `apiConfig` acceptance test
- **79 import tests pass, 3678 total tests pass**

## Quality Gates
- ✅ TypeScript: `tsc --noEmit` clean
- ✅ Lint: `eslint .` clean
- ✅ Tests: 36 files, 3678 tests passed
- ✅ Build: CLI + Core build success

## Checklist from Issue
- [x] `imports list` — list configured imports
- [x] `imports view-status --import-id "..."` — current import job status
- [x] `imports create` — create new import definition (source, mapping, schedule)
- [x] `imports schedule --import-id "..."` — configure recurring import
- [x] `imports cancel --import-id "..."` — cancel running import
- [x] JSON output for all commands

Closes #113
