### PR TITLE
feat #118: acid test dashboards module — apiConfig wiring, improved errors, expanded tests

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -119,7 +119,10 @@ const dashboards = program
 
 dashboards
   .command('list')
-  .description('List all dashboards in the project')
+  .description(
+    'List all dashboards in the project ' +
+      '(note: the Bloomreach API does not provide a dashboards endpoint — requires browser automation)',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .option('--json', 'Output as JSON')
   .action(async (options: { project: string; json?: boolean }) => {
@@ -149,17 +152,22 @@ dashboards
 
 dashboards
   .command('create')
-  .description('Prepare creation of a new dashboard (two-phase commit)')
+  .description(
+    'Prepare creation of a new dashboard (two-phase commit). ' +
+      'Dashboard name max 200 characters. Layout grid supports 1–6 columns (default: 2).',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
-  .requiredOption('--name <name>', 'Dashboard name')
+  .requiredOption('--name <name>', 'Dashboard name (1–200 characters)')
+  .option('--description <desc>', 'Dashboard description')
   .option('--analyses <json>', 'JSON array of analyses [{id, name}]')
-  .option('--layout-columns <n>', 'Number of grid columns (1-6)', '2')
+  .option('--layout-columns <n>', 'Number of grid columns (1–6, default: 2)', '2')
   .option('--note <note>', 'Operator note for audit trail')
   .option('--json', 'Output as JSON')
   .action(
     async (options: {
       project: string;
       name: string;
+      description?: string;
       analyses?: string;
       layoutColumns: string;
       note?: string;
@@ -174,6 +182,7 @@ dashboards
         const result = service.prepareCreateDashboard({
           project: options.project,
           name: options.name,
+          description: options.description,
           analyses,
           layout: { columns: parseInt(options.layoutColumns, 10) },
           operatorNote: options.note,
@@ -199,7 +208,10 @@ dashboards
 
 dashboards
   .command('set-home')
-  .description('Prepare setting a dashboard as the project home (two-phase commit)')
+  .description(
+    'Prepare setting a dashboard as the project home (two-phase commit). ' +
+      'Requires the dashboard ID.',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--dashboard-id <id>', 'Dashboard ID to set as home')
   .option('--note <note>', 'Operator note for audit trail')
@@ -234,7 +246,10 @@ dashboards
 
 dashboards
   .command('delete')
-  .description('Prepare deletion of a dashboard (two-phase commit)')
+  .description(
+    'Prepare deletion of a dashboard (two-phase commit). ' +
+      'This action is irreversible once confirmed.',
+  )
   .requiredOption('--project <project>', 'Bloomreach project identifier')
   .requiredOption('--dashboard-id <id>', 'Dashboard ID to delete')
   .option('--note <note>', 'Operator note for audit trail')

--- a/packages/core/src/__tests__/bloomreachDashboards.test.ts
+++ b/packages/core/src/__tests__/bloomreachDashboards.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   CREATE_DASHBOARD_ACTION_TYPE,
   SET_HOME_DASHBOARD_ACTION_TYPE,
@@ -13,6 +13,18 @@ import {
   createDashboardActionExecutors,
   BloomreachDashboardsService,
 } from '../index.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports CREATE_DASHBOARD_ACTION_TYPE', () => {
@@ -68,6 +80,18 @@ describe('validateDashboardName', () => {
     const name = 'x'.repeat(201);
     expect(() => validateDashboardName(name)).toThrow('must not exceed 200 characters');
   });
+
+  it('accepts mixed whitespace around valid name', () => {
+    expect(validateDashboardName(' \t  My Dashboard \n ')).toBe('My Dashboard');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateDashboardName('\n\n')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateDashboardName('\t\t')).toThrow('must not be empty');
+  });
 });
 
 describe('validateProject', () => {
@@ -81,6 +105,14 @@ describe('validateProject', () => {
 
   it('throws for whitespace-only string', () => {
     expect(() => validateProject('   ')).toThrow('must not be empty');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateProject('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateProject('\n\n')).toThrow('must not be empty');
   });
 });
 
@@ -112,6 +144,10 @@ describe('validateLayoutConfig', () => {
   it('throws for non-integer column count', () => {
     expect(() => validateLayoutConfig({ columns: 2.5 })).toThrow('between 1 and 6');
   });
+
+  it('throws for negative column count', () => {
+    expect(() => validateLayoutConfig({ columns: -1 })).toThrow('between 1 and 6');
+  });
 });
 
 describe('buildDashboardsUrl', () => {
@@ -125,6 +161,14 @@ describe('buildDashboardsUrl', () => {
 
   it('handles project name with slashes', () => {
     expect(buildDashboardsUrl('org/project')).toBe('/p/org%2Fproject/dashboards');
+  });
+
+  it('encodes unicode characters in project name', () => {
+    expect(buildDashboardsUrl('projekt åäö')).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/dashboards');
+  });
+
+  it('encodes hash in project name', () => {
+    expect(buildDashboardsUrl('my#project')).toBe('/p/my%23project/dashboards');
   });
 });
 
@@ -150,6 +194,31 @@ describe('createDashboardActionExecutors', () => {
       await expect(executor.execute({})).rejects.toThrow('not yet implemented');
     }
   });
+
+  it('accepts optional apiConfig parameter', () => {
+    const executors = createDashboardActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(3);
+  });
+
+  it('executors still throw not-yet-implemented with apiConfig', async () => {
+    const executors = createDashboardActionExecutors(TEST_API_CONFIG);
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow('not yet implemented');
+    }
+  });
+
+  it('returns identical action keys with or without apiConfig', () => {
+    const withoutConfig = Object.keys(createDashboardActionExecutors()).sort();
+    const withConfig = Object.keys(createDashboardActionExecutors(TEST_API_CONFIG)).sort();
+    expect(withConfig).toEqual(withoutConfig);
+  });
+
+  it('preserves actionType mapping with apiConfig', () => {
+    const executors = createDashboardActionExecutors(TEST_API_CONFIG);
+    for (const [key, executor] of Object.entries(executors)) {
+      expect(executor.actionType).toBe(key);
+    }
+  });
 });
 
 describe('BloomreachDashboardsService', () => {
@@ -172,12 +241,41 @@ describe('BloomreachDashboardsService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachDashboardsService('')).toThrow('must not be empty');
     });
+
+    it('throws for whitespace-only project', () => {
+      expect(() => new BloomreachDashboardsService('   ')).toThrow('must not be empty');
+    });
+
+    it('accepts apiConfig as second parameter', () => {
+      const service = new BloomreachDashboardsService('test', TEST_API_CONFIG);
+      expect(service).toBeInstanceOf(BloomreachDashboardsService);
+    });
+
+    it('exposes dashboards URL when constructed with apiConfig', () => {
+      const service = new BloomreachDashboardsService('test', TEST_API_CONFIG);
+      expect(service.dashboardsUrl).toBe('/p/test/dashboards');
+    });
+
+    it('encodes unicode project name in constructor URL', () => {
+      const service = new BloomreachDashboardsService('projekt åäö');
+      expect(service.dashboardsUrl).toBe('/p/projekt%20%C3%A5%C3%A4%C3%B6/dashboards');
+    });
+
+    it('encodes hash in constructor URL', () => {
+      const service = new BloomreachDashboardsService('my#project');
+      expect(service.dashboardsUrl).toBe('/p/my%23project/dashboards');
+    });
   });
 
   describe('listDashboards', () => {
-    it('throws not-yet-implemented error', async () => {
+    it('throws no-API-endpoint error', async () => {
       const service = new BloomreachDashboardsService('test');
-      await expect(service.listDashboards()).rejects.toThrow('not yet implemented');
+      await expect(service.listDashboards()).rejects.toThrow('does not provide an endpoint');
+    });
+
+    it('throws no-API-endpoint error when service has apiConfig', async () => {
+      const service = new BloomreachDashboardsService('test', TEST_API_CONFIG);
+      await expect(service.listDashboards()).rejects.toThrow('does not provide an endpoint');
     });
   });
 
@@ -274,6 +372,51 @@ describe('BloomreachDashboardsService', () => {
         }),
       ).toThrow('between 1 and 6');
     });
+
+    it('includes description in preview when provided', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+        description: 'Weekly performance overview',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ description: 'Weekly performance overview' }),
+      );
+    });
+
+    it('preview has undefined description when not provided', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ description: undefined }));
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: '  my-project  ',
+        name: 'Dashboard',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ project: 'my-project' }));
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareCreateDashboard({
+        project: 'test',
+        name: 'Dashboard',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
   });
 
   describe('prepareSetHomeDashboard', () => {
@@ -321,6 +464,50 @@ describe('BloomreachDashboardsService', () => {
         service.prepareSetHomeDashboard({ project: '', dashboardId: 'dash-123' }),
       ).toThrow('must not be empty');
     });
+
+    it('trims dashboardId in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareSetHomeDashboard({
+        project: 'test',
+        dashboardId: '  dash-123  ',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ dashboardId: 'dash-123' }));
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareSetHomeDashboard({
+        project: '  my-project  ',
+        dashboardId: 'dash-123',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ project: 'my-project' }));
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareSetHomeDashboard({
+        project: 'test',
+        dashboardId: 'dash-123',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+
+    it('accepts dots and dashes in dashboardId', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareSetHomeDashboard({
+        project: 'test',
+        dashboardId: 'dash.v2-alpha',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ dashboardId: 'dash.v2-alpha' }),
+      );
+    });
   });
 
   describe('prepareDeleteDashboard', () => {
@@ -361,6 +548,50 @@ describe('BloomreachDashboardsService', () => {
       expect(() =>
         service.prepareDeleteDashboard({ project: '', dashboardId: 'dash-456' }),
       ).toThrow('must not be empty');
+    });
+
+    it('trims dashboardId in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareDeleteDashboard({
+        project: 'test',
+        dashboardId: '  dash-456  ',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ dashboardId: 'dash-456' }));
+    });
+
+    it('trims project in preview', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareDeleteDashboard({
+        project: '  my-project  ',
+        dashboardId: 'dash-456',
+      });
+
+      expect(result.preview).toEqual(expect.objectContaining({ project: 'my-project' }));
+    });
+
+    it('produces token fields with expected prefixes', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareDeleteDashboard({
+        project: 'test',
+        dashboardId: 'dash-456',
+      });
+
+      expect(result.preparedActionId).toMatch(/^pa_/);
+      expect(result.confirmToken).toMatch(/^ct_stub_/);
+      expect(result.expiresAtMs).toBeGreaterThan(Date.now());
+    });
+
+    it('accepts dots and dashes in dashboardId', () => {
+      const service = new BloomreachDashboardsService('test');
+      const result = service.prepareDeleteDashboard({
+        project: 'test',
+        dashboardId: 'dash.v2-alpha',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({ dashboardId: 'dash.v2-alpha' }),
+      );
     });
   });
 });

