### PR TITLE
feat: acid test metrics module — apiConfig, improved errors, expanded tests (#116)

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -83,9 +83,7 @@ function printJson(value: unknown): void {
 
 function tryResolveApiConfig(projectToken?: string): BloomreachApiConfig | undefined {
   try {
-    return resolveApiConfig(
-      projectToken ? { projectToken } : undefined,
-    );
+    return resolveApiConfig(projectToken ? { projectToken } : undefined);
   } catch {
     return undefined;
   }
@@ -805,7 +803,10 @@ emailCampaigns
     '--schedule-type <type>',
     'Send schedule: immediate, scheduled (requires --scheduled-at), or recurring (requires --cron)',
   )
-  .option('--scheduled-at <datetime>', 'ISO-8601 datetime for scheduled sends (e.g. 2026-04-01T10:00:00Z)')
+  .option(
+    '--scheduled-at <datetime>',
+    'ISO-8601 datetime for scheduled sends (e.g. 2026-04-01T10:00:00Z)',
+  )
   .option('--cron <expression>', 'Cron expression for recurring sends (e.g. "0 9 * * MON")')
   .option('--ab-variants <n>', 'Number of A/B test variants (2-10, includes control)')
   .option('--ab-split <percent>', 'A/B test split percentage (0-100, audience fraction for test)')
@@ -1080,10 +1081,7 @@ surveys
   .option('--page-url <url>', 'Page URL pattern where survey appears (e.g. /checkout)')
   .option('--trigger-event <event>', 'Trigger event name (e.g. cart_abandon)')
   .option('--delay-ms <ms>', 'Delay in milliseconds before showing the survey')
-  .option(
-    '--frequency <frequency>',
-    'Display frequency: once, always, or once_per_session',
-  )
+  .option('--frequency <frequency>', 'Display frequency: once, always, or once_per_session')
   .option('--template-id <id>', 'Survey template ID for pre-built layouts')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
@@ -1502,10 +1500,7 @@ trends
   )
   .option('--start-date <date>', 'Start date in ISO-8601 format (YYYY-MM-DD)')
   .option('--end-date <date>', 'End date in ISO-8601 format (YYYY-MM-DD)')
-  .option(
-    '--granularity <granularity>',
-    'Time granularity: hourly | daily | weekly | monthly',
-  )
+  .option('--granularity <granularity>', 'Time granularity: hourly | daily | weekly | monthly')
   .option('--json', 'Output as JSON')
   .action(
     async (options: {
@@ -2290,7 +2285,10 @@ flows
   .description('Prepare creation of a new flow analysis (two-phase commit, UI-only)')
   .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .requiredOption('--name <name>', 'Flow analysis name (max 200 characters)')
-  .requiredOption('--starting-event <event>', 'Starting event for the journey (e.g. "session_start")')
+  .requiredOption(
+    '--starting-event <event>',
+    'Starting event for the journey (e.g. "session_start")',
+  )
   .requiredOption(
     '--events <json>',
     'JSON array of events to track (e.g. \'[{"order":1,"eventName":"purchase"},{"order":2,"eventName":"refund"}]\')',
@@ -2414,10 +2412,7 @@ flows
   .command('archive')
   .description('Prepare archiving a flow analysis (two-phase commit, UI-only)')
   .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
-  .requiredOption(
-    '--analysis-id <id>',
-    'Flow analysis ID (hex string from Bloomreach UI URL)',
-  )
+  .requiredOption('--analysis-id <id>', 'Flow analysis ID (hex string from Bloomreach UI URL)')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -4192,7 +4187,10 @@ const metrics = program
 
 metrics
   .command('list')
-  .description('List all custom computed metrics in the project')
+  .description(
+    'List all custom computed metrics in the project ' +
+      '(note: the Bloomreach API does not provide a metrics endpoint — requires browser automation)',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; json?: boolean }) => {
@@ -4222,15 +4220,19 @@ metrics
 
 metrics
   .command('create')
-  .description('Prepare creation of a custom metric (two-phase commit)')
+  .description(
+    'Prepare creation of a custom metric (two-phase commit). ' +
+      'Aggregation types: sum, count, average, min, max, unique. ' +
+      'Property-based aggregations (sum, average, min, max) require --property-name.',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--name <name>', 'Metric name')
-  .requiredOption('--event-name <eventName>', 'Event name for aggregation')
+  .requiredOption('--name <name>', 'Metric name (1–200 characters)')
+  .requiredOption('--event-name <eventName>', 'Event name for aggregation (e.g. "purchase")')
   .requiredOption(
     '--aggregation-type <type>',
     'Aggregation type (sum, count, average, min, max, unique)',
   )
-  .option('--property-name <prop>', 'Event property name for property-based aggregations')
+  .option('--property-name <prop>', 'Event property name — required for sum, average, min, max')
   .option('--description <desc>', 'Metric description')
   .option('--filters <json>', 'JSON object of metric filters')
   .option('--note <note>', 'Operator note for audit trail')
@@ -4285,16 +4287,19 @@ metrics
 
 metrics
   .command('edit')
-  .description('Prepare editing a custom metric (two-phase commit)')
+  .description(
+    'Prepare editing a custom metric (two-phase commit). ' +
+      'Provide only the fields you want to change.',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--metric-id <id>', 'Metric ID')
-  .option('--name <name>', 'New metric name')
+  .requiredOption('--metric-id <id>', 'Metric ID to edit')
+  .option('--name <name>', 'New metric name (1–200 characters)')
   .option('--event-name <eventName>', 'New event name for aggregation')
   .option(
     '--aggregation-type <type>',
     'New aggregation type (sum, count, average, min, max, unique)',
   )
-  .option('--property-name <prop>', 'New event property name for property-based aggregations')
+  .option('--property-name <prop>', 'New event property name — required for sum, average, min, max')
   .option('--description <desc>', 'New metric description')
   .option('--filters <json>', 'JSON object of metric filters')
   .option('--note <note>', 'Operator note for audit trail')
@@ -4354,9 +4359,12 @@ metrics
 
 metrics
   .command('delete')
-  .description('Prepare deletion of a custom metric (two-phase commit)')
+  .description(
+    'Prepare deletion of a custom metric (two-phase commit). ' +
+      'This action is irreversible once confirmed.',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--metric-id <id>', 'Metric ID')
+  .requiredOption('--metric-id <id>', 'Metric ID to delete')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; metricId: string; note?: string; json?: boolean }) => {
@@ -4782,7 +4790,9 @@ dataManager
 
 dataManager
   .command('configure-mapping')
-  .description('Prepare mapping configuration between source and target fields (two-phase commit, UI-only)')
+  .description(
+    'Prepare mapping configuration between source and target fields (two-phase commit, UI-only)',
+  )
   .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .requiredOption('--source-field <field>', 'Source field name (max 200 characters)')
   .requiredOption('--target-field <field>', 'Target field name (max 200 characters)')
@@ -8444,7 +8454,9 @@ evaluationSettingsDashboards
         console.log(`Evaluation dashboards (${options.project})`);
         console.log(`  URL: ${result.url}`);
         for (const dashboard of result.dashboards) {
-          console.log(`  - ${dashboard.id} (${dashboard.name}) enabled=${dashboard.enabled ?? false}`);
+          console.log(
+            `  - ${dashboard.id} (${dashboard.name}) enabled=${dashboard.enabled ?? false}`,
+          );
         }
       }
     } catch (error) {
@@ -8461,12 +8473,7 @@ evaluationSettingsDashboards
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      dashboards: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; dashboards: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachEvaluationSettingsService(options.project);
         const dashboards = JSON.parse(options.dashboards) as { id: string; enabled: boolean }[];
@@ -8601,9 +8608,7 @@ weblayers
         }
       }
     } catch (error) {
-      console.error(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -8614,38 +8619,30 @@ weblayers
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--weblayer-id <id>', 'Weblayer ID')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      weblayerId: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachWeblayersService(options.project);
-        const result = await service.viewWeblayerPerformance({
-          project: options.project,
-          weblayerId: options.weblayerId,
-        });
+  .action(async (options: { project: string; weblayerId: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachWeblayersService(options.project);
+      const result = await service.viewWeblayerPerformance({
+        project: options.project,
+        weblayerId: options.weblayerId,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log(`Weblayer Performance: ${result.weblayerId}`);
-          console.log(`  Impressions:  ${result.impressions}`);
-          console.log(`  Clicks:       ${result.clicks}`);
-          console.log(`  Conversions:  ${result.conversions}`);
-          console.log(`  CTR:          ${(result.clickThroughRate * 100).toFixed(1)}%`);
-          console.log(`  Conv. Rate:   ${(result.conversionRate * 100).toFixed(1)}%`);
-          console.log(`  Revenue:      ${result.revenue}`);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Weblayer Performance: ${result.weblayerId}`);
+        console.log(`  Impressions:  ${result.impressions}`);
+        console.log(`  Clicks:       ${result.clicks}`);
+        console.log(`  Conversions:  ${result.conversions}`);
+        console.log(`  CTR:          ${(result.clickThroughRate * 100).toFixed(1)}%`);
+        console.log(`  Conv. Rate:   ${(result.conversionRate * 100).toFixed(1)}%`);
+        console.log(`  Revenue:      ${result.revenue}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 weblayers
   .command('create')
@@ -8697,9 +8694,7 @@ weblayers
             scrollPercentage: options.scrollPercentage
               ? parseInt(options.scrollPercentage, 10)
               : undefined,
-            frequencyCap: options.frequencyCap
-              ? parseInt(options.frequencyCap, 10)
-              : undefined,
+            frequencyCap: options.frequencyCap ? parseInt(options.frequencyCap, 10) : undefined,
           };
         }
 
@@ -8736,9 +8731,7 @@ weblayers
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -8752,12 +8745,7 @@ weblayers
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      weblayerId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; weblayerId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachWeblayersService(options.project);
         const result = service.prepareStartWeblayer({
@@ -8778,9 +8766,7 @@ weblayers
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -8794,12 +8780,7 @@ weblayers
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      weblayerId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; weblayerId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachWeblayersService(options.project);
         const result = service.prepareStopWeblayer({
@@ -8820,9 +8801,7 @@ weblayers
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -8866,9 +8845,7 @@ weblayers
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -8882,12 +8859,7 @@ weblayers
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
-    async (options: {
-      project: string;
-      weblayerId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
+    async (options: { project: string; weblayerId: string; note?: string; json?: boolean }) => {
       try {
         const service = new BloomreachWeblayersService(options.project);
         const result = service.prepareArchiveWeblayer({
@@ -8908,17 +8880,13 @@ weblayers
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
   );
 
-const reports = program
-  .command('reports')
-  .description('Manage Bloomreach Engagement reports');
+const reports = program.command('reports').description('Manage Bloomreach Engagement reports');
 
 reports
   .command('list')
@@ -8927,38 +8895,31 @@ reports
   )
   .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachReportsService(options.project);
-        const result = await service.listReports({ project: options.project });
+  .action(async (options: { project: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachReportsService(options.project);
+      const result = await service.listReports({ project: options.project });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No reports found.');
-            return;
-          }
-          for (const report of result) {
-            console.log(`  ${report.name}`);
-            console.log(`    Metrics:    ${report.metrics.join(', ')}`);
-            console.log(`    Dimensions: ${report.dimensions.join(', ')}`);
-            console.log(`    ID:         ${report.id}`);
-            console.log(`    URL:        ${report.url}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No reports found.');
+          return;
         }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+        for (const report of result) {
+          console.log(`  ${report.name}`);
+          console.log(`    Metrics:    ${report.metrics.join(', ')}`);
+          console.log(`    Dimensions: ${report.dimensions.join(', ')}`);
+          console.log(`    ID:         ${report.id}`);
+          console.log(`    URL:        ${report.url}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 reports
   .command('view-results')
@@ -9033,13 +8994,13 @@ reports
           console.log(`  Columns: ${result.columns.join(', ')}`);
           console.log(`  Rows:    ${result.rows.length} (total: ${result.totalRows})`);
           if (result.dateRange) {
-            console.log(`  Date range: ${result.dateRange.startDate ?? '?'} – ${result.dateRange.endDate ?? '?'}`);
+            console.log(
+              `  Date range: ${result.dateRange.startDate ?? '?'} – ${result.dateRange.endDate ?? '?'}`,
+            );
           }
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -9090,11 +9051,11 @@ reports
         } = {
           project: options.project,
           name: options.name,
-          metrics: options.metrics.split(',').map(m => m.trim()),
+          metrics: options.metrics.split(',').map((m) => m.trim()),
         };
 
         if (options.dimensions) {
-          input.dimensions = options.dimensions.split(',').map(d => d.trim());
+          input.dimensions = options.dimensions.split(',').map((d) => d.trim());
         }
 
         if (options.startDate || options.endDate) {
@@ -9137,9 +9098,7 @@ reports
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -9149,10 +9108,7 @@ reports
   .command('export')
   .description('Prepare export of a report (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption(
-    '--report-id <id>',
-    'Report analysis ID (hex string from Bloomreach UI URL)',
-  )
+  .requiredOption('--report-id <id>', 'Report analysis ID (hex string from Bloomreach UI URL)')
   .requiredOption('--format <format>', 'Export format (csv or xlsx)')
   .option('--start-date <date>', 'Start date (ISO-8601)')
   .option('--end-date <date>', 'End date (ISO-8601)')
@@ -9214,9 +9170,7 @@ reports
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -9226,10 +9180,7 @@ reports
   .command('clone')
   .description('Prepare cloning of a report (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption(
-    '--report-id <id>',
-    'Report analysis ID (hex string from Bloomreach UI URL)',
-  )
+  .requiredOption('--report-id <id>', 'Report analysis ID (hex string from Bloomreach UI URL)')
   .option('--new-name <name>', 'Name for the cloned report')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
@@ -9263,9 +9214,7 @@ reports
           console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
         }
       } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     },
@@ -9275,46 +9224,34 @@ reports
   .command('archive')
   .description('Prepare archiving of a report (two-phase commit)')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption(
-    '--report-id <id>',
-    'Report analysis ID (hex string from Bloomreach UI URL)',
-  )
+  .requiredOption('--report-id <id>', 'Report analysis ID (hex string from Bloomreach UI URL)')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: {
-      project: string;
-      reportId: string;
-      note?: string;
-      json?: boolean;
-    }) => {
-      try {
-        const service = new BloomreachReportsService(options.project);
-        const result = service.prepareArchiveReport({
-          project: options.project,
-          reportId: options.reportId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; reportId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachReportsService(options.project);
+      const result = service.prepareArchiveReport({
+        project: options.project,
+        reportId: options.reportId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Report archive prepared.');
-          console.log(`  Report: ${options.reportId}`);
-          console.log(`  Token:  ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Report archive prepared.');
+        console.log(`  Report: ${options.reportId}`);
+        console.log(`  Token:  ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 const segmentations = program
   .command('segmentations')
@@ -9595,7 +9532,10 @@ sqlReports
     'List all SQL reports in the project (note: the Bloomreach API does not provide a SQL reports endpoint — requires browser automation)',
   )
   .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
-  .option('--status <status>', 'Filter by report status: saved, running, completed, failed, archived')
+  .option(
+    '--status <status>',
+    'Filter by report status: saved, running, completed, failed, archived',
+  )
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; status?: string; json?: boolean }) => {
     try {
@@ -9664,7 +9604,10 @@ sqlReports
   .description('Prepare creation of a new SQL report (two-phase commit, UI-only)')
   .requiredOption('--project <project>', 'Bloomreach project token (UUID from Settings > Project)')
   .requiredOption('--name <name>', 'Report name (max 200 characters)')
-  .requiredOption('--query <sql>', 'SQL query string (e.g. "SELECT customer_id, email FROM customers LIMIT 100")')
+  .requiredOption(
+    '--query <sql>',
+    'SQL query string (e.g. "SELECT customer_id, email FROM customers LIMIT 100")',
+  )
   .option(
     '--parameters <json>',
     'Query parameters as JSON (e.g. \'{"start_date":"2026-01-01","end_date":"2026-01-31"}\')',
@@ -10025,7 +9968,10 @@ catalogs
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--catalog-id <id>', 'Catalog ID')
   .option('--items <json>', 'JSON array of catalog item property objects')
-  .option('--items-file <path>', 'Path to JSON file containing items array (alternative to --items)')
+  .option(
+    '--items-file <path>',
+    'Path to JSON file containing items array (alternative to --items)',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -10040,7 +9986,9 @@ catalogs
       try {
         let items: AddCatalogItemsInput['items'];
         if (options.itemsFile) {
-          items = JSON.parse(readFileSync(options.itemsFile, 'utf-8')) as AddCatalogItemsInput['items'];
+          items = JSON.parse(
+            readFileSync(options.itemsFile, 'utf-8'),
+          ) as AddCatalogItemsInput['items'];
         } else if (options.items) {
           items = JSON.parse(options.items) as AddCatalogItemsInput['items'];
         } else {
@@ -10082,7 +10030,10 @@ catalogs
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--catalog-id <id>', 'Catalog ID')
   .option('--items <json>', 'JSON array of item updates [{id, properties}]')
-  .option('--items-file <path>', 'Path to JSON file containing items array (alternative to --items)')
+  .option(
+    '--items-file <path>',
+    'Path to JSON file containing items array (alternative to --items)',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -10097,7 +10048,9 @@ catalogs
       try {
         let items: UpdateCatalogItemsInput['items'];
         if (options.itemsFile) {
-          items = JSON.parse(readFileSync(options.itemsFile, 'utf-8')) as UpdateCatalogItemsInput['items'];
+          items = JSON.parse(
+            readFileSync(options.itemsFile, 'utf-8'),
+          ) as UpdateCatalogItemsInput['items'];
         } else if (options.items) {
           items = JSON.parse(options.items) as UpdateCatalogItemsInput['items'];
         } else {
@@ -10169,15 +10122,16 @@ catalogs
     },
   );
 
-const imports = program
-  .command('imports')
-  .description('Manage Bloomreach data imports');
+const imports = program.command('imports').description('Manage Bloomreach data imports');
 
 imports
   .command('list')
   .description('List all data imports in the project')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .option('--status <status>', 'Filter by status (pending, processing, completed, failed, cancelled, scheduled)')
+  .option(
+    '--status <status>',
+    'Filter by status (pending, processing, completed, failed, cancelled, scheduled)',
+  )
   .option('--type <type>', 'Filter by type (csv, api)')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; status?: string; type?: string; json?: boolean }) => {
@@ -10271,7 +10225,10 @@ imports
   .requiredOption('--name <name>', 'Import name')
   .requiredOption('--type <type>', 'Import type (csv, api)')
   .requiredOption('--source <source>', 'Data source URL (CSV file URL or API endpoint)')
-  .requiredOption('--mapping <json>', 'JSON array of mappings [{sourceColumn, targetProperty, transformationType?}]')
+  .requiredOption(
+    '--mapping <json>',
+    'JSON array of mappings [{sourceColumn, targetProperty, transformationType?}]',
+  )
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
@@ -10325,7 +10282,10 @@ imports
   .requiredOption('--name <name>', 'Import name')
   .requiredOption('--type <type>', 'Import type (csv, api)')
   .requiredOption('--source <source>', 'Data source URL (CSV file URL or API endpoint)')
-  .requiredOption('--mapping <json>', 'JSON array of mappings [{sourceColumn, targetProperty, transformationType?}]')
+  .requiredOption(
+    '--mapping <json>',
+    'JSON array of mappings [{sourceColumn, targetProperty, transformationType?}]',
+  )
   .requiredOption('--frequency <frequency>', 'Schedule frequency (daily, weekly, monthly, custom)')
   .option('--cron <expression>', 'Cron expression for custom frequency')
   .option('--start-date <date>', 'Schedule start date (YYYY-MM-DD)')
@@ -10397,34 +10357,32 @@ imports
   .requiredOption('--import-id <id>', 'Import ID to cancel')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; importId: string; note?: string; json?: boolean }) => {
-      try {
-        const apiConfig = tryResolveApiConfig(options.project);
-        const service = new BloomreachImportsService(options.project, apiConfig);
-        const result = service.prepareCancelImport({
-          project: options.project,
-          importId: options.importId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; importId: string; note?: string; json?: boolean }) => {
+    try {
+      const apiConfig = tryResolveApiConfig(options.project);
+      const service = new BloomreachImportsService(options.project, apiConfig);
+      const result = service.prepareCancelImport({
+        project: options.project,
+        importId: options.importId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Import cancellation prepared.');
-          console.log(`  Import: ${options.importId}`);
-          console.log(`  Token:  ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Import cancellation prepared.');
+        console.log(`  Import: ${options.importId}`);
+        console.log(`  Token:  ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 const useCases = program
   .command('use-cases')
@@ -10434,52 +10392,56 @@ useCases
   .command('list')
   .description('List all available use case templates')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .option('--category <category>', 'Filter by goal category (awareness, acquisition, retention, optimization)')
+  .option(
+    '--category <category>',
+    'Filter by goal category (awareness, acquisition, retention, optimization)',
+  )
   .option('--tag <tag>', 'Filter by tag (new, essentials, popular)')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; category?: string; tag?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachUseCasesService(options.project);
-        const input: { project: string; category?: string; tag?: string } = {
-          project: options.project,
-        };
-        if (options.category) input.category = options.category;
-        if (options.tag) input.tag = options.tag;
+  .action(async (options: { project: string; category?: string; tag?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachUseCasesService(options.project);
+      const input: { project: string; category?: string; tag?: string } = {
+        project: options.project,
+      };
+      if (options.category) input.category = options.category;
+      if (options.tag) input.tag = options.tag;
 
-        const result = await service.listUseCases(input);
+      const result = await service.listUseCases(input);
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          if (result.length === 0) {
-            console.log('No use cases found.');
-            return;
-          }
-          for (const useCase of result) {
-            console.log(`  ${useCase.name}`);
-            console.log(`    Category: ${useCase.goalCategory}`);
-            console.log(`    Tags:     ${useCase.tags.join(', ')}`);
-            if (useCase.readinessStatus) {
-              console.log(`    Ready:    ${useCase.readinessStatus}`);
-            }
-            console.log(`    ID:       ${useCase.id}`);
-            console.log(`    URL:      ${useCase.url}`);
-          }
+      if (options.json) {
+        printJson(result);
+      } else {
+        if (result.length === 0) {
+          console.log('No use cases found.');
+          return;
         }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+        for (const useCase of result) {
+          console.log(`  ${useCase.name}`);
+          console.log(`    Category: ${useCase.goalCategory}`);
+          console.log(`    Tags:     ${useCase.tags.join(', ')}`);
+          if (useCase.readinessStatus) {
+            console.log(`    Ready:    ${useCase.readinessStatus}`);
+          }
+          console.log(`    ID:       ${useCase.id}`);
+          console.log(`    URL:      ${useCase.url}`);
+        }
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 useCases
   .command('search')
   .description('Search use case templates by keyword')
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--query <query>', 'Search keyword')
-  .option('--category <category>', 'Filter by goal category (awareness, acquisition, retention, optimization)')
+  .option(
+    '--category <category>',
+    'Filter by goal category (awareness, acquisition, retention, optimization)',
+  )
   .option('--tag <tag>', 'Filter by tag (new, essentials, popular)')
   .option('--json', 'Output as JSON')
   .action(
@@ -10837,33 +10799,31 @@ access
   .requiredOption('--member-id <id>', 'Team member ID')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; memberId: string; note?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachAccessManagementService(options.project);
-        const result = service.prepareRemoveTeamMember({
-          project: options.project,
-          memberId: options.memberId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; memberId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAccessManagementService(options.project);
+      const result = service.prepareRemoveTeamMember({
+        project: options.project,
+        memberId: options.memberId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('Team member removal prepared.');
-          console.log(`  Member ID: ${options.memberId}`);
-          console.log(`  Token:     ${result.confirmToken}`);
-          console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('Team member removal prepared.');
+        console.log(`  Member ID: ${options.memberId}`);
+        console.log(`  Token:     ${result.confirmToken}`);
+        console.log(`  Expires:   ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 access
   .command('list-api-keys')
@@ -10901,33 +10861,31 @@ access
   .requiredOption('--name <name>', 'API key name')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; name: string; note?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachAccessManagementService(options.project);
-        const result = service.prepareCreateApiKey({
-          project: options.project,
-          name: options.name,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; name: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAccessManagementService(options.project);
+      const result = service.prepareCreateApiKey({
+        project: options.project,
+        name: options.name,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('API key creation prepared.');
-          console.log(`  Name:    ${options.name}`);
-          console.log(`  Token:   ${result.confirmToken}`);
-          console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('API key creation prepared.');
+        console.log(`  Name:    ${options.name}`);
+        console.log(`  Token:   ${result.confirmToken}`);
+        console.log(`  Expires: ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 access
   .command('delete-api-key')
@@ -10936,32 +10894,30 @@ access
   .requiredOption('--api-key-id <id>', 'API key ID')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
-  .action(
-    async (options: { project: string; apiKeyId: string; note?: string; json?: boolean }) => {
-      try {
-        const service = new BloomreachAccessManagementService(options.project);
-        const result = service.prepareDeleteApiKey({
-          project: options.project,
-          apiKeyId: options.apiKeyId,
-          operatorNote: options.note,
-        });
+  .action(async (options: { project: string; apiKeyId: string; note?: string; json?: boolean }) => {
+    try {
+      const service = new BloomreachAccessManagementService(options.project);
+      const result = service.prepareDeleteApiKey({
+        project: options.project,
+        apiKeyId: options.apiKeyId,
+        operatorNote: options.note,
+      });
 
-        if (options.json) {
-          printJson(result);
-        } else {
-          console.log('API key deletion prepared.');
-          console.log(`  API key ID: ${options.apiKeyId}`);
-          console.log(`  Token:      ${result.confirmToken}`);
-          console.log(`  Expires:    ${new Date(result.expiresAtMs).toISOString()}`);
-          console.log('');
-          console.log('To confirm, run:');
-          console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
-        }
-      } catch (error) {
-        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log('API key deletion prepared.');
+        console.log(`  API key ID: ${options.apiKeyId}`);
+        console.log(`  Token:      ${result.confirmToken}`);
+        console.log(`  Expires:    ${new Date(result.expiresAtMs).toISOString()}`);
+        console.log('');
+        console.log('To confirm, run:');
+        console.log(`  bloomreach actions confirm --token ${result.confirmToken}`);
       }
-    },
-  );
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/packages/core/src/__tests__/bloomreachMetrics.test.ts
+++ b/packages/core/src/__tests__/bloomreachMetrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_METRIC_ACTION_TYPE,
   EDIT_METRIC_ACTION_TYPE,
@@ -16,6 +16,18 @@ import {
   createMetricActionExecutors,
   BloomreachMetricsService,
 } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const validateMetricDescription = validateDescription;
 
@@ -77,6 +89,10 @@ describe('validateMetricName', () => {
     expect(validateMetricName(name)).toBe(name);
   });
 
+  it('accepts mixed whitespace around valid name', () => {
+    expect(validateMetricName(' \t  Revenue Metric \n ')).toBe('Revenue Metric');
+  });
+
   it('throws for empty string', () => {
     expect(() => validateMetricName('')).toThrow('must not be empty');
   });
@@ -87,6 +103,10 @@ describe('validateMetricName', () => {
 
   it('throws for tab-only string', () => {
     expect(() => validateMetricName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateMetricName('\n\n')).toThrow('must not be empty');
   });
 
   it('throws for name exceeding maximum length', () => {
@@ -108,6 +128,10 @@ describe('validateMetricId', () => {
     expect(validateMetricId('metric/group/a')).toBe('metric/group/a');
   });
 
+  it('returns ID containing dots and dashes', () => {
+    expect(validateMetricId('metric.v2-alpha')).toBe('metric.v2-alpha');
+  });
+
   it('throws for empty string', () => {
     expect(() => validateMetricId('')).toThrow('must not be empty');
   });
@@ -118,6 +142,10 @@ describe('validateMetricId', () => {
 
   it('throws for newline-only string', () => {
     expect(() => validateMetricId('\n')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateMetricId('\t')).toThrow('must not be empty');
   });
 });
 
@@ -143,9 +171,7 @@ describe('validateDescription', () => {
 
   it('throws for description exceeding max length', () => {
     const description = 'x'.repeat(1001);
-    expect(() => validateMetricDescription(description)).toThrow(
-      'must not exceed 1000 characters',
-    );
+    expect(() => validateMetricDescription(description)).toThrow('must not exceed 1000 characters');
   });
 });
 
@@ -404,6 +430,31 @@ describe('createMetricActionExecutors', () => {
       'not yet implemented',
     );
   });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createMetricActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(3);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createMetricActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+
+  it('returns identical action keys with or without apiConfig', () => {
+    const withoutConfig = Object.keys(createMetricActionExecutors()).sort();
+    const withConfig = Object.keys(createMetricActionExecutors(TEST_API_CONFIG)).sort();
+    expect(withConfig).toEqual(withoutConfig);
+  });
+
+  it('preserves actionType mapping with apiConfig', () => {
+    const executors = createMetricActionExecutors(TEST_API_CONFIG);
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
 });
 
 describe('BloomreachMetricsService', () => {
@@ -435,12 +486,32 @@ describe('BloomreachMetricsService', () => {
       const service = new BloomreachMetricsService('org/project');
       expect(service.metricsUrl).toBe('/p/org%2Fproject/data/metrics');
     });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachMetricsService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachMetricsService);
+    });
+
+    it('exposes metrics URL when constructed with apiConfig', () => {
+      const service = new BloomreachMetricsService('test', TEST_API_CONFIG);
+      expect(service.metricsUrl).toBe('/p/test/data/metrics');
+    });
+
+    it('encodes unicode project name in constructor URL', () => {
+      const service = new BloomreachMetricsService('projekt åäö');
+      expect(service.metricsUrl).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/data/metrics');
+    });
+
+    it('encodes hash in constructor URL', () => {
+      const service = new BloomreachMetricsService('my#project');
+      expect(service.metricsUrl).toBe('/p/my%23project/data/metrics');
+    });
   });
 
   describe('listMetrics', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachMetricsService('test');
-      await expect(service.listMetrics()).rejects.toThrow('not yet implemented');
+      await expect(service.listMetrics()).rejects.toThrow('does not provide an endpoint');
     });
 
     it('validates project when input is provided', async () => {
@@ -453,23 +524,35 @@ describe('BloomreachMetricsService', () => {
       await expect(service.listMetrics({ project: '   ' })).rejects.toThrow('must not be empty');
     });
 
-    it('throws not-yet-implemented error for valid project override', async () => {
+    it('throws no-API-endpoint error for valid project override', async () => {
       const service = new BloomreachMetricsService('test');
       await expect(service.listMetrics({ project: 'kingdom-of-joakim' })).rejects.toThrow(
-        'not yet implemented',
+        'does not provide an endpoint',
       );
+    });
+
+    it('throws no-API-endpoint error for trimmed project override', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(service.listMetrics({ project: '  kingdom-of-joakim  ' })).rejects.toThrow(
+        'does not provide an endpoint',
+      );
+    });
+
+    it('throws no-API-endpoint error when service has apiConfig', async () => {
+      const service = new BloomreachMetricsService('test', TEST_API_CONFIG);
+      await expect(service.listMetrics()).rejects.toThrow('does not provide an endpoint');
     });
   });
 
   describe('viewMetricResults', () => {
-    it('throws not-yet-implemented error with valid minimal input', async () => {
+    it('throws no-API-endpoint error with valid minimal input', async () => {
       const service = new BloomreachMetricsService('test');
       await expect(
         service.viewMetricResults({
           project: 'test',
           metricId: 'metric-1',
         }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide an endpoint');
     });
 
     it('validates project input', async () => {
@@ -502,14 +585,90 @@ describe('BloomreachMetricsService', () => {
       ).rejects.toThrow('Metric ID must not be empty');
     });
 
-    it('accepts trimmed metricId and reaches not-yet-implemented', async () => {
+    it('accepts trimmed metricId and reaches no-API-endpoint error', async () => {
       const service = new BloomreachMetricsService('test');
       await expect(
         service.viewMetricResults({
           project: 'test',
           metricId: '  metric-99  ',
         }),
-      ).rejects.toThrow('not yet implemented');
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('validates date range: malformed startDate', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+          startDate: 'bad-date',
+        }),
+      ).rejects.toThrow('startDate must be a valid ISO-8601 date');
+    });
+
+    it('validates date range: malformed endDate', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+          endDate: '31-01-2025',
+        }),
+      ).rejects.toThrow('endDate must be a valid ISO-8601 date');
+    });
+
+    it('validates date range: startDate must not be after endDate', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+          startDate: '2025-02-01',
+          endDate: '2025-01-01',
+        }),
+      ).rejects.toThrow('must not be after');
+    });
+
+    it('accepts only startDate and still reaches no-API-endpoint error', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+          startDate: '2025-01-01',
+        }),
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('accepts only endDate and still reaches no-API-endpoint error', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+          endDate: '2025-01-31',
+        }),
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error with trimmed project and metricId', async () => {
+      const service = new BloomreachMetricsService('test');
+      await expect(
+        service.viewMetricResults({
+          project: '  test  ',
+          metricId: '  metric-1  ',
+        }),
+      ).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error when service has apiConfig', async () => {
+      const service = new BloomreachMetricsService('test', TEST_API_CONFIG);
+      await expect(
+        service.viewMetricResults({
+          project: 'test',
+          metricId: 'metric-1',
+        }),
+      ).rejects.toThrow('does not provide an endpoint');
     });
   });
 
@@ -767,6 +926,40 @@ describe('BloomreachMetricsService', () => {
         }),
       );
     });
+
+    it('accepts slash-containing project after trim', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: '  org/project  ',
+        name: 'Metric',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'count',
+        },
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'org/project',
+        }),
+      );
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareCreateMetric({
+        project: 'test',
+        name: 'Metric',
+        aggregation: {
+          eventName: 'purchase',
+          aggregationType: 'count',
+        },
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
   });
 
   describe('prepareEditMetric', () => {
@@ -896,6 +1089,74 @@ describe('BloomreachMetricsService', () => {
         }),
       ).toThrow('must not be empty');
     });
+
+    it('trims metricId in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: '  metric-123  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          metricId: 'metric-123',
+        }),
+      );
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: '  my-project  ',
+        metricId: 'metric-123',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+        }),
+      );
+    });
+
+    it('accepts slash-containing metricId after trim', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: '  metric/group/a  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          metricId: 'metric/group/a',
+        }),
+      );
+    });
+
+    it('accepts dots and dashes in metricId after trim', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: '  metric.v2-alpha  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          metricId: 'metric.v2-alpha',
+        }),
+      );
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareEditMetric({
+        project: 'test',
+        metricId: 'metric-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
   });
 
   describe('prepareDeleteMetric', () => {
@@ -983,6 +1244,89 @@ describe('BloomreachMetricsService', () => {
       expect(result.preview).toEqual(
         expect.objectContaining({
           metricId: 'metric-900',
+        }),
+      );
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: '  my-project  ',
+        metricId: 'metric-900',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'my-project',
+        }),
+      );
+    });
+
+    it('keeps slash-containing metricId after trim', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: '  metric/group/a  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          metricId: 'metric/group/a',
+        }),
+      );
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: 'metric-900',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+
+    it('accepts dotted metricId in delete preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: ' metric.v2-alpha ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          metricId: 'metric.v2-alpha',
+        }),
+      );
+    });
+
+    it('keeps operatorNote as-is in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: 'test',
+        metricId: 'metric-900',
+        operatorNote: '  remove after migration  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: '  remove after migration  ',
+        }),
+      );
+    });
+
+    it('accepts slash-containing project in preview', () => {
+      const service = new BloomreachMetricsService('test');
+      const result = service.prepareDeleteMetric({
+        project: ' org/project ',
+        metricId: 'metric-900',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          project: 'org/project',
         }),
       );
     });

--- a/packages/core/src/bloomreachMetrics.ts
+++ b/packages/core/src/bloomreachMetrics.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 
@@ -89,20 +90,8 @@ export interface PreparedMetricAction {
 const MAX_METRIC_NAME_LENGTH = 200;
 const MIN_METRIC_NAME_LENGTH = 1;
 const MAX_DESCRIPTION_LENGTH = 1000;
-const AGGREGATION_TYPES = new Set([
-  'sum',
-  'count',
-  'average',
-  'min',
-  'max',
-  'unique',
-]);
-const PROPERTY_REQUIRED_AGGREGATION_TYPES = new Set([
-  'sum',
-  'average',
-  'min',
-  'max',
-]);
+const AGGREGATION_TYPES = new Set(['sum', 'count', 'average', 'min', 'max', 'unique']);
+const PROPERTY_REQUIRED_AGGREGATION_TYPES = new Set(['sum', 'average', 'min', 'max']);
 
 export function validateMetricName(name: string): string {
   const trimmed = name.trim();
@@ -151,9 +140,7 @@ export function validateAggregationType(type: string): string {
   return normalized;
 }
 
-export function validateAggregation(
-  aggregation: MetricAggregation,
-): MetricAggregation {
+export function validateAggregation(aggregation: MetricAggregation): MetricAggregation {
   const eventName = aggregation.eventName.trim();
   if (eventName.length === 0) {
     throw new Error('Aggregation eventName must not be empty.');
@@ -166,9 +153,7 @@ export function validateAggregation(
     PROPERTY_REQUIRED_AGGREGATION_TYPES.has(aggregationType) &&
     (propertyName === undefined || propertyName.length === 0)
   ) {
-    throw new Error(
-      `aggregation.propertyName is required for aggregationType ${aggregationType}.`,
-    );
+    throw new Error(`aggregation.propertyName is required for aggregationType ${aggregationType}.`);
   }
 
   if (propertyName !== undefined && propertyName.length === 0) {
@@ -186,6 +171,21 @@ export function buildMetricsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/data/metrics`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
+void requireApiConfig;
+
 export interface MetricActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -193,53 +193,72 @@ export interface MetricActionExecutor {
 
 class CreateMetricExecutor implements MetricActionExecutor {
   readonly actionType = CREATE_METRIC_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateMetricExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateMetricExecutor: not yet implemented. ' +
+        'Metric creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class EditMetricExecutor implements MetricActionExecutor {
   readonly actionType = EDIT_METRIC_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'EditMetricExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'EditMetricExecutor: not yet implemented. ' +
+        'Metric editing is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class DeleteMetricExecutor implements MetricActionExecutor {
   readonly actionType = DELETE_METRIC_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  async execute(
-    _payload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'DeleteMetricExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'DeleteMetricExecutor: not yet implemented. ' +
+        'Metric deletion is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createMetricActionExecutors(): Record<string, MetricActionExecutor> {
+export function createMetricActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, MetricActionExecutor> {
   return {
-    [CREATE_METRIC_ACTION_TYPE]: new CreateMetricExecutor(),
-    [EDIT_METRIC_ACTION_TYPE]: new EditMetricExecutor(),
-    [DELETE_METRIC_ACTION_TYPE]: new DeleteMetricExecutor(),
+    [CREATE_METRIC_ACTION_TYPE]: new CreateMetricExecutor(apiConfig),
+    [EDIT_METRIC_ACTION_TYPE]: new EditMetricExecutor(apiConfig),
+    [DELETE_METRIC_ACTION_TYPE]: new DeleteMetricExecutor(apiConfig),
   };
 }
 
 export class BloomreachMetricsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildMetricsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get metricsUrl(): string {
@@ -247,16 +266,20 @@ export class BloomreachMetricsService {
   }
 
   async listMetrics(input?: ListMetricsInput): Promise<BloomreachMetric[]> {
+    void this.apiConfig;
     if (input !== undefined) {
       validateProject(input.project);
     }
 
     throw new Error(
-      'listMetrics: not yet implemented. Requires browser automation infrastructure.',
+      'listMetrics: the Bloomreach API does not provide an endpoint for metrics. ' +
+        'Metric data must be obtained from the Bloomreach Engagement UI ' +
+        '(navigate to Data & Assets > Metrics in your project).',
     );
   }
 
   async viewMetricResults(input: ViewMetricResultsInput): Promise<MetricResults> {
+    void this.apiConfig;
     validateProject(input.project);
     validateMetricId(input.metricId);
 
@@ -269,7 +292,9 @@ export class BloomreachMetricsService {
     }
 
     throw new Error(
-      'viewMetricResults: not yet implemented. Requires browser automation infrastructure.',
+      'viewMetricResults: the Bloomreach API does not provide an endpoint for metric results. ' +
+        'Metric results must be viewed in the Bloomreach Engagement UI ' +
+        '(navigate to Data & Assets > Metrics and open the metric).',
     );
   }
 
@@ -277,9 +302,7 @@ export class BloomreachMetricsService {
     const project = validateProject(input.project);
     const name = validateMetricName(input.name);
     const description =
-      input.description === undefined
-        ? undefined
-        : validateDescription(input.description);
+      input.description === undefined ? undefined : validateDescription(input.description);
     const aggregation = validateAggregation(input.aggregation);
 
     const preview = {
@@ -303,16 +326,11 @@ export class BloomreachMetricsService {
   prepareEditMetric(input: EditMetricInput): PreparedMetricAction {
     const project = validateProject(input.project);
     const metricId = validateMetricId(input.metricId);
-    const name =
-      input.name === undefined ? undefined : validateMetricName(input.name);
+    const name = input.name === undefined ? undefined : validateMetricName(input.name);
     const description =
-      input.description === undefined
-        ? undefined
-        : validateDescription(input.description);
+      input.description === undefined ? undefined : validateDescription(input.description);
     const aggregation =
-      input.aggregation === undefined
-        ? undefined
-        : validateAggregation(input.aggregation);
+      input.aggregation === undefined ? undefined : validateAggregation(input.aggregation);
 
     const preview = {
       action: EDIT_METRIC_ACTION_TYPE,


### PR DESCRIPTION
## Summary

Acid test for the Metrics module — wires `BloomreachApiConfig` infrastructure, improves error messages for UI-only operations, and expands test coverage.

## Changes

### Core Module (`packages/core/src/bloomreachMetrics.ts`)
- Import `BloomreachApiConfig` type and wire to all executors and service class
- Add `requireApiConfig()` helper function for future API credential validation
- Update executor error messages: clearly state metric operations are UI-only
- Update async method errors: explain that the Bloomreach API does not provide metrics endpoints
- Add `void this.apiConfig` pattern in execute/async methods (matches `bloomreachTrends.ts` convention)

### Tests (`packages/core/src/__tests__/bloomreachMetrics.test.ts`)
- **108 → 142 tests** (+34 new tests)
- Add `BloomreachApiConfig` test fixture and `vi.restoreAllMocks()` afterEach hook
- Add apiConfig tests for `createMetricActionExecutors()`: accepts config, same keys, still throws
- Add apiConfig tests for `BloomreachMetricsService`: constructor, URL exposure, method behavior
- Expand validator edge cases: mixed whitespace, newline-only, tab-only, dots/dashes in IDs
- Add date range validation tests for `viewMetricResults`
- Add token prefix and project encoding tests for prepare methods
- Update error assertions: "not yet implemented" → "does not provide an endpoint"

### CLI (`packages/cli/src/bin/bloomreach.ts`)
- Improve `metrics list` description: note UI-only / no API endpoint
- Improve `metrics create` description: document aggregation types and propertyName requirements
- Improve `metrics edit` description: clarify partial update semantics
- Improve `metrics delete` description: warn about irreversibility
- Prettier formatting applied to entire CLI file

## Test Results
- **142/142 metrics tests pass**
- **7532/7532 total tests pass** (72 test files)
- Build succeeds
- Lint clean on changed files
- Typecheck: pre-existing errors only (vitest/node type resolution)

Closes #116
