### PR TITLE
feat #132: acid test API client — error hierarchy, retry, logging, caching, expanded tests

### DIFF
--- a/packages/core/src/__tests__/bloomreachApiClient.e2e.test.ts
+++ b/packages/core/src/__tests__/bloomreachApiClient.e2e.test.ts
@@ -1,0 +1,119 @@
+/**
+ * E2E tests for the Bloomreach API client.
+ * These tests run against the real Bloomreach API and require valid credentials
+ * in the environment: BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, BLOOMREACH_API_SECRET.
+ *
+ * Skipped automatically when credentials are not present.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveApiConfig,
+  bloomreachApiFetch,
+  buildTrackingPath,
+  buildDataPath,
+  BloomreachApiError,
+  BloomreachBuddyError,
+} from '../bloomreachApiClient.js';
+import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
+
+const HAS_CREDENTIALS = !!(
+  process.env.BLOOMREACH_PROJECT_TOKEN &&
+  process.env.BLOOMREACH_API_KEY_ID &&
+  process.env.BLOOMREACH_API_SECRET
+);
+
+let config: BloomreachApiConfig;
+if (HAS_CREDENTIALS) {
+  config = resolveApiConfig();
+}
+
+describe.skipIf(!HAS_CREDENTIALS)('bloomreachApiFetch E2E', () => {
+  it('authenticates successfully against real Bloomreach API', async () => {
+    const path = buildTrackingPath(config, '/system/time');
+    const result = await bloomreachApiFetch(config, path, { method: 'GET' });
+
+    // system/time returns { time: <number> }
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+    expect(result).toHaveProperty('time');
+  });
+
+  it('returns BloomreachApiError with invalid credentials', async () => {
+    const badConfig: BloomreachApiConfig = {
+      ...config,
+      apiKeyId: 'invalid-key-id',
+      apiSecret: 'invalid-secret',
+    };
+
+    const path = buildTrackingPath(badConfig, '/system/time');
+
+    try {
+      await bloomreachApiFetch(badConfig, path, { method: 'GET' });
+      expect.fail('Expected BloomreachApiError');
+    } catch (error) {
+      // Bloomreach may return 401 or 404 for invalid credentials
+      expect(error).toBeInstanceOf(BloomreachApiError);
+      const apiError = error as BloomreachApiError;
+      expect(apiError.statusCode).toBeGreaterThanOrEqual(400);
+      expect(apiError.statusCode).toBeLessThan(500);
+    }
+  });
+
+  it('executes GET request against data endpoint', async () => {
+    const path = buildDataPath(config, '/customers/attributes');
+    const result = await bloomreachApiFetch(config, path, { method: 'GET' });
+
+    expect(result).toBeDefined();
+  });
+
+  it('executes POST request against tracking endpoint', async () => {
+    // POST to system/time also works and returns time
+    const path = buildTrackingPath(config, '/system/time');
+    const result = await bloomreachApiFetch(config, path, { method: 'POST' });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('time');
+  });
+
+  it('throws BloomreachBuddyError with TIMEOUT code for tiny timeout', async () => {
+    const path = buildTrackingPath(config, '/system/time');
+
+    try {
+      await bloomreachApiFetch(config, path, {
+        method: 'GET',
+        timeoutMs: 1,
+      });
+      // If it somehow succeeds with 1ms timeout, that's also acceptable
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachBuddyError);
+      expect((error as BloomreachBuddyError).code).toBe('TIMEOUT');
+    }
+  });
+
+  it('buildTrackingPath + fetch integration round trip', async () => {
+    const suffix = '/system/time';
+    const path = buildTrackingPath(config, suffix);
+
+    expect(path).toContain('/track/v2/projects/');
+    expect(path).toContain(config.projectToken);
+    expect(path).toContain(suffix);
+
+    const result = await bloomreachApiFetch(config, path, { method: 'GET' });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('time');
+  });
+
+  it('buildDataPath + fetch integration round trip', async () => {
+    const suffix = '/customers/attributes';
+    const path = buildDataPath(config, suffix);
+
+    expect(path).toContain('/data/v2/projects/');
+    expect(path).toContain(config.projectToken);
+    expect(path).toContain(suffix);
+
+    const result = await bloomreachApiFetch(config, path, { method: 'GET' });
+
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/bloomreachApiClient.test.ts
+++ b/packages/core/src/__tests__/bloomreachApiClient.test.ts
@@ -6,9 +6,46 @@ import {
   buildTrackingPath,
   buildDataPath,
   BloomreachApiError,
+  BloomreachBuddyError,
+  _internal,
+  parseRetryAfter,
+  computeRetryDelay,
+  createApiCache,
+  clearApiCache,
+} from '../bloomreachApiClient.js';
+import type {
+  BloomreachApiConfig,
+  RetryOptions,
+  ApiLogEvent,
 } from '../bloomreachApiClient.js';
 
 const ORIGINAL_ENV = process.env;
+
+const TEST_CONFIG: BloomreachApiConfig = {
+  projectToken: 'project-1',
+  apiKeyId: 'my-key',
+  apiSecret: 'my-secret',
+  baseUrl: 'https://api.test.com',
+};
+
+/**
+ * Create a mock fetch implementation that returns a new Response on each call.
+ * Avoids the "Body has already been read" error when the same mock is called
+ * multiple times (e.g. during retries or caching tests).
+ */
+function mockFetchImpl(
+  body: string,
+  init: ResponseInit & { headers?: Record<string, string> } = {},
+): () => Promise<Response> {
+  return () =>
+    Promise.resolve(
+      new Response(body, {
+        status: 200,
+        ...init,
+        headers: { 'Content-Type': 'application/json', ...init.headers },
+      }),
+    );
+}
 
 beforeEach(() => {
   process.env = { ...ORIGINAL_ENV };
@@ -19,6 +56,10 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
+
+// ===========================================================================
+// resolveApiConfig
+// ===========================================================================
 
 describe('resolveApiConfig', () => {
   it('returns config when all values are provided explicitly', () => {
@@ -53,28 +94,49 @@ describe('resolveApiConfig', () => {
     });
   });
 
-  it('throws when projectToken is missing', () => {
+  it('throws BloomreachBuddyError with CONFIG_MISSING when projectToken is missing', () => {
     process.env.BLOOMREACH_PROJECT_TOKEN = '';
     process.env.BLOOMREACH_API_KEY_ID = 'env-key';
     process.env.BLOOMREACH_API_SECRET = 'env-secret';
 
     expect(() => resolveApiConfig()).toThrow('Bloomreach project token is required');
+
+    try {
+      resolveApiConfig();
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachBuddyError);
+      expect((error as BloomreachBuddyError).code).toBe('CONFIG_MISSING');
+    }
   });
 
-  it('throws when apiKeyId is missing', () => {
+  it('throws BloomreachBuddyError with CONFIG_MISSING when apiKeyId is missing', () => {
     process.env.BLOOMREACH_PROJECT_TOKEN = 'env-project';
     process.env.BLOOMREACH_API_KEY_ID = '';
     process.env.BLOOMREACH_API_SECRET = 'env-secret';
 
     expect(() => resolveApiConfig()).toThrow('Bloomreach API key ID is required');
+
+    try {
+      resolveApiConfig();
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachBuddyError);
+      expect((error as BloomreachBuddyError).code).toBe('CONFIG_MISSING');
+    }
   });
 
-  it('throws when apiSecret is missing', () => {
+  it('throws BloomreachBuddyError with CONFIG_MISSING when apiSecret is missing', () => {
     process.env.BLOOMREACH_PROJECT_TOKEN = 'env-project';
     process.env.BLOOMREACH_API_KEY_ID = 'env-key';
     process.env.BLOOMREACH_API_SECRET = '';
 
     expect(() => resolveApiConfig()).toThrow('Bloomreach API secret is required');
+
+    try {
+      resolveApiConfig();
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachBuddyError);
+      expect((error as BloomreachBuddyError).code).toBe('CONFIG_MISSING');
+    }
   });
 
   it('trims whitespace from values', () => {
@@ -112,47 +174,93 @@ describe('resolveApiConfig', () => {
   });
 });
 
+// ===========================================================================
+// buildAuthHeader
+// ===========================================================================
+
 describe('buildAuthHeader', () => {
   it('returns correct Basic auth format', () => {
-    const header = buildAuthHeader({
-      projectToken: 'project-1',
-      apiKeyId: 'my-key',
-      apiSecret: 'my-secret',
-      baseUrl: 'https://api.test.com',
-    });
-
+    const header = buildAuthHeader(TEST_CONFIG);
     expect(header.startsWith('Basic ')).toBe(true);
   });
 
   it('base64 encodes apiKeyId:apiSecret correctly', () => {
-    const header = buildAuthHeader({
-      projectToken: 'project-1',
-      apiKeyId: 'my-key',
-      apiSecret: 'my-secret',
-      baseUrl: 'https://api.test.com',
-    });
-
-    expect(header).toBe(`Basic ${Buffer.from('my-key:my-secret').toString('base64')}`);
+    const header = buildAuthHeader(TEST_CONFIG);
+    expect(header).toBe(
+      `Basic ${Buffer.from('my-key:my-secret').toString('base64')}`,
+    );
   });
 });
 
+// ===========================================================================
+// BloomreachBuddyError
+// ===========================================================================
+
+describe('BloomreachBuddyError', () => {
+  it('stores code property', () => {
+    const error = new BloomreachBuddyError('CONFIG_MISSING', 'test');
+    expect(error.code).toBe('CONFIG_MISSING');
+  });
+
+  it('has name BloomreachBuddyError', () => {
+    const error = new BloomreachBuddyError('TIMEOUT', 'test');
+    expect(error.name).toBe('BloomreachBuddyError');
+  });
+
+  it('is instanceof Error', () => {
+    const error = new BloomreachBuddyError('NETWORK_ERROR', 'test');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('stores message correctly', () => {
+    const error = new BloomreachBuddyError('API_ERROR', 'something went wrong');
+    expect(error.message).toBe('something went wrong');
+  });
+});
+
+// ===========================================================================
+// BloomreachApiError
+// ===========================================================================
+
+describe('BloomreachApiError', () => {
+  it('stores statusCode and responseBody', () => {
+    const error = new BloomreachApiError('failed', 500, { error: 'internal' });
+    expect(error.statusCode).toBe(500);
+    expect(error.responseBody).toEqual({ error: 'internal' });
+  });
+
+  it('has correct name property', () => {
+    const error = new BloomreachApiError('failed', 500, { error: 'internal' });
+    expect(error.name).toBe('BloomreachApiError');
+  });
+
+  it('is instanceof BloomreachBuddyError', () => {
+    const error = new BloomreachApiError('failed', 500, {});
+    expect(error).toBeInstanceOf(BloomreachBuddyError);
+  });
+
+  it('is instanceof Error', () => {
+    const error = new BloomreachApiError('failed', 500, {});
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('has code API_ERROR', () => {
+    const error = new BloomreachApiError('failed', 500, {});
+    expect(error.code).toBe('API_ERROR');
+  });
+});
+
+// ===========================================================================
+// bloomreachApiFetch — core behavior
+// ===========================================================================
+
 describe('bloomreachApiFetch', () => {
   it('makes request with correct URL, method, headers, and body', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ success: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
     );
 
-    const config = {
-      projectToken: 'project-1',
-      apiKeyId: 'my-key',
-      apiSecret: 'my-secret',
-      baseUrl: 'https://api.test.com',
-    };
-
-    await bloomreachApiFetch(config, '/track/v2/projects/project-1/customers', {
+    await bloomreachApiFetch(TEST_CONFIG, '/track/v2/projects/project-1/customers', {
       method: 'PUT',
       body: { customer_ids: { registered: 'cust-1' } },
     });
@@ -174,20 +282,12 @@ describe('bloomreachApiFetch', () => {
   });
 
   it('returns parsed JSON on success', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, id: 1 }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true, id: 1 })),
     );
 
     const result = await bloomreachApiFetch(
-      {
-        projectToken: 'project-1',
-        apiKeyId: 'my-key',
-        apiSecret: 'my-secret',
-        baseUrl: 'https://api.test.com',
-      },
+      TEST_CONFIG,
       '/data/v2/projects/project-1/customers/export',
     );
 
@@ -195,28 +295,19 @@ describe('bloomreachApiFetch', () => {
   });
 
   it('throws BloomreachApiError on non-2xx responses', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ error: 'bad request' }), {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'bad request' }), {
         status: 400,
         statusText: 'Bad Request',
-        headers: { 'Content-Type': 'application/json' },
       }),
     );
 
     await expect(
-      bloomreachApiFetch(
-        {
-          projectToken: 'project-1',
-          apiKeyId: 'my-key',
-          apiSecret: 'my-secret',
-          baseUrl: 'https://api.test.com',
-        },
-        '/track/v2/projects/project-1/customers',
-      ),
+      bloomreachApiFetch(TEST_CONFIG, '/track/v2/projects/project-1/customers'),
     ).rejects.toBeInstanceOf(BloomreachApiError);
   });
 
-  it('handles timeout and aborts the request', async () => {
+  it('handles timeout and throws BloomreachBuddyError with TIMEOUT code', async () => {
     vi.useFakeTimers();
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
@@ -227,61 +318,872 @@ describe('bloomreachApiFetch', () => {
       });
     });
 
-    const request = bloomreachApiFetch(
-      {
-        projectToken: 'project-1',
-        apiKeyId: 'my-key',
-        apiSecret: 'my-secret',
-        baseUrl: 'https://api.test.com',
-      },
+    const promise = bloomreachApiFetch(
+      TEST_CONFIG,
       '/track/v2/projects/project-1/customers',
       { timeoutMs: 10 },
     );
 
-    const assertion = expect(request).rejects.toThrow('timed out after 10ms');
+    // Register the rejection handler BEFORE advancing timers to prevent
+    // the rejection from firing as "unhandled".
+    const assertion = promise
+      .then(() => {
+        expect.fail('Expected BloomreachBuddyError');
+      })
+      .catch((error: unknown) => {
+        expect(error).toBeInstanceOf(BloomreachBuddyError);
+        expect((error as BloomreachBuddyError).code).toBe('TIMEOUT');
+        expect((error as BloomreachBuddyError).message).toContain(
+          'timed out after 10ms',
+        );
+      });
 
     await vi.advanceTimersByTimeAsync(10);
-
     await assertion;
+  });
+
+  it('wraps network errors in BloomreachBuddyError with NETWORK_ERROR code', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed'),
+    );
+
+    try {
+      await bloomreachApiFetch(TEST_CONFIG, '/test');
+      expect.fail('Expected BloomreachBuddyError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachBuddyError);
+      expect((error as BloomreachBuddyError).code).toBe('NETWORK_ERROR');
+      expect((error as BloomreachBuddyError).message).toBe('fetch failed');
+    }
   });
 });
 
-describe('buildTrackingPath and buildDataPath', () => {
-  it('returns correctly formatted tracking path', () => {
-    const result = buildTrackingPath(
-      {
-        projectToken: 'project-1',
-        apiKeyId: 'my-key',
-        apiSecret: 'my-secret',
-        baseUrl: 'https://api.test.com',
-      },
-      '/customers',
+// ===========================================================================
+// HTTP method handling
+// ===========================================================================
+
+describe('HTTP method handling', () => {
+  it('defaults to POST when method not specified', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
     );
 
+    await bloomreachApiFetch(TEST_CONFIG, '/test');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('passes GET correctly', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ data: [] })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', { method: 'GET' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('passes PUT correctly', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      method: 'PUT',
+      body: { key: 'value' },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+
+  it('passes DELETE correctly', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', { method: 'DELETE' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('omits body field when body is undefined', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', { method: 'GET' });
+
+    const callArgs = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(callArgs.body).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// Content-Type and Accept headers
+// ===========================================================================
+
+describe('Content-Type and Accept headers', () => {
+  it('sends Content-Type application/json on POST with body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      method: 'POST',
+      body: { key: 'value' },
+    });
+
+    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('sends Content-Type application/json on PUT with body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      method: 'PUT',
+      body: { key: 'value' },
+    });
+
+    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('sends Accept application/json on all requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', { method: 'GET' });
+
+    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(headers['Accept']).toBe('application/json');
+  });
+
+  it('sends Content-Type application/json on GET requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ data: [] })),
+    );
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', { method: 'GET' });
+
+    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+});
+
+// ===========================================================================
+// Empty response handling
+// ===========================================================================
+
+describe('empty response handling', () => {
+  it('returns undefined for empty response body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => Promise.resolve(new Response('', { status: 200 })),
+    );
+
+    const result = await bloomreachApiFetch(TEST_CONFIG, '/test');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for 204 No Content with null body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => Promise.resolve(new Response(null, { status: 204, statusText: 'No Content' })),
+    );
+
+    const result = await bloomreachApiFetch(TEST_CONFIG, '/test');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns raw text for non-JSON response body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        Promise.resolve(
+          new Response('404 page not found', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' },
+          }),
+        ),
+    );
+
+    const result = await bloomreachApiFetch(TEST_CONFIG, '/test');
+
+    expect(result).toBe('404 page not found');
+  });
+});
+
+// ===========================================================================
+// Error message structure
+// ===========================================================================
+
+describe('error message structure', () => {
+  it('BloomreachApiError message includes status code and statusText', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'not found' }), {
+        status: 404,
+        statusText: 'Not Found',
+      }),
+    );
+
+    try {
+      await bloomreachApiFetch(TEST_CONFIG, '/test');
+      expect.fail('Expected BloomreachApiError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachApiError);
+      const apiError = error as BloomreachApiError;
+      expect(apiError.message).toContain('404');
+      expect(apiError.message).toContain('Not Found');
+    }
+  });
+
+  it('responseBody contains parsed JSON from server', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ errors: [{ message: 'invalid' }] }), {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+      }),
+    );
+
+    try {
+      await bloomreachApiFetch(TEST_CONFIG, '/test');
+      expect.fail('Expected BloomreachApiError');
+    } catch (error) {
+      const apiError = error as BloomreachApiError;
+      expect(apiError.responseBody).toEqual({
+        errors: [{ message: 'invalid' }],
+      });
+    }
+  });
+
+  it('responseBody contains raw text when server returns non-JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        Promise.resolve(
+          new Response('404 page not found', {
+            status: 404,
+            statusText: 'Not Found',
+          }),
+        ),
+    );
+
+    try {
+      await bloomreachApiFetch(TEST_CONFIG, '/test');
+      expect.fail('Expected BloomreachApiError');
+    } catch (error) {
+      const apiError = error as BloomreachApiError;
+      expect(apiError.responseBody).toBe('404 page not found');
+    }
+  });
+
+  it('API error is instanceof BloomreachBuddyError with code API_ERROR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'fail' }), {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    );
+
+    try {
+      await bloomreachApiFetch(TEST_CONFIG, '/test');
+      expect.fail('Expected BloomreachApiError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachBuddyError);
+      expect((error as BloomreachBuddyError).code).toBe('API_ERROR');
+    }
+  });
+});
+
+// ===========================================================================
+// parseRetryAfter
+// ===========================================================================
+
+describe('parseRetryAfter', () => {
+  it('returns null when Retry-After header is absent', () => {
+    const headers = new Headers();
+    expect(parseRetryAfter(headers)).toBeNull();
+  });
+
+  it('parses integer seconds', () => {
+    const headers = new Headers({ 'Retry-After': '120' });
+    expect(parseRetryAfter(headers)).toBe(120_000);
+  });
+
+  it('parses zero seconds', () => {
+    const headers = new Headers({ 'Retry-After': '0' });
+    expect(parseRetryAfter(headers)).toBe(0);
+  });
+
+  it('parses HTTP-date format', () => {
+    const futureDate = new Date(Date.now() + 60_000).toUTCString();
+    const headers = new Headers({ 'Retry-After': futureDate });
+    const result = parseRetryAfter(headers);
+    expect(result).toBeGreaterThan(50_000);
+    expect(result).toBeLessThanOrEqual(60_000);
+  });
+
+  it('returns 0 for past HTTP-date', () => {
+    const pastDate = new Date(Date.now() - 60_000).toUTCString();
+    const headers = new Headers({ 'Retry-After': pastDate });
+    expect(parseRetryAfter(headers)).toBe(0);
+  });
+
+  it('returns null for unparseable value', () => {
+    const headers = new Headers({ 'Retry-After': 'garbage' });
+    expect(parseRetryAfter(headers)).toBeNull();
+  });
+});
+
+// ===========================================================================
+// computeRetryDelay
+// ===========================================================================
+
+describe('computeRetryDelay', () => {
+  const defaultOpts: Required<RetryOptions> = {
+    maxRetries: 3,
+    baseDelayMs: 500,
+    maxDelayMs: 30_000,
+    retryableStatuses: [429, 500, 502, 503, 504],
+  };
+
+  it('uses Retry-After when available', () => {
+    const delay = computeRetryDelay(0, defaultOpts, 5_000);
+    expect(delay).toBe(5_000);
+  });
+
+  it('caps Retry-After at maxDelayMs', () => {
+    const delay = computeRetryDelay(0, defaultOpts, 60_000);
+    expect(delay).toBe(30_000);
+  });
+
+  it('computes exponential backoff when Retry-After is null', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5); // jitter factor = 1.0
+    const delay = computeRetryDelay(0, defaultOpts, null);
+    expect(delay).toBe(500); // 500 * 2^0 * 1.0
+  });
+
+  it('doubles delay on each attempt', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5); // jitter factor = 1.0
+    const d0 = computeRetryDelay(0, defaultOpts, null);
+    const d1 = computeRetryDelay(1, defaultOpts, null);
+    const d2 = computeRetryDelay(2, defaultOpts, null);
+    expect(d1).toBe(d0 * 2);
+    expect(d2).toBe(d0 * 4);
+  });
+
+  it('caps computed delay at maxDelayMs', () => {
+    const opts = { ...defaultOpts, maxDelayMs: 1_000 };
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const delay = computeRetryDelay(10, opts, null); // huge exponential
+    expect(delay).toBe(1_000);
+  });
+
+  it('applies jitter in ±20% range', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0); // min jitter = 0.8
+    const low = computeRetryDelay(0, defaultOpts, null);
+    expect(low).toBe(400); // 500 * 0.8
+
+    vi.spyOn(Math, 'random').mockReturnValue(1); // max jitter = 1.2
+    const high = computeRetryDelay(0, defaultOpts, null);
+    expect(high).toBeCloseTo(600, 5); // 500 * 1.2 (floating point safe)
+  });
+});
+
+// ===========================================================================
+// Retry behavior in bloomreachApiFetch
+// ===========================================================================
+
+describe('retry behavior', () => {
+  let sleepSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sleepSpy = vi.spyOn(_internal, 'sleep').mockResolvedValue(undefined);
+  });
+
+  it('does not retry by default — single fetch on 500 throws immediately', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'internal' }), {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    );
+
+    await expect(
+      bloomreachApiFetch(TEST_CONFIG, '/test'),
+    ).rejects.toBeInstanceOf(BloomreachApiError);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries up to maxRetries on 429', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'too many' }), {
+        status: 429,
+        statusText: 'Too Many Requests',
+      }),
+    );
+
+    await expect(
+      bloomreachApiFetch(TEST_CONFIG, '/test', {
+        retry: { maxRetries: 2, baseDelayMs: 10 },
+      }),
+    ).rejects.toBeInstanceOf(BloomreachApiError);
+
+    // 1 initial + 2 retries = 3 total
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(sleepSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on 500, 502, 503, 504', async () => {
+    for (const status of [500, 502, 503, 504]) {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(
+        mockFetchImpl(JSON.stringify({ error: 'fail' }), {
+          status,
+          statusText: 'Server Error',
+        }),
+      );
+
+      const result = bloomreachApiFetch(TEST_CONFIG, '/test', {
+        retry: { maxRetries: 1, baseDelayMs: 1 },
+      });
+
+      await expect(result).rejects.toBeInstanceOf(BloomreachApiError);
+
+      vi.mocked(globalThis.fetch).mockRestore();
+      sleepSpy.mockClear();
+    }
+  });
+
+  it('does NOT retry on 400, 401, 403, 404', async () => {
+    for (const status of [400, 401, 403, 404]) {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+        mockFetchImpl(JSON.stringify({ error: 'client error' }), {
+          status,
+          statusText: 'Client Error',
+        }),
+      );
+
+      await expect(
+        bloomreachApiFetch(TEST_CONFIG, '/test', {
+          retry: { maxRetries: 3, baseDelayMs: 1 },
+        }),
+      ).rejects.toBeInstanceOf(BloomreachApiError);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('succeeds on retry — first call 500, second call 200', async () => {
+    let callCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'fail' }), {
+            status: 500,
+            statusText: 'Server Error',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    const result = await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(callCount).toBe(2);
+  });
+
+  it('throws last BloomreachApiError after exhausting all retries', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'overloaded' }), {
+        status: 503,
+        statusText: 'Service Unavailable',
+      }),
+    );
+
+    try {
+      await bloomreachApiFetch(TEST_CONFIG, '/test', {
+        retry: { maxRetries: 2, baseDelayMs: 1 },
+      });
+      expect.fail('Expected BloomreachApiError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BloomreachApiError);
+      expect((error as BloomreachApiError).statusCode).toBe(503);
+    }
+  });
+
+  it('respects Retry-After header (integer seconds)', async () => {
+    let callCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'rate limited' }), {
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: {
+              'Content-Type': 'application/json',
+              'Retry-After': '5',
+            },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      retry: { maxRetries: 1, baseDelayMs: 100 },
+    });
+
+    // Should use Retry-After (5000ms) instead of computed delay
+    expect(sleepSpy).toHaveBeenCalledWith(5_000);
+  });
+
+  it('uses custom retryableStatuses', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ error: 'conflict' }), {
+        status: 409,
+        statusText: 'Conflict',
+      }),
+    );
+
+    await expect(
+      bloomreachApiFetch(TEST_CONFIG, '/test', {
+        retry: { maxRetries: 1, baseDelayMs: 1, retryableStatuses: [409] },
+      }),
+    ).rejects.toBeInstanceOf(BloomreachApiError);
+
+    // 409 is retryable with custom config: 1 initial + 1 retry = 2
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ===========================================================================
+// Request/response logging
+// ===========================================================================
+
+describe('request/response logging', () => {
+  it('does not call logger when option not provided', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    // No logger option — should not throw
+    await bloomreachApiFetch(TEST_CONFIG, '/test');
+  });
+
+  it('calls logger with request event before fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    const events: ApiLogEvent[] = [];
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      method: 'GET',
+      logger: (event) => events.push(event),
+    });
+
+    const requestEvent = events.find((e) => e.type === 'request');
+    expect(requestEvent).toBeDefined();
+    if (requestEvent) {
+      expect(requestEvent.method).toBe('GET');
+      expect(requestEvent.url).toBe('https://api.test.com/test');
+      expect(requestEvent.timestamp).toBeGreaterThan(0);
+    }
+  });
+
+  it('calls logger with response event after fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    const events: ApiLogEvent[] = [];
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      method: 'GET',
+      logger: (event) => events.push(event),
+    });
+
+    const responseEvent = events.find((e) => e.type === 'response');
+    expect(responseEvent).toBeDefined();
+    if (responseEvent && responseEvent.type === 'response') {
+      expect(responseEvent.statusCode).toBe(200);
+      expect(responseEvent.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('durationMs is a non-negative number', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    const events: ApiLogEvent[] = [];
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      logger: (event) => events.push(event),
+    });
+
+    const responseEvent = events.find((e) => e.type === 'response');
+    expect(responseEvent).toBeDefined();
+    if (responseEvent && responseEvent.type === 'response') {
+      expect(typeof responseEvent.durationMs).toBe('number');
+      expect(responseEvent.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('logs retry attempts with incrementing attempt field', async () => {
+    vi.spyOn(_internal, 'sleep').mockResolvedValue(undefined);
+
+    let callCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'fail' }), {
+            status: 500,
+            statusText: 'Server Error',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    const events: ApiLogEvent[] = [];
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+      logger: (event) => events.push(event),
+    });
+
+    const responseEvents = events.filter((e) => e.type === 'response');
+    expect(responseEvents).toHaveLength(3);
+
+    const [first, second, third] = responseEvents;
+
+    // First response (attempt 0) has no attempt field
+    expect(first).toBeDefined();
+    if (first && first.type === 'response') {
+      expect('attempt' in first).toBe(false);
+    }
+    // Second response has attempt=1
+    expect(second).toBeDefined();
+    if (second && second.type === 'response') {
+      expect(second.attempt).toBe(1);
+    }
+    // Third response has attempt=2
+    expect(third).toBeDefined();
+    if (third && third.type === 'response') {
+      expect(third.attempt).toBe(2);
+    }
+  });
+
+  it('does not include auth headers or body in any log event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    const events: ApiLogEvent[] = [];
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      body: { secret: 'data' },
+      logger: (event) => events.push(event),
+    });
+
+    for (const event of events) {
+      const eventStr = JSON.stringify(event);
+      expect(eventStr).not.toContain('Authorization');
+      expect(eventStr).not.toContain('my-key');
+      expect(eventStr).not.toContain('my-secret');
+      expect(eventStr).not.toContain('"secret"');
+    }
+  });
+});
+
+// ===========================================================================
+// Response caching
+// ===========================================================================
+
+describe('response caching', () => {
+  it('returns cached response on hit (fetch called once for two calls)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ data: 'cached' })),
+    );
+
+    const store = createApiCache();
+    const opts = { method: 'GET' as const, cache: { ttlMs: 60_000, store } };
+
+    const r1 = await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+    const r2 = await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+
+    expect(r1).toEqual({ data: 'cached' });
+    expect(r2).toEqual({ data: 'cached' });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches again after TTL expires', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ data: 'fresh' })),
+    );
+
+    const store = createApiCache();
+    const opts = { method: 'GET' as const, cache: { ttlMs: 100, store } };
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+
+    // Manually expire the cache entry
+    for (const [key, entry] of store) {
+      store.set(key, { ...entry, expiresAt: Date.now() - 1 });
+    }
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT cache POST requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    const store = createApiCache();
+    const opts = {
+      method: 'POST' as const,
+      body: { key: 'value' },
+      cache: { ttlMs: 60_000, store },
+    };
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(store.size).toBe(0);
+  });
+
+  it('does NOT cache PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ success: true })),
+    );
+
+    const store = createApiCache();
+    const opts = {
+      method: 'PUT' as const,
+      body: { key: 'value' },
+      cache: { ttlMs: 60_000, store },
+    };
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(store.size).toBe(0);
+  });
+
+  it('different URLs get separate cache entries', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    const store = createApiCache();
+    const cache = { ttlMs: 60_000, store };
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test-a', {
+      method: 'GET',
+      cache,
+    });
+    await bloomreachApiFetch(TEST_CONFIG, '/test-b', {
+      method: 'GET',
+      cache,
+    });
+
+    expect(store.size).toBe(2);
+  });
+
+  it('clearApiCache forces re-fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ data: 'refetched' })),
+    );
+
+    const store = createApiCache();
+    const opts = { method: 'GET' as const, cache: { ttlMs: 60_000, store } };
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+    clearApiCache(store);
+    await bloomreachApiFetch(TEST_CONFIG, '/test', opts);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('custom store option works (isolated cache)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      mockFetchImpl(JSON.stringify({ ok: true })),
+    );
+
+    const storeA = createApiCache();
+    const storeB = createApiCache();
+
+    await bloomreachApiFetch(TEST_CONFIG, '/test', {
+      method: 'GET',
+      cache: { ttlMs: 60_000, store: storeA },
+    });
+
+    expect(storeA.size).toBe(1);
+    expect(storeB.size).toBe(0);
+  });
+});
+
+// ===========================================================================
+// buildTrackingPath and buildDataPath
+// ===========================================================================
+
+describe('buildTrackingPath and buildDataPath', () => {
+  it('returns correctly formatted tracking path', () => {
+    const result = buildTrackingPath(TEST_CONFIG, '/customers');
     expect(result).toBe('/track/v2/projects/project-1/customers');
   });
 
   it('returns correctly formatted data path', () => {
-    const result = buildDataPath(
-      {
-        projectToken: 'project-1',
-        apiKeyId: 'my-key',
-        apiSecret: 'my-secret',
-        baseUrl: 'https://api.test.com',
-      },
-      '/customers/export',
-    );
-
+    const result = buildDataPath(TEST_CONFIG, '/customers/export');
     expect(result).toBe('/data/v2/projects/project-1/customers/export');
   });
 
   it('encodes special characters in project token', () => {
-    const config = {
-      projectToken: 'proj/with space',
-      apiKeyId: 'my-key',
-      apiSecret: 'my-secret',
-      baseUrl: 'https://api.test.com',
-    };
+    const config = { ...TEST_CONFIG, projectToken: 'proj/with space' };
 
     expect(buildTrackingPath(config, '/customers')).toBe(
       '/track/v2/projects/proj%2Fwith%20space/customers',
@@ -289,20 +1191,5 @@ describe('buildTrackingPath and buildDataPath', () => {
     expect(buildDataPath(config, '/customers/export')).toBe(
       '/data/v2/projects/proj%2Fwith%20space/customers/export',
     );
-  });
-});
-
-describe('BloomreachApiError', () => {
-  it('stores statusCode and responseBody', () => {
-    const error = new BloomreachApiError('failed', 500, { error: 'internal' });
-
-    expect(error.statusCode).toBe(500);
-    expect(error.responseBody).toEqual({ error: 'internal' });
-  });
-
-  it('has correct name property', () => {
-    const error = new BloomreachApiError('failed', 500, { error: 'internal' });
-
-    expect(error.name).toBe('BloomreachApiError');
   });
 });

--- a/packages/core/src/bloomreachApiClient.ts
+++ b/packages/core/src/bloomreachApiClient.ts
@@ -1,3 +1,7 @@
+// ---------------------------------------------------------------------------
+// Types & config
+// ---------------------------------------------------------------------------
+
 export interface BloomreachApiConfig {
   projectToken: string;
   apiKeyId: string;
@@ -6,6 +10,51 @@ export interface BloomreachApiConfig {
 }
 
 const DEFAULT_BASE_URL = 'https://api.exponea.com';
+
+// ---------------------------------------------------------------------------
+// Error hierarchy
+// ---------------------------------------------------------------------------
+
+export type BloomreachErrorCode =
+  | 'CONFIG_MISSING'
+  | 'TIMEOUT'
+  | 'RATE_LIMITED'
+  | 'API_ERROR'
+  | 'NETWORK_ERROR';
+
+/**
+ * Base error class for all Bloomreach Buddy errors.
+ * Every error carries a machine-readable `code` for programmatic handling.
+ */
+export class BloomreachBuddyError extends Error {
+  readonly code: BloomreachErrorCode;
+
+  constructor(code: BloomreachErrorCode, message: string) {
+    super(message);
+    this.name = 'BloomreachBuddyError';
+    this.code = code;
+  }
+}
+
+/**
+ * Thrown on non-2xx API responses. Carries the HTTP status code and the
+ * parsed (or raw) response body for inspection.
+ */
+export class BloomreachApiError extends BloomreachBuddyError {
+  readonly statusCode: number;
+  readonly responseBody: unknown;
+
+  constructor(message: string, statusCode: number, responseBody: unknown) {
+    super('API_ERROR', message);
+    this.name = 'BloomreachApiError';
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
 
 /**
  * Resolve API config from explicit values merged with environment variables.
@@ -26,17 +75,20 @@ export function resolveApiConfig(
     DEFAULT_BASE_URL;
 
   if (projectToken.trim().length === 0) {
-    throw new Error(
+    throw new BloomreachBuddyError(
+      'CONFIG_MISSING',
       'Bloomreach project token is required. Set BLOOMREACH_PROJECT_TOKEN or pass --project-token.',
     );
   }
   if (apiKeyId.trim().length === 0) {
-    throw new Error(
+    throw new BloomreachBuddyError(
+      'CONFIG_MISSING',
       'Bloomreach API key ID is required. Set BLOOMREACH_API_KEY_ID or pass --api-key-id.',
     );
   }
   if (apiSecret.trim().length === 0) {
-    throw new Error(
+    throw new BloomreachBuddyError(
+      'CONFIG_MISSING',
       'Bloomreach API secret is required. Set BLOOMREACH_API_SECRET or pass --api-secret.',
     );
   }
@@ -49,87 +101,329 @@ export function resolveApiConfig(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
 export function buildAuthHeader(config: BloomreachApiConfig): string {
   const credentials = `${config.apiKeyId}:${config.apiSecret}`;
   return `Basic ${Buffer.from(credentials).toString('base64')}`;
 }
 
-export class BloomreachApiError extends Error {
-  readonly statusCode: number;
-  readonly responseBody: unknown;
+// ---------------------------------------------------------------------------
+// Retry & rate-limit helpers
+// ---------------------------------------------------------------------------
 
-  constructor(message: string, statusCode: number, responseBody: unknown) {
-    super(message);
-    this.name = 'BloomreachApiError';
-    this.statusCode = statusCode;
-    this.responseBody = responseBody;
-  }
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default 3). */
+  maxRetries?: number;
+  /** Initial delay in ms before the first retry (default 500). */
+  baseDelayMs?: number;
+  /** Upper bound for computed delay in ms (default 30 000). */
+  maxDelayMs?: number;
+  /** HTTP status codes eligible for retry (default [429, 500, 502, 503, 504]). */
+  retryableStatuses?: number[];
 }
+
+export interface RateLimitInfo {
+  /** Parsed delay from Retry-After header, in milliseconds.  `null` when absent. */
+  retryAfterMs: number | null;
+}
+
+const DEFAULT_RETRYABLE_STATUSES = [429, 500, 502, 503, 504];
+
+/**
+ * Internal utilities exposed via an object so tests can spy on them.
+ * Object-property access is interceptable by `vi.spyOn` in ESM.
+ * @internal
+ */
+export const _internal = {
+  sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  },
+};
+
+/**
+ * Parse the `Retry-After` response header.
+ * Supports both delta-seconds ("120") and HTTP-date ("Wed, 21 Oct 2025 07:28:00 GMT").
+ * Returns milliseconds to wait, or `null` if the header is absent/unparseable.
+ * @internal
+ */
+export function parseRetryAfter(headers: Headers): number | null {
+  const value = headers.get('retry-after');
+  if (value === null) return null;
+
+  // Try as integer seconds first
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1_000;
+  }
+
+  // Try as HTTP-date
+  const date = Date.parse(value);
+  if (!Number.isNaN(date)) {
+    const delta = date - Date.now();
+    return delta > 0 ? delta : 0;
+  }
+
+  return null;
+}
+
+/**
+ * Compute the delay for the next retry attempt using exponential backoff
+ * with ±20 % jitter, capped at `maxDelayMs`. If a `Retry-After` value is
+ * available it takes precedence.
+ * @internal
+ */
+export function computeRetryDelay(
+  attempt: number,
+  options: Required<RetryOptions>,
+  retryAfterMs: number | null,
+): number {
+  if (retryAfterMs !== null && retryAfterMs > 0) {
+    return Math.min(retryAfterMs, options.maxDelayMs);
+  }
+
+  const exponential = options.baseDelayMs * 2 ** attempt;
+  const jitter = 0.8 + Math.random() * 0.4; // ±20 %
+  return Math.min(exponential * jitter, options.maxDelayMs);
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+export interface ApiRequestLog {
+  type: 'request';
+  method: string;
+  url: string;
+  timestamp: number;
+}
+
+export interface ApiResponseLog {
+  type: 'response';
+  method: string;
+  url: string;
+  statusCode: number;
+  durationMs: number;
+  timestamp: number;
+  /** Present when the request is a retry attempt (1-indexed). */
+  attempt?: number;
+}
+
+export type ApiLogEvent = ApiRequestLog | ApiResponseLog;
+
+// ---------------------------------------------------------------------------
+// Caching
+// ---------------------------------------------------------------------------
+
+export interface CacheEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+export interface CacheOptions {
+  /** Time-to-live in milliseconds. */
+  ttlMs: number;
+  /** Optional external store. Falls back to module-level default. */
+  store?: Map<string, CacheEntry>;
+}
+
+const defaultCacheStore = new Map<string, CacheEntry>();
+
+/** Create a fresh, isolated cache store. */
+export function createApiCache(): Map<string, CacheEntry> {
+  return new Map();
+}
+
+/** Remove all entries from the given cache (or the module-level default). */
+export function clearApiCache(
+  cache: Map<string, CacheEntry> = defaultCacheStore,
+): void {
+  cache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Fetch options (extended)
+// ---------------------------------------------------------------------------
 
 export interface BloomreachFetchOptions {
   method?: string;
   body?: unknown;
   timeoutMs?: number;
+  /** Opt-in retry with exponential backoff.  Omit to disable retries. */
+  retry?: RetryOptions;
+  /** Opt-in structured request/response logging.  Omit to disable. */
+  logger?: (event: ApiLogEvent) => void;
+  /** Opt-in TTL-based caching for GET requests.  Omit to disable. */
+  cache?: CacheOptions;
 }
+
+// ---------------------------------------------------------------------------
+// Core fetch implementation
+// ---------------------------------------------------------------------------
 
 /**
  * Make an authenticated request to the Bloomreach REST API.
- * @throws {BloomreachApiError} On non-2xx responses.
+ *
+ * Features (all opt-in via {@link BloomreachFetchOptions}):
+ * - Retry with exponential back-off and `Retry-After` awareness
+ * - Structured request/response logging
+ * - TTL-based response caching (GET only)
+ *
+ * @throws {BloomreachApiError} On non-2xx responses (after retries are exhausted).
+ * @throws {BloomreachBuddyError} On timeout (`code: 'TIMEOUT'`) or network failure (`code: 'NETWORK_ERROR'`).
  */
 export async function bloomreachApiFetch(
   config: BloomreachApiConfig,
   path: string,
   options: BloomreachFetchOptions = {},
 ): Promise<unknown> {
-  const { method = 'POST', body, timeoutMs = 30_000 } = options;
+  const {
+    method = 'POST',
+    body,
+    timeoutMs = 30_000,
+    retry,
+    logger,
+    cache,
+  } = options;
   const url = `${config.baseUrl}${path}`;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const response = await fetch(url, {
-      method,
-      headers: {
-        Authorization: buildAuthHeader(config),
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-      signal: controller.signal,
-    });
-
-    const text = await response.text();
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(text);
-    } catch {
-      parsed = text;
+  // ---- Cache check (GET only) ----
+  if (cache && method === 'GET') {
+    const store = cache.store ?? defaultCacheStore;
+    const cacheKey = `GET::${url}`;
+    const cached = store.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data;
     }
-
-    if (!response.ok) {
-      throw new BloomreachApiError(
-        `Bloomreach API error ${response.status}: ${response.statusText}`,
-        response.status,
-        parsed,
-      );
-    }
-
-    return parsed;
-  } catch (error) {
-    if (error instanceof BloomreachApiError) {
-      throw error;
-    }
-    if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new Error(
-        `Bloomreach API request timed out after ${timeoutMs}ms: ${method} ${path}`,
-      );
-    }
-    throw error;
-  } finally {
-    clearTimeout(timer);
   }
+
+  // ---- Retry setup ----
+  const maxRetries = retry?.maxRetries ?? 0;
+  const retryOpts: Required<RetryOptions> = {
+    maxRetries,
+    baseDelayMs: retry?.baseDelayMs ?? 500,
+    maxDelayMs: retry?.maxDelayMs ?? 30_000,
+    retryableStatuses: retry?.retryableStatuses ?? DEFAULT_RETRYABLE_STATUSES,
+  };
+
+  let lastError: BloomreachApiError | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    // ---- Log request ----
+    if (logger && attempt === 0) {
+      logger({ type: 'request', method, url, timestamp: Date.now() });
+    }
+
+    const start = performance.now();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          Authorization: buildAuthHeader(config),
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+      const durationMs = performance.now() - start;
+
+      // ---- Log response ----
+      if (logger) {
+        const logEntry: ApiResponseLog = {
+          type: 'response',
+          method,
+          url,
+          statusCode: response.status,
+          durationMs,
+          timestamp: Date.now(),
+        };
+        if (attempt > 0) logEntry.attempt = attempt;
+        logger(logEntry);
+      }
+
+      // ---- Parse body ----
+      const text = await response.text();
+      let parsed: unknown;
+      if (text.length === 0) {
+        parsed = undefined;
+      } else {
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+      }
+
+      // ---- Handle errors ----
+      if (!response.ok) {
+        const apiError = new BloomreachApiError(
+          `Bloomreach API error ${response.status}: ${response.statusText}`,
+          response.status,
+          parsed,
+        );
+
+        // Should we retry?
+        if (
+          attempt < maxRetries &&
+          retryOpts.retryableStatuses.includes(response.status)
+        ) {
+          lastError = apiError;
+          const retryAfterMs = parseRetryAfter(response.headers);
+          const delay = computeRetryDelay(attempt, retryOpts, retryAfterMs);
+          await _internal.sleep(delay);
+          continue;
+        }
+
+        throw apiError;
+      }
+
+      // ---- Cache store (GET only) ----
+      if (cache && method === 'GET') {
+        const store = cache.store ?? defaultCacheStore;
+        const cacheKey = `GET::${url}`;
+        store.set(cacheKey, {
+          data: parsed,
+          expiresAt: Date.now() + cache.ttlMs,
+        });
+      }
+
+      return parsed;
+    } catch (error) {
+      clearTimeout(timer);
+
+      if (error instanceof BloomreachApiError) {
+        throw error;
+      }
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw new BloomreachBuddyError(
+          'TIMEOUT',
+          `Bloomreach API request timed out after ${timeoutMs}ms: ${method} ${path}`,
+        );
+      }
+
+      throw new BloomreachBuddyError(
+        'NETWORK_ERROR',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  /* istanbul ignore next — should be unreachable when maxRetries >= 0 */
+  if (lastError) throw lastError;
+  throw new BloomreachBuddyError('NETWORK_ERROR', 'Unexpected retry loop exit');
 }
+
+// ---------------------------------------------------------------------------
+// Path builders
+// ---------------------------------------------------------------------------
 
 export function buildTrackingPath(
   config: BloomreachApiConfig,


### PR DESCRIPTION
## Summary

Acid test for the API Client Infrastructure (`packages/core/src/bloomreachApiClient.ts`). Implements all QoL improvements from #132 and expands test coverage from 21 to 76+ test cases.

## Changes

### Error Hierarchy (backward-compatible)
- **`BloomreachBuddyError`** base class with machine-readable error codes: `CONFIG_MISSING`, `TIMEOUT`, `RATE_LIMITED`, `API_ERROR`, `NETWORK_ERROR`
- **`BloomreachApiError`** now extends `BloomreachBuddyError` (still `instanceof Error`)
- `resolveApiConfig` throws `BloomreachBuddyError` with `CONFIG_MISSING` instead of raw `Error`
- Timeout now throws `BloomreachBuddyError` with `TIMEOUT` code
- Network failures throw `BloomreachBuddyError` with `NETWORK_ERROR` code

### Retry with Exponential Backoff
- Opt-in via `retry` option in `BloomreachFetchOptions`
- Configurable `maxRetries`, `baseDelayMs`, `maxDelayMs`, `retryableStatuses`
- Exponential backoff with ±20% jitter
- `Retry-After` header parsing (integer seconds and HTTP-date) takes precedence over computed delay
- Default retryable statuses: 429, 500, 502, 503, 504

### Request/Response Logging
- Opt-in via `logger` callback in `BloomreachFetchOptions`
- Structured `ApiRequestLog` and `ApiResponseLog` events
- Includes method, URL, status code, duration — excludes auth headers and body (security)
- Retry attempts logged with `attempt` field

### TTL-based Response Caching
- Opt-in via `cache` option in `BloomreachFetchOptions`
- Only caches GET requests (POST/PUT/DELETE always bypass)
- Configurable TTL and external store for isolation
- `createApiCache()` and `clearApiCache()` utilities

### Empty Response Handling
- Empty response body now returns `undefined` instead of `""` (no consumers check for `""`)

### Tests
- **76 unit tests** covering error hierarchy, retry logic, rate-limit header parsing, logging, caching, HTTP methods, Content-Type headers, empty responses, error message structure
- **7 conditional E2E tests** (skipped when `BLOOMREACH_*` env vars not set) testing real API auth, error handling, HTTP methods, and path builder integration
- All new features are opt-in — zero breaking changes to existing 6 consumer modules

## Quality Gates
- ✅ `npm test` — 4565 passed, 7 skipped (E2E without creds)
- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — 0 errors
- ✅ `npm run build` — clean

Closes #132
