### PR TITLE
feat #173: add interactive setup wizard for Bloomreach API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,87 @@ _Coming soon._
 
 ## Getting Started
 
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v20 or later
+- A Bloomreach Engagement account with API access
+
+### Installation
+
 ```bash
-# Clone
 git clone https://github.com/sigvardt/bloomreach-buddy.git
 cd bloomreach-buddy
-
-# Install
 npm install
+npm run build
+```
 
-# Run
-npm start
+### Interactive Setup (Recommended)
+
+Run the setup wizard to configure your API credentials:
+
+```bash
+npx bloomreach setup
+```
+
+The wizard will guide you through each step:
+
+1. **Project Token** — enter your project token
+2. **API Key ID** — enter the key ID from your private API key
+3. **API Secret** — enter the secret (masked input)
+4. **Base URL** — accept the default (`https://api.exponea.com`) or enter a custom URL
+5. **Validation** — the wizard verifies your credentials with a test API call
+6. **Save** — credentials are written to a `.env` file
+
+### Where to Find Your Credentials
+
+All three values are in the Bloomreach Engagement dashboard:
+
+| Credential | Location |
+|---|---|
+| **Project Token** | Project Settings → Access Management → API → Project Token |
+| **API Key ID** | Project Settings → Access Management → API → Private API keys |
+| **API Secret** | Shown once when you create a new private API key |
+
+To create a new API key:
+
+1. Log into [Bloomreach Engagement](https://app.bloomreach.com/)
+2. Navigate to **Project Settings → Access Management → API**
+3. Under **Private API keys**, click **+ Add new API key**
+4. Give it a name (e.g. "bloomreach-buddy")
+5. Select the required permissions (see below)
+6. Copy the **API Key ID** and **API Secret** immediately — the secret is only shown once
+
+### Minimum API Permissions
+
+Your API key needs these permissions at minimum:
+
+- **Customer data** — read access (required for credential validation)
+- **Tracking** — read access (used by the setup wizard)
+
+Grant additional permissions based on which features you plan to use (campaigns, segmentations, scenarios, etc.).
+
+### Manual Setup
+
+If you prefer manual configuration, copy the example file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your credentials:
+
+```bash
+BLOOMREACH_PROJECT_TOKEN=your-project-token
+BLOOMREACH_API_KEY_ID=your-api-key-id
+BLOOMREACH_API_SECRET=your-api-secret
+# Optional: override the default API base URL
+# BLOOMREACH_API_BASE_URL=https://api.exponea.com
+```
+
+### Verify Your Setup
+
+```bash
+npx bloomreach status
 ```
 
 ## Development
@@ -28,6 +99,7 @@ npm start
 npm run lint       # ESLint
 npm run typecheck  # TypeScript
 npm test           # Vitest
+npm run build      # Build all packages
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -695,6 +695,334 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
+      "integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.0.tgz",
+      "integrity": "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.8.tgz",
+      "integrity": "sha512-Di6dgmiZ9xCSUxWUReWTqDtbhXCuG2MQm2xmgSAIruzQzBqNf49b8E07/vbCYY506kDe8BiwJbegXweG8M1klw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.5.tgz",
+      "integrity": "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.8.tgz",
+      "integrity": "sha512-sLcpbb9B3XqUEGrj1N66KwhDhEckzZ4nI/W6SvLXyBX8Wic3LDLENlWRvkOGpCPoserabe+MxQkpiMoI8irvyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/external-editor": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.8.tgz",
+      "integrity": "sha512-QieW3F1prNw3j+hxO7/NKkG1pk3oz7pOB6+5Upwu3OIwADfPX0oZVppsqlL+Vl/uBHHDSOBY0BirLctLnXwGGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.3.tgz",
+      "integrity": "sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
+      "integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.8.tgz",
+      "integrity": "sha512-p0IJslw0AmedLEkOU+yrEX3Aj2RTpQq7ZOf8nc1DIhjzaxRWrrgeuE5Kyh39fVRgtcACaMXx/9WNo8+GjgBOfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.8.tgz",
+      "integrity": "sha512-uGLiQah9A0F9UIvJBX52m0CnqtLaym0WpT9V4YZrjZ+YRDKZdwwoEPz06N6w8ChE2lrnsdyhY9sL+Y690Kh9gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.8.tgz",
+      "integrity": "sha512-zt1sF4lYLdvPqvmvHdmjOzuUUjuCQ897pdUCO8RbXMUDKXJTTyOQgtn23le+jwcb+MpHl3VAFvzIdxRAf6aPlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.0.tgz",
+      "integrity": "sha512-JAj66kjdH/F1+B7LCigjARbwstt3SNUOSzMdjpsvwJmzunK88gJeXmcm95L9nw1KynvFVuY4SzXh/3Y0lvtgSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.0",
+        "@inquirer/confirm": "^6.0.8",
+        "@inquirer/editor": "^5.0.8",
+        "@inquirer/expand": "^5.0.8",
+        "@inquirer/input": "^5.0.8",
+        "@inquirer/number": "^4.0.8",
+        "@inquirer/password": "^5.0.8",
+        "@inquirer/rawlist": "^5.2.4",
+        "@inquirer/search": "^4.1.4",
+        "@inquirer/select": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.4.tgz",
+      "integrity": "sha512-fTuJ5Cq9W286isLxwj6GGyfTjx1Zdk4qppVEPexFuA6yioCCXS4V1zfKroQqw7QdbDPN73xs2DiIAlo55+kBqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.4.tgz",
+      "integrity": "sha512-9yPTxq7LPmYjrGn3DRuaPuPbmC6u3fiWcsE9ggfLcdgO/ICHYgxq7mEy1yJ39brVvgXhtOtvDVjDh9slJxE4LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.0.tgz",
+      "integrity": "sha512-OyYbKnchS1u+zRe14LpYrN8S0wH1vD0p2yKISvSsJdH2TpI87fh4eZdWnpdbrGauCRWDph3NwxRmM4Pcm/hx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
+      "integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1506,7 +1834,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -2085,6 +2413,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2099,6 +2433,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/commander": {
@@ -2658,6 +3001,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2673,6 +3031,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3505,6 +3872,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -4199,6 +4575,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -4525,7 +4913,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4811,6 +5199,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@bloomreach-buddy/core": "0.0.1",
+        "@inquirer/prompts": "8.3.0",
         "commander": "^14.0.3"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@bloomreach-buddy/core": "0.0.1",
+    "@inquirer/prompts": "8.3.0",
     "commander": "^14.0.3"
   },
   "devDependencies": {

--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { input, password, confirm } from '@inquirer/prompts';
 import { readFileSync } from 'node:fs';
 import {
   BloomreachAccessManagementService,
@@ -39,6 +40,10 @@ import {
   BloomreachVouchersService,
   BloomreachWeblayersService,
   resolveApiConfig,
+  validateCredentials,
+  writeEnvFile,
+  openBrowserUrl,
+  BLOOMREACH_API_SETTINGS_URL,
 } from '@bloomreach-buddy/core';
 import type {
   BloomreachApiConfig,
@@ -11971,6 +11976,194 @@ recommendations
         }
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+
+// ---------------------------------------------------------------------------
+// Setup wizard
+// ---------------------------------------------------------------------------
+
+program
+  .command('setup')
+  .description('Interactive setup wizard for Bloomreach API credentials')
+  .option('--no-browser', 'Skip opening the browser to API settings')
+  .option('--no-validate', 'Skip credential validation via API call')
+  .option('--env-path <path>', 'Directory for .env file (default: current directory)')
+  .option('--overwrite', 'Overwrite .env entirely instead of merging')
+  .option('--json', 'Output result as JSON')
+  .action(
+    async (options: {
+      browser: boolean;
+      validate: boolean;
+      envPath?: string;
+      overwrite?: boolean;
+      json?: boolean;
+    }) => {
+      try {
+        console.log('');
+        console.log('  Bloomreach Buddy Setup');
+        console.log('  =====================');
+        console.log('');
+
+        // Check for existing credentials
+        const existing = tryResolveApiConfig();
+        if (existing) {
+          console.log('  Existing credentials detected.');
+          console.log(`    Project Token: ${existing.projectToken.slice(0, 8)}...`);
+          console.log(`    API Key ID:    ${existing.apiKeyId.slice(0, 8)}...`);
+          console.log('');
+
+          const reconfigure = await confirm({
+            message: 'Credentials already configured. Reconfigure?',
+            default: false,
+          });
+
+          if (!reconfigure) {
+            console.log('');
+            console.log('  Setup cancelled. Existing credentials preserved.');
+            return;
+          }
+          console.log('');
+        }
+
+        // Instructions
+        console.log('  You will need three values from the Bloomreach dashboard:');
+        console.log('');
+        console.log('  1. Project Token');
+        console.log('     Location: Project Settings > Access Management > API');
+        console.log('');
+        console.log('  2. API Key ID');
+        console.log('     Location: Project Settings > Access Management > API > Private API keys');
+        console.log('');
+        console.log('  3. API Secret');
+        console.log('     Shown once when you create a new API key');
+        console.log('');
+
+        // Offer to open browser
+        if (options.browser) {
+          const openBrowser = await confirm({
+            message: 'Open Bloomreach dashboard in your browser?',
+            default: true,
+          });
+
+          if (openBrowser) {
+            openBrowserUrl(BLOOMREACH_API_SETTINGS_URL);
+            console.log(`  Opening ${BLOOMREACH_API_SETTINGS_URL}`);
+            console.log('');
+          }
+        }
+
+        // Collect credentials
+        console.log('  Step 1: Project Token');
+        const projectToken = await input({
+          message: 'Project Token:',
+          required: true,
+          validate: (v) => v.trim().length > 0 || 'Project token is required',
+        });
+
+        console.log('');
+        console.log('  Step 2: API Key');
+        const apiKeyId = await input({
+          message: 'API Key ID:',
+          required: true,
+          validate: (v) => v.trim().length > 0 || 'API key ID is required',
+        });
+
+        const apiSecret = await password({
+          message: 'API Secret:',
+          mask: '*',
+          validate: (v) => v.length > 0 || 'API secret is required',
+        });
+
+        console.log('');
+        console.log('  Step 3: API Base URL (optional)');
+        const baseUrl = await input({
+          message: 'Base URL:',
+          default: 'https://api.exponea.com',
+          validate: (v) => {
+            try {
+              new URL(v);
+              return true;
+            } catch {
+              return 'Must be a valid URL';
+            }
+          },
+        });
+
+        const credentials = {
+          projectToken: projectToken.trim(),
+          apiKeyId: apiKeyId.trim(),
+          apiSecret,
+          baseUrl: baseUrl.trim(),
+        };
+
+        // Validate credentials
+        if (options.validate) {
+          console.log('');
+          console.log('  Validating credentials...');
+
+          const validationResult = await validateCredentials(credentials);
+
+          if (!validationResult.valid) {
+            console.error('');
+            console.error(`  Validation failed: ${validationResult.message}`);
+            console.error(`  Error type: ${validationResult.error}`);
+            console.error('');
+
+            const retry = await confirm({
+              message: 'Validation failed. Save credentials anyway?',
+              default: false,
+            });
+
+            if (!retry) {
+              console.log('  Setup cancelled.');
+              process.exit(1);
+            }
+          } else {
+            console.log('  Credentials verified successfully!');
+            if (validationResult.serverTime) {
+              const serverDate = new Date(validationResult.serverTime * 1000);
+              console.log(`  Server time: ${serverDate.toISOString()}`);
+            }
+          }
+        }
+
+        // Write .env file
+        console.log('');
+        const envPath = writeEnvFile(credentials, {
+          directory: options.envPath,
+          merge: !options.overwrite,
+        });
+
+        if (options.json) {
+          printJson({
+            status: 'success',
+            envPath,
+            projectToken: credentials.projectToken,
+            apiKeyId: credentials.apiKeyId,
+            baseUrl: credentials.baseUrl,
+          });
+        } else {
+          console.log(`  Credentials written to ${envPath}`);
+          console.log('');
+          console.log('  Setup complete! You can verify with:');
+          console.log('    bloomreach status');
+          console.log('');
+        }
+      } catch (error) {
+        if (options.json) {
+          printJson({
+            status: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          });
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         process.exit(1);
       }
     },

--- a/packages/core/src/__tests__/bloomreachSetup.test.ts
+++ b/packages/core/src/__tests__/bloomreachSetup.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { exec } from 'node:child_process';
+import {
+  validateCredentials,
+  writeEnvFile,
+  openBrowserUrl,
+  BLOOMREACH_API_SETTINGS_URL,
+} from '../bloomreachSetup.js';
+import type { ValidateCredentialsInput } from '../bloomreachSetup.js';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+}));
+
+const VALID_INPUT: ValidateCredentialsInput = {
+  projectToken: 'test-token',
+  apiKeyId: 'test-key-id',
+  apiSecret: 'test-secret',
+};
+
+const ORIGINAL_PLATFORM = process.platform;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM });
+});
+
+// ===========================================================================
+// validateCredentials
+// ===========================================================================
+
+describe('validateCredentials', () => {
+  it('returns valid result on successful 2xx with success: true', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true, time: 1700000000.5 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(true);
+    expect(result.serverTime).toBe(1700000000.5);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns invalid_credentials on 401 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'access key not found' }), {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('invalid_credentials');
+    expect(result.message).toContain('incorrect');
+  });
+
+  it('returns invalid_credentials on 403 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'forbidden' }), {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('invalid_credentials');
+  });
+
+  it('returns invalid_project on 404 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'project not found' }), {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('invalid_project');
+    expect(result.message).toContain('Project token not found');
+  });
+
+  it('returns network_error on fetch failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed'),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('network_error');
+    expect(result.message).toContain('fetch failed');
+  });
+
+  it('returns timeout on abort error', async () => {
+    vi.useFakeTimers();
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      }),
+    );
+
+    const promise = validateCredentials({
+      ...VALID_INPUT,
+      baseUrl: 'https://api.test.com',
+    });
+
+    // Advance past the 30s default timeout in bloomreachApiFetch
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    const result = await promise;
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('timeout');
+
+    vi.useRealTimers();
+  });
+
+  it('sends correct auth header and path', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true, time: 1700000000 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    await validateCredentials({
+      projectToken: 'my-project',
+      apiKeyId: 'my-key',
+      apiSecret: 'my-secret',
+      baseUrl: 'https://api.test.com',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://api.test.com/track/v2/projects/my-project/system/time',
+    );
+    expect(init.method).toBe('GET');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe(
+      `Basic ${Buffer.from('my-key:my-secret').toString('base64')}`,
+    );
+  });
+
+  it('trims whitespace from credentials', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true, time: 1700000000 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    await validateCredentials({
+      projectToken: '  my-project  ',
+      apiKeyId: '  my-key  ',
+      apiSecret: '  my-secret  ',
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/my-project/');
+  });
+
+  it('returns invalid_credentials when success is false in 2xx body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ success: false, error: 'access key not found' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      ),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('invalid_credentials');
+    expect(result.message).toBe('access key not found');
+  });
+
+  it('returns unknown error for unexpected API errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'internal' }), {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const result = await validateCredentials(VALID_INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('unknown');
+    expect(result.message).toContain('500');
+  });
+
+  it('uses default base URL when not provided', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true, time: 1700000000 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    await validateCredentials({
+      projectToken: 'my-project',
+      apiKeyId: 'my-key',
+      apiSecret: 'my-secret',
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://api.exponea.com/');
+  });
+});
+
+// ===========================================================================
+// writeEnvFile
+// ===========================================================================
+
+describe('writeEnvFile', () => {
+  it('writes .env file with all required vars', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    writeEnvFile(VALID_INPUT, { directory: '/test/dir' });
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [path, content] = vi.mocked(writeFileSync).mock.calls[0] as [string, string, string];
+    expect(path).toBe('/test/dir/.env');
+    expect(content).toContain('BLOOMREACH_PROJECT_TOKEN=test-token');
+    expect(content).toContain('BLOOMREACH_API_KEY_ID=test-key-id');
+    expect(content).toContain('BLOOMREACH_API_SECRET=test-secret');
+  });
+
+  it('includes BLOOMREACH_API_BASE_URL only when non-default', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    writeEnvFile(
+      { ...VALID_INPUT, baseUrl: 'https://custom.api.com' },
+      { directory: '/test', merge: false },
+    );
+
+    const content = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    expect(content).toContain('BLOOMREACH_API_BASE_URL=https://custom.api.com');
+  });
+
+  it('omits BLOOMREACH_API_BASE_URL when using default', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    writeEnvFile(
+      { ...VALID_INPUT, baseUrl: 'https://api.exponea.com' },
+      { directory: '/test', merge: false },
+    );
+
+    const content = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    expect(content).not.toContain('BLOOMREACH_API_BASE_URL');
+  });
+
+  it('preserves existing non-Bloomreach lines when merge is true', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      'OTHER_VAR=keep-me\nANOTHER=also-keep\nBLOOMREACH_PROJECT_TOKEN=old-token\n' as never,
+    );
+
+    writeEnvFile(VALID_INPUT, { directory: '/test', merge: true });
+
+    const content = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    expect(content).toContain('OTHER_VAR=keep-me');
+    expect(content).toContain('ANOTHER=also-keep');
+    expect(content).toContain('BLOOMREACH_PROJECT_TOKEN=test-token');
+    expect(content).not.toContain('old-token');
+  });
+
+  it('overwrites entirely when merge is false', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('OTHER_VAR=keep-me\n' as never);
+
+    writeEnvFile(VALID_INPUT, { directory: '/test', merge: false });
+
+    const content = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    expect(content).not.toContain('OTHER_VAR');
+    expect(content).toContain('BLOOMREACH_PROJECT_TOKEN=test-token');
+  });
+
+  it('returns the path of the written file', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = writeEnvFile(VALID_INPUT, { directory: '/test/dir' });
+
+    expect(result).toBe('/test/dir/.env');
+  });
+
+  it('trims whitespace from credential values', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    writeEnvFile(
+      { projectToken: '  spaced  ', apiKeyId: '  key  ', apiSecret: '  secret  ' },
+      { directory: '/test', merge: false },
+    );
+
+    const content = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    expect(content).toContain('BLOOMREACH_PROJECT_TOKEN=spaced');
+    expect(content).toContain('BLOOMREACH_API_KEY_ID=key');
+    expect(content).toContain('BLOOMREACH_API_SECRET=secret');
+  });
+});
+
+// ===========================================================================
+// openBrowserUrl
+// ===========================================================================
+
+describe('openBrowserUrl', () => {
+  it('calls exec with "open" on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    openBrowserUrl('https://example.com');
+
+    expect(exec).toHaveBeenCalledWith(
+      'open "https://example.com"',
+      expect.any(Function),
+    );
+  });
+
+  it('calls exec with "xdg-open" on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    openBrowserUrl('https://example.com');
+
+    expect(exec).toHaveBeenCalledWith(
+      'xdg-open "https://example.com"',
+      expect.any(Function),
+    );
+  });
+
+  it('calls exec with "start" on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    openBrowserUrl('https://example.com');
+
+    expect(exec).toHaveBeenCalledWith(
+      'start "" "https://example.com"',
+      expect.any(Function),
+    );
+  });
+
+  it('does not throw when exec fails', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    vi.mocked(exec).mockImplementation((_cmd, callback) => {
+      if (typeof callback === 'function') {
+        (callback as (err: Error | null) => void)(new Error('spawn failed'));
+      }
+      return undefined as never;
+    });
+
+    expect(() => openBrowserUrl('https://example.com')).not.toThrow();
+  });
+});
+
+// ===========================================================================
+// BLOOMREACH_API_SETTINGS_URL
+// ===========================================================================
+
+describe('BLOOMREACH_API_SETTINGS_URL', () => {
+  it('is a valid URL', () => {
+    expect(() => new URL(BLOOMREACH_API_SETTINGS_URL)).not.toThrow();
+  });
+});

