### PR TITLE
feat #129: acid test access management — apiConfig wiring, improved errors, expanded tests

### DIFF
--- a/packages/core/src/__tests__/bloomreachAccessManagement.test.ts
+++ b/packages/core/src/__tests__/bloomreachAccessManagement.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
 import {
   INVITE_TEAM_MEMBER_ACTION_TYPE,
   UPDATE_MEMBER_ROLE_ACTION_TYPE,
@@ -20,6 +21,17 @@ import {
   createAccessActionExecutors,
   BloomreachAccessManagementService,
 } from '../index.js';
+
+const TEST_API_CONFIG: BloomreachApiConfig = {
+  projectToken: 'test-token-123',
+  apiKeyId: 'key-id',
+  apiSecret: 'key-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('action type constants', () => {
   it('exports INVITE_TEAM_MEMBER_ACTION_TYPE', () => {
@@ -80,6 +92,10 @@ describe('validateEmail', () => {
     expect(() => validateEmail('')).toThrow('must not be empty');
   });
 
+  it('throws for whitespace-only string', () => {
+    expect(() => validateEmail('   ')).toThrow('must not be empty');
+  });
+
   it('throws for no at-sign', () => {
     expect(() => validateEmail('person.example.com')).toThrow('must contain "@"');
   });
@@ -91,6 +107,18 @@ describe('validateEmail', () => {
   it('throws for at-sign at end', () => {
     expect(() => validateEmail('person@')).toThrow('must contain "@"');
   });
+
+  it('returns trimmed value with tabs and newlines', () => {
+    expect(validateEmail('\n\tperson@example.com\t\n')).toBe('person@example.com');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateEmail('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateEmail('\n\n')).toThrow('must not be empty');
+  });
 });
 
 describe('validateMemberRole', () => {
@@ -98,8 +126,22 @@ describe('validateMemberRole', () => {
     expect(validateMemberRole('admin')).toBe('admin');
   });
 
+  it('accepts all valid roles', () => {
+    for (const role of TEAM_MEMBER_ROLES) {
+      expect(validateMemberRole(role)).toBe(role);
+    }
+  });
+
   it('throws for invalid role', () => {
     expect(() => validateMemberRole('owner')).toThrow('must be one of');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => validateMemberRole('')).toThrow('must be one of');
+  });
+
+  it('throws for role with wrong case', () => {
+    expect(() => validateMemberRole('Admin')).toThrow('must be one of');
   });
 });
 
@@ -114,6 +156,26 @@ describe('validateMemberId', () => {
 
   it('throws for empty ID', () => {
     expect(() => validateMemberId('')).toThrow('must not be empty');
+  });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateMemberId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed value with tabs and newlines', () => {
+    expect(validateMemberId('\n\tmember-abc\t\n')).toBe('member-abc');
+  });
+
+  it('accepts unicode member ID', () => {
+    expect(validateMemberId('člen-123')).toBe('člen-123');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateMemberId('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateMemberId('\n\n')).toThrow('must not be empty');
   });
 });
 
@@ -139,9 +201,29 @@ describe('validateApiKeyName', () => {
     expect(() => validateApiKeyName('')).toThrow('must not be empty');
   });
 
+  it('throws for whitespace-only string', () => {
+    expect(() => validateApiKeyName('   ')).toThrow('must not be empty');
+  });
+
   it('throws for too long name', () => {
     const name = 'x'.repeat(201);
     expect(() => validateApiKeyName(name)).toThrow('must not exceed 200 characters');
+  });
+
+  it('returns trimmed value with tabs and newlines', () => {
+    expect(validateApiKeyName('\n\tServer Key\t\n')).toBe('Server Key');
+  });
+
+  it('accepts unicode key name', () => {
+    expect(validateApiKeyName('Produkční klíč')).toBe('Produkční klíč');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateApiKeyName('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateApiKeyName('\n\n')).toThrow('must not be empty');
   });
 });
 
@@ -157,27 +239,62 @@ describe('validateApiKeyId', () => {
   it('throws for empty ID', () => {
     expect(() => validateApiKeyId('')).toThrow('must not be empty');
   });
+
+  it('throws for whitespace-only string', () => {
+    expect(() => validateApiKeyId('   ')).toThrow('must not be empty');
+  });
+
+  it('returns trimmed value with tabs and newlines', () => {
+    expect(validateApiKeyId('\n\tkey-abc\t\n')).toBe('key-abc');
+  });
+
+  it('accepts unicode key ID', () => {
+    expect(validateApiKeyId('klíč-123')).toBe('klíč-123');
+  });
+
+  it('throws for tab-only string', () => {
+    expect(() => validateApiKeyId('\t\t')).toThrow('must not be empty');
+  });
+
+  it('throws for newline-only string', () => {
+    expect(() => validateApiKeyId('\n\n')).toThrow('must not be empty');
+  });
 });
 
-describe('buildProjectTeamUrl', () => {
-  it('builds URL for a simple project name', () => {
+describe('URL builders', () => {
+  it('builds URLs for a simple project name', () => {
     expect(buildProjectTeamUrl('kingdom-of-joakim')).toBe(
       '/p/kingdom-of-joakim/project-settings/project-team-v2',
     );
+    expect(buildApiKeysUrl('kingdom-of-joakim')).toBe(
+      '/p/kingdom-of-joakim/project-settings/api',
+    );
   });
 
-  it('encodes special characters in project name', () => {
-    expect(buildProjectTeamUrl('my project')).toBe('/p/my%20project/project-settings/project-team-v2');
-  });
-});
-
-describe('buildApiKeysUrl', () => {
-  it('builds URL for a simple project name', () => {
-    expect(buildApiKeysUrl('kingdom-of-joakim')).toBe('/p/kingdom-of-joakim/project-settings/api');
-  });
-
-  it('encodes special characters in project name', () => {
+  it('encodes spaces in URLs', () => {
+    expect(buildProjectTeamUrl('my project')).toBe(
+      '/p/my%20project/project-settings/project-team-v2',
+    );
     expect(buildApiKeysUrl('my project')).toBe('/p/my%20project/project-settings/api');
+  });
+
+  it('handles project names with slashes in URLs', () => {
+    expect(buildProjectTeamUrl('org/project')).toBe(
+      '/p/org%2Fproject/project-settings/project-team-v2',
+    );
+    expect(buildApiKeysUrl('org/project')).toBe('/p/org%2Fproject/project-settings/api');
+  });
+
+  it('encodes unicode project names in URLs', () => {
+    expect(buildProjectTeamUrl('projekt åäö')).toContain('%C3%A5');
+    expect(buildApiKeysUrl('projekt åäö')).toContain('%C3%A5');
+  });
+
+  it('encodes hash in URLs', () => {
+    expect(buildProjectTeamUrl('my#project')).toBe(
+      '/p/my%23project/project-settings/project-team-v2',
+    );
+    expect(buildApiKeysUrl('my#project')).toBe('/p/my%23project/project-settings/api');
   });
 });
 
@@ -192,7 +309,7 @@ describe('createAccessActionExecutors', () => {
     expect(executors[DELETE_API_KEY_ACTION_TYPE]).toBeDefined();
   });
 
-  it('each executor has an actionType property', () => {
+  it('each executor has an actionType property matching key', () => {
     const executors = createAccessActionExecutors();
     for (const [key, executor] of Object.entries(executors)) {
       expect(executor.actionType).toBe(key);
@@ -204,6 +321,72 @@ describe('createAccessActionExecutors', () => {
     for (const executor of Object.values(executors)) {
       await expect(executor.execute({})).rejects.toThrow('not yet implemented');
     }
+  });
+
+  it('executors throw UI-only availability message on execute', async () => {
+    const executors = createAccessActionExecutors();
+    for (const executor of Object.values(executors)) {
+      await expect(executor.execute({})).rejects.toThrow(
+        'only available through the Bloomreach Engagement UI',
+      );
+    }
+  });
+
+  it('InviteTeamMemberExecutor mentions UI-only availability', async () => {
+    const executors = createAccessActionExecutors();
+    await expect(executors[INVITE_TEAM_MEMBER_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('UpdateMemberRoleExecutor mentions UI-only availability', async () => {
+    const executors = createAccessActionExecutors();
+    await expect(executors[UPDATE_MEMBER_ROLE_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('RemoveTeamMemberExecutor mentions UI-only availability', async () => {
+    const executors = createAccessActionExecutors();
+    await expect(executors[REMOVE_TEAM_MEMBER_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('CreateApiKeyExecutor mentions UI-only availability', async () => {
+    const executors = createAccessActionExecutors();
+    await expect(executors[CREATE_API_KEY_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+
+  it('DeleteApiKeyExecutor mentions UI-only availability', async () => {
+    const executors = createAccessActionExecutors();
+    await expect(executors[DELETE_API_KEY_ACTION_TYPE].execute({})).rejects.toThrow(
+      'only available through the Bloomreach Engagement UI',
+    );
+  });
+});
+
+describe('apiConfig acceptance', () => {
+  it('createAccessActionExecutors accepts apiConfig', () => {
+    const executors = createAccessActionExecutors(TEST_API_CONFIG);
+    expect(Object.keys(executors)).toHaveLength(5);
+  });
+
+  it('createAccessActionExecutors works without apiConfig', () => {
+    const executors = createAccessActionExecutors();
+    expect(Object.keys(executors)).toHaveLength(5);
+  });
+
+  it('BloomreachAccessManagementService accepts apiConfig', () => {
+    const service = new BloomreachAccessManagementService('test', TEST_API_CONFIG);
+    expect(service.projectTeamUrl).toBe('/p/test/project-settings/project-team-v2');
+  });
+
+  it('BloomreachAccessManagementService works without apiConfig', () => {
+    const service = new BloomreachAccessManagementService('test');
+    expect(service.projectTeamUrl).toBe('/p/test/project-settings/project-team-v2');
   });
 });
 
@@ -229,19 +412,60 @@ describe('BloomreachAccessManagementService', () => {
     it('throws for empty project', () => {
       expect(() => new BloomreachAccessManagementService('')).toThrow('must not be empty');
     });
-  });
 
-  describe('listTeamMembers', () => {
-    it('throws not-yet-implemented error', async () => {
-      const service = new BloomreachAccessManagementService('test');
-      await expect(service.listTeamMembers()).rejects.toThrow('not yet implemented');
+    it('encodes spaces in URL', () => {
+      const service = new BloomreachAccessManagementService('my project');
+      expect(service.projectTeamUrl).toBe('/p/my%20project/project-settings/project-team-v2');
+    });
+
+    it('encodes unicode in URL', () => {
+      const service = new BloomreachAccessManagementService('projekt åäö');
+      expect(service.projectTeamUrl).toContain('%C3%A5');
+    });
+
+    it('encodes hash in URL', () => {
+      const service = new BloomreachAccessManagementService('my#project');
+      expect(service.projectTeamUrl).toBe('/p/my%23project/project-settings/project-team-v2');
     });
   });
 
-  describe('listApiKeys', () => {
-    it('throws not-yet-implemented error', async () => {
+  describe('URL getters', () => {
+    it('returns both access management URLs', () => {
+      const service = new BloomreachAccessManagementService('kingdom-of-joakim');
+      expect(service.projectTeamUrl).toBe('/p/kingdom-of-joakim/project-settings/project-team-v2');
+      expect(service.apiKeysUrl).toBe('/p/kingdom-of-joakim/project-settings/api');
+    });
+  });
+
+  describe('read methods', () => {
+    it('listTeamMembers throws not-yet-implemented error', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listTeamMembers()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listApiKeys throws not-yet-implemented error', async () => {
       const service = new BloomreachAccessManagementService('test');
       await expect(service.listApiKeys()).rejects.toThrow('not yet implemented');
+    });
+
+    it('listTeamMembers throws descriptive UI-only error', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listTeamMembers()).rejects.toThrow('Bloomreach Engagement UI');
+    });
+
+    it('listApiKeys throws descriptive UI-only error', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listApiKeys()).rejects.toThrow('Bloomreach Engagement UI');
+    });
+
+    it('listTeamMembers validates project when input provided', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listTeamMembers({ project: '' })).rejects.toThrow('must not be empty');
+    });
+
+    it('listApiKeys validates project when input provided', async () => {
+      const service = new BloomreachAccessManagementService('test');
+      await expect(service.listApiKeys({ project: '' })).rejects.toThrow('must not be empty');
     });
   });
 
@@ -263,6 +487,37 @@ describe('BloomreachAccessManagementService', () => {
           project: 'test',
           email: 'member@example.com',
           role: 'manager',
+        }),
+      );
+    });
+
+    it('trims email value', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareInviteTeamMember({
+        project: 'test',
+        email: '  member@example.com  ',
+        role: 'admin',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          email: 'member@example.com',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareInviteTeamMember({
+        project: 'test',
+        email: 'member@example.com',
+        role: 'editor',
+        operatorNote: 'invited for content team',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'invited for content team',
         }),
       );
     });
@@ -329,6 +584,37 @@ describe('BloomreachAccessManagementService', () => {
       );
     });
 
+    it('trims memberId value', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareUpdateMemberRole({
+        project: 'test',
+        memberId: '  mem-123  ',
+        role: 'viewer',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          memberId: 'mem-123',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareUpdateMemberRole({
+        project: 'test',
+        memberId: 'mem-123',
+        role: 'analyst',
+        operatorNote: 'promoted to analyst',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'promoted to analyst',
+        }),
+      );
+    });
+
     it('throws for empty memberId', () => {
       const service = new BloomreachAccessManagementService('test');
       expect(() =>
@@ -374,6 +660,21 @@ describe('BloomreachAccessManagementService', () => {
       );
     });
 
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareRemoveTeamMember({
+        project: 'test',
+        memberId: 'mem-456',
+        operatorNote: 'left the company',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'left the company',
+        }),
+      );
+    });
+
     it('throws for empty memberId', () => {
       const service = new BloomreachAccessManagementService('test');
       expect(() => service.prepareRemoveTeamMember({ project: 'test', memberId: '' })).toThrow(
@@ -404,6 +705,35 @@ describe('BloomreachAccessManagementService', () => {
           action: 'access.create_api_key',
           project: 'test',
           name: 'My API Key',
+        }),
+      );
+    });
+
+    it('trims name value', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareCreateApiKey({
+        project: 'test',
+        name: '  Server Key  ',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          name: 'Server Key',
+        }),
+      );
+    });
+
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareCreateApiKey({
+        project: 'test',
+        name: 'Server Key',
+        operatorNote: 'for production server',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'for production server',
         }),
       );
     });
@@ -452,6 +782,21 @@ describe('BloomreachAccessManagementService', () => {
       );
     });
 
+    it('includes operatorNote in preview', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const result = service.prepareDeleteApiKey({
+        project: 'test',
+        apiKeyId: 'key-456',
+        operatorNote: 'rotating keys',
+      });
+
+      expect(result.preview).toEqual(
+        expect.objectContaining({
+          operatorNote: 'rotating keys',
+        }),
+      );
+    });
+
     it('throws for empty apiKeyId', () => {
       const service = new BloomreachAccessManagementService('test');
       expect(() => service.prepareDeleteApiKey({ project: 'test', apiKeyId: '' })).toThrow(
@@ -464,6 +809,35 @@ describe('BloomreachAccessManagementService', () => {
       expect(() => service.prepareDeleteApiKey({ project: '', apiKeyId: 'key-456' })).toThrow(
         'must not be empty',
       );
+    });
+  });
+
+  describe('token expiry consistency', () => {
+    it('all prepare methods set expiry ~30 minutes in the future', () => {
+      const service = new BloomreachAccessManagementService('test');
+      const now = Date.now();
+      const thirtyMinMs = 30 * 60 * 1000;
+
+      const results = [
+        service.prepareInviteTeamMember({
+          project: 'test',
+          email: 'a@b.com',
+          role: 'admin',
+        }),
+        service.prepareUpdateMemberRole({
+          project: 'test',
+          memberId: 'm-1',
+          role: 'editor',
+        }),
+        service.prepareRemoveTeamMember({ project: 'test', memberId: 'm-1' }),
+        service.prepareCreateApiKey({ project: 'test', name: 'K' }),
+        service.prepareDeleteApiKey({ project: 'test', apiKeyId: 'k-1' }),
+      ];
+
+      for (const result of results) {
+        expect(result.expiresAtMs).toBeGreaterThanOrEqual(now + thirtyMinMs - 1000);
+        expect(result.expiresAtMs).toBeLessThanOrEqual(now + thirtyMinMs + 5000);
+      }
     });
   });
 });

--- a/packages/core/src/bloomreachAccessManagement.ts
+++ b/packages/core/src/bloomreachAccessManagement.ts
@@ -1,4 +1,9 @@
 import { validateProject } from './bloomreachDashboards.js';
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+
+// ---------------------------------------------------------------------------
+// Action type constants
+// ---------------------------------------------------------------------------
 
 export const INVITE_TEAM_MEMBER_ACTION_TYPE = 'access.invite_team_member';
 export const UPDATE_MEMBER_ROLE_ACTION_TYPE = 'access.update_member_role';
@@ -6,10 +11,18 @@ export const REMOVE_TEAM_MEMBER_ACTION_TYPE = 'access.remove_team_member';
 export const CREATE_API_KEY_ACTION_TYPE = 'access.create_api_key';
 export const DELETE_API_KEY_ACTION_TYPE = 'access.delete_api_key';
 
+// ---------------------------------------------------------------------------
+// Rate limit constants
+// ---------------------------------------------------------------------------
+
 export const ACCESS_RATE_LIMIT_WINDOW_MS = 3_600_000;
 export const ACCESS_INVITE_RATE_LIMIT = 20;
 export const ACCESS_MODIFY_RATE_LIMIT = 30;
 export const ACCESS_API_KEY_RATE_LIMIT = 10;
+
+// ---------------------------------------------------------------------------
+// Data interfaces
+// ---------------------------------------------------------------------------
 
 export const TEAM_MEMBER_ROLES = ['admin', 'manager', 'analyst', 'editor', 'viewer'] as const;
 export type TeamMemberRole = (typeof TEAM_MEMBER_ROLES)[number];
@@ -35,6 +48,10 @@ export interface BloomreachApiKey {
   status: string;
   url: string;
 }
+
+// ---------------------------------------------------------------------------
+// Input interfaces
+// ---------------------------------------------------------------------------
 
 export interface ListTeamMembersInput {
   project: string;
@@ -76,12 +93,20 @@ export interface DeleteApiKeyInput {
   operatorNote?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Prepared action result
+// ---------------------------------------------------------------------------
+
 export interface PreparedAccessAction {
   preparedActionId: string;
   confirmToken: string;
   expiresAtMs: number;
   preview: Record<string, unknown>;
 }
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
 
 const MAX_API_KEY_NAME_LENGTH = 200;
 
@@ -137,6 +162,10 @@ export function validateApiKeyId(id: string): string {
   return trimmed;
 }
 
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
 export function buildProjectTeamUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/project-settings/project-team-v2`;
 }
@@ -145,6 +174,25 @@ export function buildApiKeysUrl(project: string): string {
   return `/p/${encodeURIComponent(project)}/project-settings/api`;
 }
 
+function requireApiConfig(
+  config: BloomreachApiConfig | undefined,
+  operation: string,
+): BloomreachApiConfig {
+  if (!config) {
+    throw new Error(
+      `${operation} requires API credentials. ` +
+        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    );
+  }
+  return config;
+}
+
+void requireApiConfig;
+
+// ---------------------------------------------------------------------------
+// Action executor interface + implementations
+// ---------------------------------------------------------------------------
+
 export interface AccessActionExecutor {
   readonly actionType: string;
   execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -152,80 +200,121 @@ export interface AccessActionExecutor {
 
 class InviteTeamMemberExecutor implements AccessActionExecutor {
   readonly actionType = INVITE_TEAM_MEMBER_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'InviteTeamMemberExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'InviteTeamMemberExecutor: not yet implemented. ' +
+        'Team member invitation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class UpdateMemberRoleExecutor implements AccessActionExecutor {
   readonly actionType = UPDATE_MEMBER_ROLE_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'UpdateMemberRoleExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'UpdateMemberRoleExecutor: not yet implemented. ' +
+        'Member role updates are only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class RemoveTeamMemberExecutor implements AccessActionExecutor {
   readonly actionType = REMOVE_TEAM_MEMBER_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'RemoveTeamMemberExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'RemoveTeamMemberExecutor: not yet implemented. ' +
+        'Team member removal is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class CreateApiKeyExecutor implements AccessActionExecutor {
   readonly actionType = CREATE_API_KEY_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'CreateApiKeyExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'CreateApiKeyExecutor: not yet implemented. ' +
+        'API key creation is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
 class DeleteApiKeyExecutor implements AccessActionExecutor {
   readonly actionType = DELETE_API_KEY_ACTION_TYPE;
+  private readonly apiConfig?: BloomreachApiConfig;
+
+  constructor(apiConfig?: BloomreachApiConfig) {
+    this.apiConfig = apiConfig;
+  }
 
   async execute(
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    void this.apiConfig;
     throw new Error(
-      'DeleteApiKeyExecutor: not yet implemented. Requires browser automation infrastructure.',
+      'DeleteApiKeyExecutor: not yet implemented. ' +
+        'API key deletion is only available through the Bloomreach Engagement UI.',
     );
   }
 }
 
-export function createAccessActionExecutors(): Record<string, AccessActionExecutor> {
+export function createAccessActionExecutors(apiConfig?: BloomreachApiConfig): Record<string, AccessActionExecutor> {
   return {
-    [INVITE_TEAM_MEMBER_ACTION_TYPE]: new InviteTeamMemberExecutor(),
-    [UPDATE_MEMBER_ROLE_ACTION_TYPE]: new UpdateMemberRoleExecutor(),
-    [REMOVE_TEAM_MEMBER_ACTION_TYPE]: new RemoveTeamMemberExecutor(),
-    [CREATE_API_KEY_ACTION_TYPE]: new CreateApiKeyExecutor(),
-    [DELETE_API_KEY_ACTION_TYPE]: new DeleteApiKeyExecutor(),
+    [INVITE_TEAM_MEMBER_ACTION_TYPE]: new InviteTeamMemberExecutor(apiConfig),
+    [UPDATE_MEMBER_ROLE_ACTION_TYPE]: new UpdateMemberRoleExecutor(apiConfig),
+    [REMOVE_TEAM_MEMBER_ACTION_TYPE]: new RemoveTeamMemberExecutor(apiConfig),
+    [CREATE_API_KEY_ACTION_TYPE]: new CreateApiKeyExecutor(apiConfig),
+    [DELETE_API_KEY_ACTION_TYPE]: new DeleteApiKeyExecutor(apiConfig),
   };
 }
 
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
 export class BloomreachAccessManagementService {
+  private readonly apiConfig?: BloomreachApiConfig;
   private readonly teamUrl: string;
   private readonly keysUrl: string;
 
-  constructor(project: string) {
+  constructor(project: string, apiConfig?: BloomreachApiConfig) {
     const validatedProject = validateProject(project);
+    this.apiConfig = apiConfig;
     this.teamUrl = buildProjectTeamUrl(validatedProject);
     this.keysUrl = buildApiKeysUrl(validatedProject);
   }
@@ -239,22 +328,24 @@ export class BloomreachAccessManagementService {
   }
 
   async listTeamMembers(input?: ListTeamMembersInput): Promise<BloomreachTeamMember[]> {
+    void this.apiConfig;
     if (input !== undefined) {
       validateProject(input.project);
     }
-
     throw new Error(
-      'listTeamMembers: not yet implemented. Requires browser automation infrastructure.',
+      'listTeamMembers: not yet implemented. the Bloomreach API does not provide an endpoint for team members. ' +
+        'Team members must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Project Team).',
     );
   }
 
   async listApiKeys(input?: ListApiKeysInput): Promise<BloomreachApiKey[]> {
+    void this.apiConfig;
     if (input !== undefined) {
       validateProject(input.project);
     }
-
     throw new Error(
-      'listApiKeys: not yet implemented. Requires browser automation infrastructure.',
+      'listApiKeys: not yet implemented. the Bloomreach API does not provide an endpoint for API keys. ' +
+        'API keys must be managed through the Bloomreach Engagement UI (navigate to Project Settings > API).',
     );
   }
 


### PR DESCRIPTION
## Summary

Acid test for the Access Management module — brings it in line with the established pattern used across all other completed acid test modules (security settings, evaluation settings, dashboards, etc.).

## Changes

### Core module (`bloomreachAccessManagement.ts`)
- Wire `BloomreachApiConfig` through executor constructors and service class
- Add `requireApiConfig()` helper (consistent with all other modules)
- Improve error messages: generic "Requires browser automation" → descriptive UI-only messages mentioning exact Bloomreach Engagement UI navigation paths
- Add `void this.apiConfig` usage in executors and read methods
- Add section divider comments matching codebase convention
- Service constructor now accepts optional `apiConfig` parameter

### Tests (`bloomreachAccessManagement.test.ts`)
- Expanded from **62 → 112 tests** (+50 new test cases)
- Add edge cases for all validators: whitespace-only, tab-only, newline-only, unicode
- Add URL builder tests: slashes, unicode encoding, hash encoding
- Add per-executor UI-only availability message checks
- Add `apiConfig acceptance` block (with/without apiConfig)
- Add `token expiry consistency` block (all prepare methods ~30 min)
- Add trimming/operatorNote tests for prepare methods
- Add `validateMemberRole` exhaustive role coverage
- Add read method UI-only error and project validation tests

### Quality Gates
- ✅ Lint: clean
- ✅ Tests: 8866 passed (72 files)
- ✅ Build: success

Closes #129
