### PR TITLE
feat #133: acid test MCP server — input validation, structured errors, 92 unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4839,7 +4839,8 @@
         "bloomreach-mcp": "dist/bin/bloomreach-mcp.js"
       },
       "devDependencies": {
-        "tsup": "^8.0.0"
+        "tsup": "^8.0.0",
+        "vitest": "^4.1.0"
       }
     }
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -17,13 +17,16 @@
   ],
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@bloomreach-buddy/core": "0.0.1",
     "@modelcontextprotocol/sdk": "^1.12.1"
   },
   "devDependencies": {
-    "tsup": "^8.0.0"
+    "tsup": "^8.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/mcp/src/__tests__/toolArgs.test.ts
+++ b/packages/mcp/src/__tests__/toolArgs.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import {
+  readString,
+  readRequiredString,
+  readBoundedString,
+  readValidatedUrl,
+  readPositiveNumber,
+  readNonNegativeNumber,
+  readBoolean,
+  readRequiredBoolean,
+  readOptionalPositiveNumber,
+  readOptionalNonNegativeNumber,
+  readStringArray,
+  readRequiredStringArray,
+  readObject,
+  trimOrUndefined,
+} from '../toolArgs.js';
+
+describe('readString', () => {
+  it('returns the value when string is present', () => {
+    expect(readString({ name: 'test' }, 'name', 'default')).toBe('test');
+  });
+
+  it('returns fallback when key is missing', () => {
+    expect(readString({}, 'name', 'default')).toBe('default');
+  });
+
+  it('returns fallback for empty string', () => {
+    expect(readString({ name: '  ' }, 'name', 'default')).toBe('default');
+  });
+
+  it('trims whitespace', () => {
+    expect(readString({ name: '  hello  ' }, 'name', '')).toBe('hello');
+  });
+});
+
+describe('trimOrUndefined', () => {
+  it('returns trimmed string for non-empty values', () => {
+    expect(trimOrUndefined('  hello  ')).toBe('hello');
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(trimOrUndefined('  ')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string', () => {
+    expect(trimOrUndefined(undefined)).toBeUndefined();
+  });
+});
+
+describe('readRequiredString', () => {
+  it('returns the value when present', () => {
+    expect(readRequiredString({ name: 'test' }, 'name')).toBe('test');
+  });
+
+  it('throws when key is missing', () => {
+    expect(() => readRequiredString({}, 'name')).toThrow('name is required');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => readRequiredString({ name: '' }, 'name')).toThrow('name is required');
+  });
+});
+
+describe('readBoundedString', () => {
+  it('returns the value within bounds', () => {
+    expect(readBoundedString({ name: 'test' }, 'name', 100)).toBe('test');
+  });
+
+  it('throws when value exceeds maxLength', () => {
+    expect(() => readBoundedString({ name: 'long text' }, 'name', 3)).toThrow(
+      'must be 3 characters or fewer',
+    );
+  });
+
+  it('uses fallback when provided and key is missing', () => {
+    expect(readBoundedString({}, 'name', 100, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('readValidatedUrl', () => {
+  it('returns normalized URL for valid input', () => {
+    expect(readValidatedUrl({ url: 'https://example.com' }, 'url')).toBe('https://example.com/');
+  });
+
+  it('throws for invalid URL', () => {
+    expect(() => readValidatedUrl({ url: 'not-a-url' }, 'url')).toThrow('must be a valid URL');
+  });
+});
+
+describe('readPositiveNumber', () => {
+  it('returns the value when positive', () => {
+    expect(readPositiveNumber({ count: 5 }, 'count', 1)).toBe(5);
+  });
+
+  it('returns fallback for non-number', () => {
+    expect(readPositiveNumber({ count: 'nope' }, 'count', 10)).toBe(10);
+  });
+
+  it('throws for zero', () => {
+    expect(() => readPositiveNumber({ count: 0 }, 'count', 1)).toThrow(
+      'must be a positive number',
+    );
+  });
+
+  it('throws for negative', () => {
+    expect(() => readPositiveNumber({ count: -1 }, 'count', 1)).toThrow(
+      'must be a positive number',
+    );
+  });
+});
+
+describe('readNonNegativeNumber', () => {
+  it('returns zero', () => {
+    expect(readNonNegativeNumber({ offset: 0 }, 'offset', 1)).toBe(0);
+  });
+
+  it('throws for negative', () => {
+    expect(() => readNonNegativeNumber({ offset: -1 }, 'offset', 0)).toThrow(
+      'must be zero or a positive number',
+    );
+  });
+});
+
+describe('readBoolean', () => {
+  it('returns the boolean value', () => {
+    expect(readBoolean({ active: true }, 'active', false)).toBe(true);
+  });
+
+  it('returns fallback for non-boolean', () => {
+    expect(readBoolean({ active: 'yes' }, 'active', false)).toBe(false);
+  });
+});
+
+describe('readRequiredBoolean', () => {
+  it('returns the boolean value', () => {
+    expect(readRequiredBoolean({ active: false }, 'active')).toBe(false);
+  });
+
+  it('throws for non-boolean', () => {
+    expect(() => readRequiredBoolean({ active: 'yes' }, 'active')).toThrow('active is required');
+  });
+});
+
+describe('readOptionalPositiveNumber', () => {
+  it('returns undefined when key is absent', () => {
+    expect(readOptionalPositiveNumber({}, 'limit')).toBeUndefined();
+  });
+
+  it('returns the value when present and positive', () => {
+    expect(readOptionalPositiveNumber({ limit: 5 }, 'limit')).toBe(5);
+  });
+});
+
+describe('readOptionalNonNegativeNumber', () => {
+  it('returns undefined when key is absent', () => {
+    expect(readOptionalNonNegativeNumber({}, 'offset')).toBeUndefined();
+  });
+
+  it('returns the value when present and non-negative', () => {
+    expect(readOptionalNonNegativeNumber({ offset: 0 }, 'offset')).toBe(0);
+  });
+
+  it('throws for negative values', () => {
+    expect(() => readOptionalNonNegativeNumber({ offset: -1 }, 'offset')).toThrow(
+      'must be a non-negative integer',
+    );
+  });
+});
+
+describe('readStringArray', () => {
+  it('returns array of strings', () => {
+    expect(readStringArray({ tags: ['a', 'b'] }, 'tags')).toEqual(['a', 'b']);
+  });
+
+  it('wraps single string in array', () => {
+    expect(readStringArray({ tags: 'single' }, 'tags')).toEqual(['single']);
+  });
+
+  it('returns undefined when key is absent', () => {
+    expect(readStringArray({}, 'tags')).toBeUndefined();
+  });
+
+  it('filters empty strings from arrays', () => {
+    expect(readStringArray({ tags: ['a', '', '  ', 'b'] }, 'tags')).toEqual(['a', 'b']);
+  });
+
+  it('throws for non-string non-array values', () => {
+    expect(() => readStringArray({ tags: 42 }, 'tags')).toThrow(
+      'must be a string or array of strings',
+    );
+  });
+});
+
+describe('readRequiredStringArray', () => {
+  it('returns the array when present', () => {
+    expect(readRequiredStringArray({ ids: ['a'] }, 'ids')).toEqual(['a']);
+  });
+
+  it('throws when empty', () => {
+    expect(() => readRequiredStringArray({}, 'ids')).toThrow('ids is required');
+  });
+});
+
+describe('readObject', () => {
+  it('returns the object when present', () => {
+    expect(readObject({ data: { key: 'val' } }, 'data')).toEqual({ key: 'val' });
+  });
+
+  it('returns undefined when absent', () => {
+    expect(readObject({}, 'data')).toBeUndefined();
+  });
+
+  it('throws for non-object values', () => {
+    expect(() => readObject({ data: 'string' }, 'data')).toThrow('must be an object');
+  });
+
+  it('throws for arrays', () => {
+    expect(() => readObject({ data: [1, 2] }, 'data')).toThrow('must be an object');
+  });
+});

--- a/packages/mcp/src/__tests__/toolConstants.test.ts
+++ b/packages/mcp/src/__tests__/toolConstants.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { BLOOMREACH_MCP_TOOL_NAMES } from '../index.js';
+
+describe('tool constants', () => {
+  it('exports 245 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(245);
+  });
+
+  it('all tool names follow bloomreach.<domain>.<action> dot-notation', () => {
+    for (const name of BLOOMREACH_MCP_TOOL_NAMES) {
+      const parts = name.split('.');
+      expect(parts.length).toBeGreaterThanOrEqual(3);
+      expect(parts[0]).toBe('bloomreach');
+      for (const part of parts) {
+        expect(part).toMatch(/^[a-z_]+$/);
+      }
+    }
+  });
+
+  it('has no duplicate tool names', () => {
+    const unique = new Set(BLOOMREACH_MCP_TOOL_NAMES);
+    expect(unique.size).toBe(BLOOMREACH_MCP_TOOL_NAMES.length);
+  });
+
+  it('includes bloomreach.session.status tool', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toContain('bloomreach.session.status');
+  });
+
+  it('includes bloomreach.dashboards.list tool', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toContain('bloomreach.dashboards.list');
+  });
+
+  it('includes prepare tools with prepare_ in name', () => {
+    const prepareTools = BLOOMREACH_MCP_TOOL_NAMES.filter((name) => name.includes('prepare_'));
+    expect(prepareTools.length).toBeGreaterThan(0);
+    for (const name of prepareTools) {
+      expect(name).toMatch(/prepare_/);
+    }
+  });
+
+  it('covers all 33 expected service domains', () => {
+    const domains = new Set(BLOOMREACH_MCP_TOOL_NAMES.map((name) => name.split('.')[1]));
+    const expectedDomains = [
+      'access',
+      'assets',
+      'campaign_settings',
+      'campaigns_calendar',
+      'catalogs',
+      'customers',
+      'dashboards',
+      'data_manager',
+      'email_campaigns',
+      'evaluation_settings',
+      'exports',
+      'flows',
+      'funnels',
+      'geo_analyses',
+      'imports',
+      'initiatives',
+      'integrations',
+      'metrics',
+      'performance',
+      'project_settings',
+      'reports',
+      'retentions',
+      'scenarios',
+      'security_settings',
+      'segmentations',
+      'session',
+      'sql_reports',
+      'surveys',
+      'tag_manager',
+      'trends',
+      'use_cases',
+      'vouchers',
+      'weblayers',
+    ];
+
+    expect(domains.size).toBe(expectedDomains.length);
+    for (const domain of expectedDomains) {
+      expect(domains).toContain(domain);
+    }
+  });
+});

--- a/packages/mcp/src/__tests__/toolResults.test.ts
+++ b/packages/mcp/src/__tests__/toolResults.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { BloomreachBuddyError } from '@bloomreach-buddy/core';
+import { toToolResult, toErrorResult, buildRecoveryHint } from '../toolResults.js';
+
+describe('toToolResult', () => {
+  it('wraps payload in MCP text content', () => {
+    const result = toToolResult({ items: [1, 2] });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: JSON.stringify({ items: [1, 2] }, null, 2) }],
+    });
+  });
+
+  it('handles null payload', () => {
+    const result = toToolResult(null);
+    expect(result.content[0]?.text).toBe('null');
+  });
+
+  it('handles string payload', () => {
+    const result = toToolResult('ok');
+    expect(result.content[0]?.text).toBe('"ok"');
+  });
+});
+
+describe('toErrorResult', () => {
+  it('wraps generic Error with UNKNOWN code and recovery hint', () => {
+    const result = toErrorResult(new Error('something broke'));
+    expect(result.isError).toBe(true);
+
+    const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(payload.code).toBe('UNKNOWN');
+    expect(payload.message).toBe('something broke');
+    expect(payload.recovery_hint).toBeTruthy();
+  });
+
+  it('wraps BloomreachBuddyError with its error code', () => {
+    const error = new BloomreachBuddyError('API_ERROR', 'Bad request');
+    const result = toErrorResult(error);
+
+    const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(payload.code).toBe('API_ERROR');
+    expect(payload.message).toBe('Bad request');
+  });
+
+  it('handles non-Error values', () => {
+    const result = toErrorResult('string error');
+    const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(payload.code).toBe('UNKNOWN');
+    expect(payload.message).toBe('Unknown error occurred.');
+  });
+});
+
+describe('buildRecoveryHint', () => {
+  it('returns CONFIG_MISSING hint for config errors', () => {
+    const error = new BloomreachBuddyError('CONFIG_MISSING', 'no config');
+    expect(buildRecoveryHint(error)).toContain('BLOOMREACH_PROJECT_TOKEN');
+  });
+
+  it('returns TIMEOUT hint for timeout errors', () => {
+    const error = new BloomreachBuddyError('TIMEOUT', 'timed out');
+    expect(buildRecoveryHint(error)).toContain('timed out');
+  });
+
+  it('returns RATE_LIMITED hint for rate limit errors', () => {
+    const error = new BloomreachBuddyError('RATE_LIMITED', 'too fast');
+    expect(buildRecoveryHint(error)).toContain('rate limit');
+  });
+
+  it('returns API_ERROR hint for API errors', () => {
+    const error = new BloomreachBuddyError('API_ERROR', 'bad request');
+    expect(buildRecoveryHint(error)).toContain('API');
+  });
+
+  it('returns NETWORK_ERROR hint for network errors', () => {
+    const error = new BloomreachBuddyError('NETWORK_ERROR', 'disconnected');
+    expect(buildRecoveryHint(error)).toContain('network');
+  });
+
+  it('returns generic hint for non-Bloomreach errors', () => {
+    const hint = buildRecoveryHint(new Error('generic'));
+    expect(hint).toContain('unexpected error');
+  });
+});

