### PR TITLE
fix #172: ensure core builds before CLI/MCP for DTS resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
+    "build": "npm run build -w @bloomreach-buddy/core && npm run build -w @bloomreach-buddy/cli -w @bloomreach-buddy/mcp",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/bin/bloomreach.ts'],
   format: ['esm'],
-  dts: true,
+  dts: { compilerOptions: { composite: false } },
   clean: true,
   sourcemap: true,
 });

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts', 'src/bin/bloomreach-mcp.ts'],
   format: ['esm'],
-  dts: true,
+  dts: { compilerOptions: { composite: false } },
   clean: true,
   sourcemap: true,
 });


### PR DESCRIPTION
## Summary

Fixes the CLI package DTS build failure (`TS2307: Cannot find module '@bloomreach-buddy/core'`) by ensuring core builds before dependent packages.

## Root Cause

`npm run build --workspaces` ran workspace builds in alphabetical order, so `@bloomreach-buddy/cli` started its DTS generation before `@bloomreach-buddy/core` had produced `dist/index.d.ts`. The ESM build succeeded (tsup bundles source directly), but DTS generation requires compiled type declarations from dependencies.

## Changes

- **`package.json`**: Replace `npm run build --workspaces` with explicit ordering — build core first, then CLI + MCP in parallel
- **`packages/cli/tsup.config.ts`**: Set `dts: { compilerOptions: { composite: false } }` to match core's convention (prevents composite mode conflicts in tsup's DTS worker)
- **`packages/mcp/tsup.config.ts`**: Same `composite: false` alignment

## Verification

All quality gates pass after the fix:
- `npm run build` — all 3 packages (core, CLI, MCP) ESM + DTS ✅
- `npm run typecheck` — clean ✅
- `npm run lint` — clean ✅
- `npm test` — 9,292 tests passed ✅

Closes #172