--- a/packages/core/src/bloomreachDashboards.ts
+++ b/packages/core/src/bloomreachDashboards.ts
@@ -1,3 +1,5 @@
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+
 export const CREATE_DASHBOARD_ACTION_TYPE = 'dashboards.create_dashboard';
 export const SET_HOME_DASHBOARD_ACTION_TYPE = 'dashboards.set_home_dashboard';
 export const DELETE_DASHBOARD_ACTION_TYPE = 'dashboards.delete_dashboard';
@@ -35,6 +37,7 @@ export interface ListDashboardsInput {
 export interface CreateDashboardInput {
   project: string;
   name: string;
+  description?: string;
   analyses?: DashboardAnalysis[];
   layout?: DashboardLayoutConfig;
   operatorNote?: string;
@@ -110,6 +113,21 @@ export function buildDashboardsUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/dashboards`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
+void requireApiConfig;
+
 /**
  * Executor for a confirmed dashboard mutation.
  * Execute methods require browser automation infrastructure (not yet built).
@@ -121,39 +139,62 @@ export interface DashboardActionExecutor {
 
 class CreateDashboardExecutor implements DashboardActionExecutor {
   readonly actionType = CREATE_DASHBOARD_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateDashboardExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateDashboardExecutor: not yet implemented. ' +
+        'Dashboard creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class SetHomeDashboardExecutor implements DashboardActionExecutor {
   readonly actionType = SET_HOME_DASHBOARD_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'SetHomeDashboardExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'SetHomeDashboardExecutor: not yet implemented. ' +
+        'Setting the home dashboard is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class DeleteDashboardExecutor implements DashboardActionExecutor {
   readonly actionType = DELETE_DASHBOARD_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'DeleteDashboardExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'DeleteDashboardExecutor: not yet implemented. ' +
+        'Dashboard deletion is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createDashboardActionExecutors(): Record<string, DashboardActionExecutor> {
+export function createDashboardActionExecutors(
+  apiConfig?: BloomreachApiConfig,
+): Record<string, DashboardActionExecutor> {
   return {
-    [CREATE_DASHBOARD_ACTION_TYPE]: new CreateDashboardExecutor(),
-    [SET_HOME_DASHBOARD_ACTION_TYPE]: new SetHomeDashboardExecutor(),
-    [DELETE_DASHBOARD_ACTION_TYPE]: new DeleteDashboardExecutor(),
+    [CREATE_DASHBOARD_ACTION_TYPE]: new CreateDashboardExecutor(apiConfig),
+    [SET_HOME_DASHBOARD_ACTION_TYPE]: new SetHomeDashboardExecutor(apiConfig),
+    [DELETE_DASHBOARD_ACTION_TYPE]: new DeleteDashboardExecutor(apiConfig),
   };
 }
 
@@ -164,9 +205,11 @@ export function createDashboardActionExecutors(): Record<string, DashboardAction
  */
 export class BloomreachDashboardsService {
   private readonly baseUrl: string;
+  private readonly apiConfig?: BloomreachApiConfig;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     this.baseUrl = buildDashboardsUrl(validateProject(project));
+    this.apiConfig = apiConfig;
   }
 
   get dashboardsUrl(): string {
@@ -175,8 +218,11 @@ export class BloomreachDashboardsService {
 
   /** @throws {Error} Browser automation not yet available. */
   async listDashboards(_input?: ListDashboardsInput): Promise<BloomreachDashboard[]> {
+    void this.apiConfig;
     throw new Error(
-      'listDashboards: not yet implemented. Requires browser automation infrastructure.',
+      'listDashboards: the Bloomreach API does not provide an endpoint for dashboards. ' +
+        'Dashboard data must be obtained from the Bloomreach Engagement UI ' +
+        '(navigate to Dashboards in your project).',
     );
   }
 
@@ -193,6 +239,7 @@ export class BloomreachDashboardsService {
       action: CREATE_DASHBOARD_ACTION_TYPE,
       project,
       name,
+      description: input.description,
       analysisCount: input.analyses?.length ?? 0,
       layout: input.layout ?? { columns: 2 },
       operatorNote: input.operatorNote,


### PR DESCRIPTION
## Summary

Acid test for the dashboards module — applies the established pattern (matching metrics #116, tag-manager #115, etc.) to wire `BloomreachApiConfig`, improve error messages, and expand test coverage.

## Changes

- **Core module** (`bloomreachDashboards.ts`):
  - Wire `BloomreachApiConfig` to all three executor classes and the service constructor
  - Add `requireApiConfig()` helper for future API credential validation
  - Update error messages: executors and `listDashboards()` now explain that dashboards are UI-only in Bloomreach
  - Add optional `description` field to `CreateDashboardInput` and include it in prepare preview

- **Tests** (`bloomreachDashboards.test.ts`):
  - Expand from **49 → 79 tests** (+30 new)
  - Add apiConfig tests for executors and service constructor
  - Add edge-case tests: mixed whitespace (tabs/newlines), unicode project names, hash encoding, negative columns, dots/dashes in IDs
  - Add trimming verification tests for prepare method previews
  - Add description field tests for `prepareCreateDashboard`
  - Update `listDashboards` assertion to match new error message

- **CLI** (`bloomreach.ts`):
  - Add `--description` option to `dashboards create` command
  - Improve command descriptions with UI-only notes and parameter constraints
  - Improve option help text with character limits and defaults

## Quality Gates

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 7724 tests passed (72 test files)
- ✅ `npm run build` — success

Closes #118