--- a/packages/mcp/src/__tests__/toolSchema.test.ts
+++ b/packages/mcp/src/__tests__/toolSchema.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateToolArgValueAgainstSchema,
+  isPlainObject,
+  describeToolArgValue,
+  appendToolSchemaPath,
+  formatToolSchemaPath,
+  describeToolSchemaTypes,
+} from '../toolSchema.js';
+import type { BloomreachMcpInputSchema } from '../toolSchema.js';
+
+describe('isPlainObject', () => {
+  it('returns true for plain objects', () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ key: 'value' })).toBe(true);
+  });
+
+  it('returns false for arrays', () => {
+    expect(isPlainObject([])).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isPlainObject(null)).toBe(false);
+  });
+
+  it('returns false for primitives', () => {
+    expect(isPlainObject('string')).toBe(false);
+    expect(isPlainObject(42)).toBe(false);
+    expect(isPlainObject(true)).toBe(false);
+    expect(isPlainObject(undefined)).toBe(false);
+  });
+});
+
+describe('describeToolArgValue', () => {
+  it('returns "array" for arrays', () => {
+    expect(describeToolArgValue([])).toBe('array');
+  });
+
+  it('returns "null" for null', () => {
+    expect(describeToolArgValue(null)).toBe('null');
+  });
+
+  it('returns "non-finite number" for Infinity', () => {
+    expect(describeToolArgValue(Infinity)).toBe('non-finite number');
+    expect(describeToolArgValue(NaN)).toBe('non-finite number');
+  });
+
+  it('returns typeof for regular values', () => {
+    expect(describeToolArgValue('hello')).toBe('string');
+    expect(describeToolArgValue(42)).toBe('number');
+    expect(describeToolArgValue(true)).toBe('boolean');
+  });
+});
+
+describe('appendToolSchemaPath', () => {
+  it('returns segment for empty path', () => {
+    expect(appendToolSchemaPath('', 'project')).toBe('project');
+  });
+
+  it('appends with dot separator', () => {
+    expect(appendToolSchemaPath('root', 'child')).toBe('root.child');
+  });
+
+  it('appends array index without dot', () => {
+    expect(appendToolSchemaPath('items', '[0]')).toBe('items[0]');
+  });
+});
+
+describe('formatToolSchemaPath', () => {
+  it('returns "arguments" for empty path', () => {
+    expect(formatToolSchemaPath('')).toBe('arguments');
+  });
+
+  it('returns the path itself when non-empty', () => {
+    expect(formatToolSchemaPath('project')).toBe('project');
+  });
+});
+
+describe('describeToolSchemaTypes', () => {
+  it('returns the type for simple schemas', () => {
+    expect(describeToolSchemaTypes({ type: 'string' })).toBe('string');
+  });
+
+  it('returns enum values for enum schemas', () => {
+    expect(describeToolSchemaTypes({ enum: ['a', 'b'] })).toBe('"a", "b"');
+  });
+
+  it('returns joined types for anyOf schemas', () => {
+    expect(describeToolSchemaTypes({ anyOf: [{ type: 'string' }, { type: 'number' }] })).toBe(
+      'string, number',
+    );
+  });
+
+  it('returns "supported value" for empty schema', () => {
+    expect(describeToolSchemaTypes({})).toBe('supported value');
+  });
+});
+
+describe('validateToolArgValueAgainstSchema', () => {
+  it('accepts valid string values', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'string' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 'hello', '')).not.toThrow();
+  });
+
+  it('rejects non-string when string expected', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'string' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 123, '')).toThrow('must be a string');
+  });
+
+  it('accepts valid number values', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'number' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 42.5, '')).not.toThrow();
+  });
+
+  it('rejects non-finite numbers', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'number' };
+    expect(() => validateToolArgValueAgainstSchema(schema, Infinity, '')).toThrow(
+      'must be a finite number',
+    );
+  });
+
+  it('accepts valid integer values', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'integer' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 42, '')).not.toThrow();
+  });
+
+  it('rejects non-integer when integer expected', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'integer' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 42.5, '')).toThrow(
+      'must be an integer',
+    );
+  });
+
+  it('accepts valid boolean values', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'boolean' };
+    expect(() => validateToolArgValueAgainstSchema(schema, true, '')).not.toThrow();
+  });
+
+  it('rejects non-boolean when boolean expected', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'boolean' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 'true', '')).toThrow(
+      'must be a boolean',
+    );
+  });
+
+  it('accepts valid array values', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'array' };
+    expect(() => validateToolArgValueAgainstSchema(schema, [1, 2, 3], '')).not.toThrow();
+  });
+
+  it('rejects non-array when array expected', () => {
+    const schema: BloomreachMcpInputSchema = { type: 'array' };
+    expect(() => validateToolArgValueAgainstSchema(schema, 'not-array', '')).toThrow(
+      'must be an array',
+    );
+  });
+
+  it('validates array items against item schema', () => {
+    const schema: BloomreachMcpInputSchema = {
+      type: 'array',
+      items: { type: 'string' },
+    };
+    expect(() => validateToolArgValueAgainstSchema(schema, ['a', 'b'], '')).not.toThrow();
+    expect(() => validateToolArgValueAgainstSchema(schema, ['a', 42], '')).toThrow(
+      '[1] must be a string',
+    );
+  });
+
+  it('validates object with required fields', () => {
+    const schema: BloomreachMcpInputSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    };
+
+    expect(() => validateToolArgValueAgainstSchema(schema, { name: 'test' }, '')).not.toThrow();
+    expect(() => validateToolArgValueAgainstSchema(schema, {}, '')).toThrow('name is required');
+  });
+
+  it('rejects additional properties when additionalProperties is false', () => {
+    const schema: BloomreachMcpInputSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      additionalProperties: false,
+    };
+
+    expect(() => validateToolArgValueAgainstSchema(schema, { name: 'ok', extra: 1 }, '')).toThrow(
+      'extra is not allowed',
+    );
+  });
+
+  it('validates enum values', () => {
+    const schema: BloomreachMcpInputSchema = {
+      type: 'string',
+      enum: ['active', 'paused', 'archived'],
+    };
+
+    expect(() => validateToolArgValueAgainstSchema(schema, 'active', '')).not.toThrow();
+    expect(() => validateToolArgValueAgainstSchema(schema, 'deleted', '')).toThrow('must be one of');
+  });
+
+  it('validates anyOf schemas', () => {
+    const schema: BloomreachMcpInputSchema = {
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+    };
+
+    expect(() => validateToolArgValueAgainstSchema(schema, 'text', '')).not.toThrow();
+    expect(() => validateToolArgValueAgainstSchema(schema, 42, '')).not.toThrow();
+    expect(() => validateToolArgValueAgainstSchema(schema, true, '')).toThrow('must match one of');
+  });
+});

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -4,6 +4,9 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import * as core from '@bloomreach-buddy/core';
 import * as toolNames from '../index.js';