--- a/packages/core/src/bloomreachSetup.ts
+++ b/packages/core/src/bloomreachSetup.ts
@@ -1,0 +1,258 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { exec } from 'node:child_process';
+import { join } from 'node:path';
+
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import {
+  bloomreachApiFetch,
+  buildTrackingPath,
+  BloomreachApiError,
+  BloomreachBuddyError,
+} from './bloomreachApiClient.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Input for credential validation. */
+export interface ValidateCredentialsInput {
+  projectToken: string;
+  apiKeyId: string;
+  apiSecret: string;
+  baseUrl?: string;
+}
+
+/** Possible error categories from credential validation. */
+export type ValidateCredentialsError =
+  | 'invalid_credentials'
+  | 'invalid_project'
+  | 'network_error'
+  | 'timeout'
+  | 'unknown';
+
+/** Result of a credential validation attempt. */
+export interface ValidateCredentialsResult {
+  valid: boolean;
+  /** Server time (epoch seconds) returned by Bloomreach on success. */
+  serverTime?: number;
+  /** Machine-readable error category on failure. */
+  error?: ValidateCredentialsError;
+  /** Human-readable error message on failure. */
+  message?: string;
+}
+
+/** Options for writing a `.env` file. */
+export interface WriteEnvFileOptions {
+  /** Directory to write `.env` to. Defaults to `process.cwd()`. */
+  directory?: string;
+  /**
+   * When `true` (default), only `BLOOMREACH_*` keys are updated in an
+   * existing `.env` file — all other lines are preserved.  When `false`,
+   * the file is overwritten entirely.
+   */
+  merge?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BASE_URL = 'https://api.exponea.com';
+
+/** URL to the Bloomreach API settings page. */
+export const BLOOMREACH_API_SETTINGS_URL = 'https://app.bloomreach.com/';
+
+/** Keys written to the `.env` file. */
+const ENV_KEYS = [
+  'BLOOMREACH_PROJECT_TOKEN',
+  'BLOOMREACH_API_KEY_ID',
+  'BLOOMREACH_API_SECRET',
+  'BLOOMREACH_API_BASE_URL',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Credential validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate Bloomreach API credentials by calling the lightweight
+ * `/system/time` tracking endpoint.
+ *
+ * - **2xx with `success: true`** — credentials valid
+ * - **401 / 403** — invalid API key or secret
+ * - **404** — invalid project token
+ * - Network / timeout errors are mapped to their respective categories.
+ */
+export async function validateCredentials(
+  input: ValidateCredentialsInput,
+): Promise<ValidateCredentialsResult> {
+  const config: BloomreachApiConfig = {
+    projectToken: input.projectToken.trim(),
+    apiKeyId: input.apiKeyId.trim(),
+    apiSecret: input.apiSecret.trim(),
+    baseUrl: (input.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, ''),
+  };
+
+  try {
+    const path = buildTrackingPath(config, '/system/time');
+    const response = await bloomreachApiFetch(config, path, { method: 'GET' });
+
+    const body = response as Record<string, unknown> | undefined;
+    if (body && body['success'] === true) {
+      return {
+        valid: true,
+        serverTime: typeof body['time'] === 'number' ? body['time'] : undefined,
+      };
+    }
+
+    // Non-success body from a 2xx response — treat as invalid credentials.
+    const errorMsg =
+      typeof body?.['error'] === 'string'
+        ? body['error']
+        : 'Unexpected response from Bloomreach API';
+    return { valid: false, error: 'invalid_credentials', message: errorMsg };
+  } catch (err: unknown) {
+    if (err instanceof BloomreachApiError) {
+      if (err.statusCode === 401 || err.statusCode === 403) {
+        return {
+          valid: false,
+          error: 'invalid_credentials',
+          message: 'API key ID or secret is incorrect.',
+        };
+      }
+      if (err.statusCode === 400) {
+        return {
+          valid: false,
+          error: 'invalid_project',
+          message: 'Bad request. The project token may be malformed or invalid.',
+        };
+      }
+      if (err.statusCode === 404) {
+        return {
+          valid: false,
+          error: 'invalid_project',
+          message: 'Project token not found. Verify the token in Bloomreach settings.',
+        };
+      }
+      return {
+        valid: false,
+        error: 'unknown',
+        message: `API error ${err.statusCode}: ${err.message}`,
+      };
+    }
+
+    if (err instanceof BloomreachBuddyError) {
+      if (err.code === 'TIMEOUT') {
+        return {
+          valid: false,
+          error: 'timeout',
+          message: 'Request timed out. Check your network and base URL.',
+        };
+      }
+      if (err.code === 'NETWORK_ERROR') {
+        return {
+          valid: false,
+          error: 'network_error',
+          message: `Network error: ${err.message}`,
+        };
+      }
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    return { valid: false, error: 'unknown', message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// .env file writing
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the key=value lines for a `.env` file.
+ * Only includes `BLOOMREACH_API_BASE_URL` when it differs from the default.
+ */
+function buildEnvLines(credentials: ValidateCredentialsInput): string[] {
+  const lines: string[] = [
+    '# Bloomreach Buddy — API credentials',
+    `BLOOMREACH_PROJECT_TOKEN=${credentials.projectToken.trim()}`,
+    `BLOOMREACH_API_KEY_ID=${credentials.apiKeyId.trim()}`,
+    `BLOOMREACH_API_SECRET=${credentials.apiSecret.trim()}`,
+  ];
+
+  const baseUrl = credentials.baseUrl?.trim();
+  if (baseUrl && baseUrl !== DEFAULT_BASE_URL) {
+    lines.push(`BLOOMREACH_API_BASE_URL=${baseUrl}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Write Bloomreach credentials to a `.env` file.
+ *
+ * When `merge` is `true` (default), only `BLOOMREACH_*` keys are
+ * inserted or updated — all other lines in an existing `.env` are
+ * preserved.  When `false`, the file is overwritten entirely.
+ *
+ * @returns The absolute path of the written `.env` file.
+ */
+export function writeEnvFile(
+  credentials: ValidateCredentialsInput,
+  options?: WriteEnvFileOptions,
+): string {
+  const directory = options?.directory ?? process.cwd();
+  const merge = options?.merge ?? true;
+  const envPath = join(directory, '.env');
+  const newLines = buildEnvLines(credentials);
+
+  if (merge && existsSync(envPath)) {
+    const existing = readFileSync(envPath, 'utf-8');
+    const envKeySet = new Set<string>(ENV_KEYS as unknown as string[]);
+    const preserved = existing
+      .split('\n')
+      .filter((line) => {
+        const key = line.split('=')[0]?.trim();
+        return !envKeySet.has(key);
+      });
+
+    // Remove trailing blank lines before appending.
+    while (preserved.length > 0 && preserved[preserved.length - 1]?.trim() === '') {
+      preserved.pop();
+    }
+
+    const merged = preserved.length > 0
+      ? [...preserved, '', ...newLines, '']
+      : [...newLines, ''];
+
+    writeFileSync(envPath, merged.join('\n'), 'utf-8');
+  } else {
+    writeFileSync(envPath, [...newLines, ''].join('\n'), 'utf-8');
+  }
+
+  return envPath;
+}
+
+// ---------------------------------------------------------------------------
+// Browser opening
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to open a URL in the user's default browser.
+ * Best-effort — errors are silently ignored.
+ */
+export function openBrowserUrl(url: string): void {
+  const platform = process.platform;
+
+  let command: string;
+  if (platform === 'darwin') {
+    command = `open "${url}"`;
+  } else if (platform === 'win32') {
+    command = `start "" "${url}"`;
+  } else {
+    command = `xdg-open "${url}"`;
+  }
+
+  exec(command, () => {
+    // Silently ignore errors — browser opening is best-effort.
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export * from './bloomreachWeblayers.js';
 export * from './bloomreachUseCases.js';
 export * from './bloomreachAccessManagement.js';
 export * from './bloomreachApiClient.js';
+export * from './bloomreachSetup.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */


### PR DESCRIPTION
## Summary

Adds an interactive `bloomreach setup` CLI command that guides users through configuring Bloomreach API credentials, validates them against the live API, and writes a `.env` file.

Closes #173

## Changes

### Core module (`packages/core/src/bloomreachSetup.ts`)
- `validateCredentials()` — validates API credentials by calling the lightweight `/track/v2/projects/{token}/system/time` endpoint. Maps HTTP status codes to user-friendly error categories (invalid_credentials, invalid_project, network_error, timeout).
- `writeEnvFile()` — writes/merges credentials into a `.env` file. In merge mode (default), only `BLOOMREACH_*` keys are updated; all other environment variables are preserved.
- `openBrowserUrl()` — cross-platform browser opening (macOS/Linux/Windows) via `child_process.exec`, best-effort.

### CLI command (`packages/cli/src/bin/bloomreach.ts`)
- New `bloomreach setup` command with interactive prompts via `@inquirer/prompts`
- Password-masked input for API secret
- Detects existing credentials and offers reconfiguration
- Opens Bloomreach dashboard in browser (opt-out with `--no-browser`)
- Validates credentials via test API call (opt-out with `--no-validate`)
- Supports `--json` output, `--overwrite` mode, `--env-path` for custom directory

### Tests (`packages/core/src/__tests__/bloomreachSetup.test.ts`)
- 23 unit tests covering:
  - Credential validation (success, 401/403/404/400/500 responses, network errors, timeouts)
  - `.env` file writing (basic write, custom base URL, merge mode, overwrite mode, trimming)
  - Browser opening (platform detection, error resilience)

### Documentation (`README.md`)
- Expanded "Getting Started" section with:
  - Interactive setup instructions (`npx bloomreach setup`)
  - Manual setup via `.env.example`
  - Where to find each credential in the Bloomreach dashboard
  - Minimum API permissions required
  - Setup verification command

## Quality Gates

| Gate | Status |
|------|--------|
| TypeScript (core) | ✅ Pass |
| TypeScript (CLI) | ✅ Pass |
| ESLint | ✅ Pass |
| Unit Tests | ✅ 4,623 passed |
| Build (all packages) | ✅ Pass |
| Manual QA | ✅ writeEnvFile, validateCredentials, merge mode, CLI --help all verified |

## Setup Wizard UX

```
$ bloomreach setup

  Bloomreach Buddy Setup
  =====================

  You will need three values from the Bloomreach dashboard:

  1. Project Token
     Location: Project Settings > Access Management > API

  2. API Key ID
     Location: Project Settings > Access Management > API > Private API keys

  3. API Secret
     Shown once when you create a new API key

? Open Bloomreach dashboard in your browser? Yes

  Step 1: Project Token
? Project Token: abc123-def456

  Step 2: API Key
? API Key ID: my-key-id
? API Secret: ****

  Step 3: API Base URL (optional)
? Base URL: https://api.exponea.com

  Validating credentials...
  Credentials verified successfully!
  Server time: 2026-03-15T20:45:00.000Z

  Credentials written to /path/to/.env

  Setup complete! You can verify with:
    bloomreach status
```