+import { toToolResult, toErrorResult } from '../toolResults.js';
+import { isPlainObject, validateToolArgValueAgainstSchema } from '../toolSchema.js';
+import type { BloomreachMcpInputSchema } from '../toolSchema.js';
 
 const projectId = process.env.BLOOMREACH_PROJECT ?? '';
 
@@ -46,24 +49,6 @@ type ServiceConstructor = new (
   project: string,
   apiConfig?: core.BloomreachApiConfig,
 ) => ServiceInstance;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function toToolResult(payload: unknown) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
-  };
-}
-
-function toErrorResult(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  return {
-    isError: true,
-    content: [{ type: 'text' as const, text: JSON.stringify({ error: message }, null, 2) }],
-  };
-}
 
 function getProject(args: Record<string, unknown>): string {
   const projectFromArgs = typeof args.project === 'string' ? args.project.trim() : '';
@@ -5574,7 +5559,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name } = request.params;
-  const args = isRecord(request.params.arguments) ? request.params.arguments : {};
+  const args = isPlainObject(request.params.arguments) ? request.params.arguments : {};
 
   try {
     if (name === toolNames.BLOOMREACH_STATUS_TOOL) {
@@ -5587,7 +5572,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     const route = toolByName.get(name);
     if (!route || !route.serviceClass || !route.methodName) {
-      return toErrorResult(`Unknown tool: ${name}`);
+      return toErrorResult(new Error(`Unknown tool: ${name}`));
+    }
+
+    // Validate input arguments against the tool's schema
+    try {
+      validateToolArgValueAgainstSchema(
+        route.inputSchema as BloomreachMcpInputSchema,
+        args,
+        '',
+      );
+    } catch (validationError) {
+      return toErrorResult(validationError);
     }
 
     const project = getProject(args);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,8 @@
+// Re-export utility modules for consumers
+export * from './toolSchema.js';
+export * from './toolArgs.js';
+export * from './toolResults.js';
+
 export const BLOOMREACH_STATUS_TOOL = 'bloomreach.session.status';
 export const BLOOMREACH_DASHBOARDS_LIST_TOOL = 'bloomreach.dashboards.list';
 export const BLOOMREACH_DASHBOARDS_PREPARE_CREATE_TOOL = 'bloomreach.dashboards.prepare_create';

--- a/packages/mcp/src/toolArgs.ts
+++ b/packages/mcp/src/toolArgs.ts
@@ -1,0 +1,160 @@
+export type ToolArgs = Record<string, unknown>;
+
+export function readString(args: ToolArgs, key: string, fallback: string): string {
+  const value = args[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+export function trimOrUndefined(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function readRequiredString(args: ToolArgs, key: string): string {
+  const value = args[key];
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  throw new Error(`${key} is required.`);
+}
+
+export function readBoundedString(
+  args: ToolArgs,
+  key: string,
+  maxLength = 5000,
+  fallback?: string,
+): string {
+  const value =
+    typeof fallback === 'string' ? readString(args, key, fallback) : readRequiredString(args, key);
+
+  if (value.length > maxLength) {
+    throw new Error(`${key} must be ${maxLength} characters or fewer.`);
+  }
+
+  return value;
+}
+
+export function readValidatedUrl(args: ToolArgs, key: string): string {
+  const value = readRequiredString(args, key);
+
+  try {
+    return new URL(value).toString();
+  } catch (error) {
+    throw new Error(
+      `${key} must be a valid URL. ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export function readPositiveNumber(args: ToolArgs, key: string, fallback: number): number {
+  const value = args[key];
+  if (typeof value !== 'number') {
+    return fallback;
+  }
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${key} must be a positive number.`);
+  }
+
+  return value;
+}
+
+export function readNonNegativeNumber(args: ToolArgs, key: string, fallback: number): number {
+  const value = args[key];
+  if (typeof value !== 'number') {
+    return fallback;
+  }
+
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${key} must be zero or a positive number.`);
+  }
+
+  return value;
+}
+
+export function readBoolean(args: ToolArgs, key: string, fallback: boolean): boolean {
+  const value = args[key];
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+export function readRequiredBoolean(args: ToolArgs, key: string): boolean {
+  const value = args[key];
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  throw new Error(`${key} is required.`);
+}
+
+export function readOptionalPositiveNumber(args: ToolArgs, key: string): number | undefined {
+  if (!(key in args) || args[key] === undefined) {
+    return undefined;
+  }
+
+  return readPositiveNumber(args, key, 1);
+}
+
+export function readOptionalNonNegativeNumber(args: ToolArgs, key: string): number | undefined {
+  if (!(key in args) || args[key] === undefined) {
+    return undefined;
+  }
+
+  const value = args[key];
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    throw new Error(`${key} must be a non-negative integer.`);
+  }
+
+  return value;
+}
+
+export function readStringArray(args: ToolArgs, key: string): string[] | undefined {
+  const value = args[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return [value.trim()];
+  }
+
+  if (Array.isArray(value)) {
+    const items = value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+    return items.length > 0 ? items : undefined;
+  }
+
+  throw new Error(`${key} must be a string or array of strings.`);
+}
+
+export function readRequiredStringArray(args: ToolArgs, key: string): string[] {
+  const values = readStringArray(args, key);
+  if (values && values.length > 0) {
+    return values;
+  }
+
+  throw new Error(`${key} is required.`);
+}
+
+export function readObject(args: ToolArgs, key: string): Record<string, unknown> | undefined {
+  const value = args[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  throw new Error(`${key} must be an object.`);
+}

--- a/packages/mcp/src/toolResults.ts
+++ b/packages/mcp/src/toolResults.ts
@@ -1,0 +1,68 @@
+import { BloomreachBuddyError } from '@bloomreach-buddy/core';
+import type { ToolArgs } from './toolArgs.js';
+
+export type ToolResult = { content: Array<{ type: 'text'; text: string }> };
+
+export type ToolErrorResult = {
+  isError: true;
+  content: Array<{ type: 'text'; text: string }>;
+};
+
+export type ToolHandler = (args: ToolArgs) => Promise<ToolResult>;
+
+function isBloomreachError(error: unknown): error is BloomreachBuddyError {
+  return error instanceof BloomreachBuddyError;
+}
+
+export function toToolResult(payload: unknown): ToolResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export function buildRecoveryHint(error: unknown): string {
+  if (!isBloomreachError(error)) {
+    return 'An unexpected error occurred. Verify Bloomreach credentials and retry.';
+  }
+
+  switch (error.code) {
+    case 'CONFIG_MISSING':
+      return 'Missing API credentials. Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET, then retry.';
+    case 'TIMEOUT':
+      return 'The request timed out. Retry shortly and reduce query scope if possible.';
+    case 'RATE_LIMITED':
+      return 'Bloomreach rate limit reached. Wait for the rate-limit window to reset before retrying.';
+    case 'API_ERROR':
+      return 'Bloomreach API returned an error response. Check input parameters and project permissions, then retry.';
+    case 'NETWORK_ERROR':
+      return 'A network error occurred. Verify connectivity to Bloomreach API endpoints and retry.';
+    default:
+      return 'The operation failed. Check the error details and retry with corrected input.';
+  }
+}
+
+export function toErrorResult(error: unknown): ToolErrorResult {
+  const code = isBloomreachError(error) ? error.code : 'UNKNOWN';
+  const message = error instanceof Error ? error.message : 'Unknown error occurred.';
+
+  const errorPayload = {
+    code,
+    message,
+    recovery_hint: buildRecoveryHint(error),
+  };
+
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(errorPayload, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp/src/toolSchema.ts
+++ b/packages/mcp/src/toolSchema.ts
@@ -1,0 +1,229 @@
+export type BloomreachMcpSchemaPrimitiveType =
+  | 'array'
+  | 'boolean'
+  | 'integer'
+  | 'number'
+  | 'object'
+  | 'string';
+
+export type BloomreachMcpSchemaEnumValue = boolean | number | string;
+
+export interface BloomreachMcpInputSchema {
+  type?: BloomreachMcpSchemaPrimitiveType;
+  description?: string;
+  properties?: Record<string, BloomreachMcpInputSchema>;
+  required?: string[];
+  additionalProperties?: boolean | BloomreachMcpInputSchema;
+  items?: BloomreachMcpInputSchema;
+  enum?: readonly BloomreachMcpSchemaEnumValue[];
+  anyOf?: readonly BloomreachMcpInputSchema[];
+}
+
+export interface BloomreachMcpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: BloomreachMcpInputSchema;
+}
+
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function describeToolArgValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return 'non-finite number';
+  }
+
+  return typeof value;
+}
+
+export function appendToolSchemaPath(path: string, segment: string): string {
+  if (path.length === 0) {
+    return segment;
+  }
+
+  if (segment.startsWith('[')) {
+    return `${path}${segment}`;
+  }
+
+  return `${path}.${segment}`;
+}
+
+export function formatToolSchemaPath(path: string): string {
+  return path.length > 0 ? path : 'arguments';
+}
+
+export function describeToolSchemaTypes(schema: BloomreachMcpInputSchema): string {
+  if (schema.anyOf && schema.anyOf.length > 0) {
+    return schema.anyOf.map((entry) => describeToolSchemaTypes(entry)).join(', ');
+  }
+
+  if (schema.enum && schema.enum.length > 0) {
+    return schema.enum.map((entry) => JSON.stringify(entry)).join(', ');
+  }
+
+  if (schema.type) {
+    return schema.type;
+  }
+
+  return 'supported value';
+}
+
+export function throwToolSchemaValidationError(
+  path: string,
+  message: string,
+  details: Record<string, unknown> = {},
+): never {
+  void details;
+  throw new Error(`${formatToolSchemaPath(path)} ${message}`);
+}
+
+export function validateToolArgEnum(
+  schema: BloomreachMcpInputSchema,
+  value: unknown,
+  path: string,
+): void {
+  if (schema.enum && !schema.enum.includes(value as BloomreachMcpSchemaEnumValue)) {
+    throwToolSchemaValidationError(
+      path,
+      `must be one of: ${schema.enum.map((entry) => JSON.stringify(entry)).join(', ')}.`,
+      {
+        actual_type: describeToolArgValue(value),
+        allowed_values: [...schema.enum],
+      },
+    );
+  }
+}
+
+export function validateToolArgValueAgainstSchema(
+  schema: BloomreachMcpInputSchema,
+  value: unknown,
+  path: string,
+): void {
+  if (schema.anyOf && schema.anyOf.length > 0) {
+    for (const candidate of schema.anyOf) {
+      try {
+        validateToolArgValueAgainstSchema(candidate, value, path);
+        return;
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error;
+        }
+      }
+    }
+
+    throwToolSchemaValidationError(
+      path,
+      `must match one of: ${describeToolSchemaTypes(schema)}.`,
+      {
+        actual_type: describeToolArgValue(value),
+        expected: describeToolSchemaTypes(schema),
+      },
+    );
+  }
+
+  switch (schema.type) {
+    case 'string':
+      if (typeof value !== 'string') {
+        throwToolSchemaValidationError(path, 'must be a string.', {
+          actual_type: describeToolArgValue(value),
+        });
+      }
+      validateToolArgEnum(schema, value, path);
+      return;
+    case 'number':
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throwToolSchemaValidationError(path, 'must be a finite number.', {
+          actual_type: describeToolArgValue(value),
+        });
+      }
+      validateToolArgEnum(schema, value, path);
+      return;
+    case 'integer':
+      if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) {
+        throwToolSchemaValidationError(path, 'must be an integer.', {
+          actual_type: describeToolArgValue(value),
+        });
+      }
+      validateToolArgEnum(schema, value, path);
+      return;
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        throwToolSchemaValidationError(path, 'must be a boolean.', {
+          actual_type: describeToolArgValue(value),
+        });
+      }
+      validateToolArgEnum(schema, value, path);
+      return;
+    case 'array':
+      if (!Array.isArray(value)) {
+        throwToolSchemaValidationError(path, 'must be an array.', {
+          actual_type: describeToolArgValue(value),
+        });
+      }
+
+      if (schema.items) {
+        const itemSchema = schema.items;
+        value.forEach((entry, index) => {
+          validateToolArgValueAgainstSchema(
+            itemSchema,
+            entry,
+            appendToolSchemaPath(path, `[${index}]`),
+          );
+        });
+      }
+      return;
+    case 'object': {
+      if (!isPlainObject(value)) {
+        throwToolSchemaValidationError(path, 'must be an object.', {
+          actual_type: describeToolArgValue(value),
+        });
+      }
+
+      const properties = schema.properties ?? {};
+      const required = schema.required ?? [];
+      for (const requiredKey of required) {
+        if (!(requiredKey in value) || value[requiredKey] === undefined) {
+          throwToolSchemaValidationError(
+            appendToolSchemaPath(path, requiredKey),
+            'is required.',
+          );
+        }
+      }
+
+      for (const [key, entryValue] of Object.entries(value)) {
+        const propertyPath = appendToolSchemaPath(path, key);
+        const propertySchema = properties[key];
+
+        if (propertySchema) {
+          if (entryValue !== undefined) {
+            validateToolArgValueAgainstSchema(propertySchema, entryValue, propertyPath);
+          }
+          continue;
+        }
+
+        if (schema.additionalProperties === false) {
+          throwToolSchemaValidationError(propertyPath, 'is not allowed.');
+        }
+
+        if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+          validateToolArgValueAgainstSchema(schema.additionalProperties, entryValue, propertyPath);
+        }
+      }
+      return;
+    }
+    default:
+      validateToolArgEnum(schema, value, path);
+      return;
+  }
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/__tests__/**/*.test.ts'],
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary

Acid test improvements for the MCP server (`packages/mcp/`). Builds on the base implementation from #169 to add input validation, structured error handling, and comprehensive unit tests.

## Changes

### New utility modules
- **`toolSchema.ts`** — JSON Schema-based input validation framework with support for all primitive types, enums, `anyOf`, nested objects, and array items
- **`toolArgs.ts`** — Type-safe argument extraction helpers for string, number, boolean, array, and object parameters with bounds checking and URL validation
- **`toolResults.ts`** — Structured error responses with `BloomreachBuddyError` code detection and agent-friendly recovery hints for all 5 error codes

### Server improvements
- Replaced inline `toToolResult`/`toErrorResult` with structured versions from `toolResults.ts`
- Added input schema validation before tool execution via `validateToolArgValueAgainstSchema`
- Error responses now include `{ code, message, recovery_hint }` instead of bare `{ error: message }`

### Test coverage (92 tests)
- **toolConstants**: 245 tool names, dot-notation convention, uniqueness, 33 service domains
- **toolSchema**: All validation paths (string, number, integer, boolean, array, object, enum, anyOf)
- **toolArgs**: All extraction helpers with edge cases and error conditions
- **toolResults**: Error formatting with BloomreachBuddyError codes and recovery hints

### Configuration
- Added `vitest.config.ts` excluding `dist/` from test discovery
- Added vitest devDependency and test scripts to `package.json`
- Re-exported utility modules from `index.ts`

## Quality gates
- TypeScript: ✅ Pass
- ESLint: ✅ Pass (0 errors)
- Tests: ✅ 92/92 MCP tests pass, 4565/4565 core regression tests pass
- Build: ✅ Pass

## Acid test checklist
- [x] Build: `packages/mcp` compiles without errors
- [x] Tool constants: All 245 tool names follow dot-notation convention
- [x] Server startup: MCP server starts via stdio
- [x] Tool registration: All tools registered with proper schemas
- [x] Tool execution: Tools correctly delegate to core service methods
- [x] Error handling: Tool errors return structured MCP error responses with codes and recovery hints
- [x] Input validation: Tools validate input schemas before execution
- [x] Two-phase commit: Write tools return prepare results with confirm tokens

Closes #133
