### PR TITLE
fix #176: implement real connectivity check in status tool

### DIFF
--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { BloomreachClient } from '../index.js';
+
+vi.mock('../bloomreachSetup.js', () => ({
+  validateCredentials: vi.fn(),
+}));
+
+import { validateCredentials } from '../bloomreachSetup.js';
+
+const mockedValidateCredentials = vi.mocked(validateCredentials);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('BloomreachClient', () => {
   it('should instantiate with config', () => {
@@ -13,17 +25,124 @@ describe('BloomreachClient', () => {
     expect(client.config.apiToken).toBe('test-token');
   });
 
-  it('should return status', async () => {
-    const client = new BloomreachClient({
-      environment: 'test-env',
-      apiToken: 'test-token',
+  describe('status()', () => {
+    it('returns apiConfigured:false and error when no apiConfig provided', async () => {
+      const client = new BloomreachClient({
+        environment: 'test-env',
+        apiToken: 'test-token',
+      });
+
+      const result = await client.status();
+
+      expect(result.connected).toBe(false);
+      expect(result.environment).toBe('test-env');
+      expect(result.apiConfigured).toBe(false);
+      expect(result.error).toContain('API credentials not configured');
+      expect(result.project).toBeUndefined();
+      expect(result.apiBaseUrl).toBeUndefined();
     });
 
-    const result = await client.status();
+    it('returns connected:true when validateCredentials succeeds', async () => {
+      mockedValidateCredentials.mockResolvedValue({
+        valid: true,
+        serverTime: 1234567890,
+      });
 
-    expect(result).toEqual({
-      connected: false,
-      environment: 'test-env',
+      const client = new BloomreachClient({
+        environment: 'production',
+        apiToken: 'test-token',
+        apiConfig: {
+          projectToken: 'my-project-token',
+          apiKeyId: 'key-id',
+          apiSecret: 'secret',
+          baseUrl: 'https://api.exponea.com',
+        },
+      });
+
+      const result = await client.status();
+
+      expect(result.connected).toBe(true);
+      expect(result.environment).toBe('production');
+      expect(result.apiConfigured).toBe(true);
+      expect(result.project).toBe('my-project-token');
+      expect(result.apiBaseUrl).toBe('https://api.exponea.com');
+      expect(result.error).toBeUndefined();
+
+      expect(mockedValidateCredentials).toHaveBeenCalledWith({
+        projectToken: 'my-project-token',
+        apiKeyId: 'key-id',
+        apiSecret: 'secret',
+        baseUrl: 'https://api.exponea.com',
+      });
+    });
+
+    it('returns connected:false with error when validateCredentials reports invalid', async () => {
+      mockedValidateCredentials.mockResolvedValue({
+        valid: false,
+        error: 'invalid_credentials',
+        message: 'API key ID or secret is incorrect.',
+      });
+
+      const client = new BloomreachClient({
+        environment: 'test-env',
+        apiToken: 'test-token',
+        apiConfig: {
+          projectToken: 'bad-token',
+          apiKeyId: 'wrong-key',
+          apiSecret: 'wrong-secret',
+          baseUrl: 'https://api.exponea.com',
+        },
+      });
+
+      const result = await client.status();
+
+      expect(result.connected).toBe(false);
+      expect(result.apiConfigured).toBe(true);
+      expect(result.error).toBe('API key ID or secret is incorrect.');
+      expect(result.apiBaseUrl).toBe('https://api.exponea.com');
+    });
+
+    it('returns connected:false with error when validateCredentials throws', async () => {
+      mockedValidateCredentials.mockRejectedValue(new Error('Network failure'));
+
+      const client = new BloomreachClient({
+        environment: 'test-env',
+        apiToken: 'test-token',
+        apiConfig: {
+          projectToken: 'token',
+          apiKeyId: 'key',
+          apiSecret: 'secret',
+          baseUrl: 'https://api.exponea.com',
+        },
+      });
+
+      const result = await client.status();
+
+      expect(result.connected).toBe(false);
+      expect(result.apiConfigured).toBe(true);
+      expect(result.error).toBe('Network failure');
+    });
+
+    it('returns connected:false with fallback message when validateCredentials returns invalid with no message', async () => {
+      mockedValidateCredentials.mockResolvedValue({
+        valid: false,
+      });
+
+      const client = new BloomreachClient({
+        environment: 'test-env',
+        apiToken: 'test-token',
+        apiConfig: {
+          projectToken: 'token',
+          apiKeyId: 'key',
+          apiSecret: 'secret',
+          baseUrl: 'https://api.exponea.com',
+        },
+      });
+
+      const result = await client.status();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toBe('Connection verification failed');
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,6 @@
+import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { validateCredentials } from './bloomreachSetup.js';
+
 export * from './bloomreachCampaignCalendar.js';
 export * from './bloomreachCampaignSettings.js';
 export * from './bloomreachCatalogs.js';
@@ -40,6 +43,16 @@ export interface BloomreachClientConfig {
   environment: string;
   /** API token for authentication */
   apiToken: string;
+  apiConfig?: BloomreachApiConfig;
+}
+
+export interface BloomreachStatusResult {
+  connected: boolean;
+  environment: string;
+  project?: string;
+  apiConfigured: boolean;
+  apiBaseUrl?: string;
+  error?: string;
 }
 
 /**
@@ -64,10 +77,47 @@ export class BloomreachClient {
    * Check connectivity to the Bloomreach API.
    * @returns status object with connection information
    */
-  async status(): Promise<{ connected: boolean; environment: string }> {
-    return {
+  async status(): Promise<BloomreachStatusResult> {
+    const apiConfig = this.config.apiConfig;
+    const apiConfigured = apiConfig != null;
+    const base: BloomreachStatusResult = {
       connected: false,
       environment: this.config.environment,
+      apiConfigured,
+      apiBaseUrl: apiConfig?.baseUrl,
     };
+
+    if (!apiConfigured || !apiConfig) {
+      return {
+        ...base,
+        error:
+          'API credentials not configured. Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      };
+    }
+
+    try {
+      const result = await validateCredentials({
+        projectToken: apiConfig.projectToken,
+        apiKeyId: apiConfig.apiKeyId,
+        apiSecret: apiConfig.apiSecret,
+        baseUrl: apiConfig.baseUrl,
+      });
+
+      if (result.valid) {
+        return {
+          ...base,
+          connected: true,
+          project: apiConfig.projectToken,
+        };
+      }
+
+      return {
+        ...base,
+        error: result.message ?? 'Connection verification failed',
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ...base, error: message };
+    }
   }
 }

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -5562,13 +5562,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const args = isPlainObject(request.params.arguments) ? request.params.arguments : {};
 
   try {
-    if (name === toolNames.BLOOMREACH_STATUS_TOOL) {
-      const client = new core.BloomreachClient({
-        environment: process.env.BLOOMREACH_ENVIRONMENT ?? 'not-configured',
-        apiToken: process.env.BLOOMREACH_API_TOKEN ?? '',
-      });
-      return toToolResult(await client.status());
-    }
+if (name === toolNames.BLOOMREACH_STATUS_TOOL) {
+  const client = new core.BloomreachClient({
+    environment: process.env.BLOOMREACH_ENVIRONMENT ?? 'not-configured',
+    apiToken: process.env.BLOOMREACH_API_TOKEN ?? '',
+    apiConfig,
+  });
+  return toToolResult(await client.status());
+}
 
     const route = toolByName.get(name);
     if (!route || !route.serviceClass || !route.methodName) {


### PR DESCRIPTION
## Summary

Fixes #176 — The `bloomreach.session.status` MCP tool always returned `connected: false` regardless of configuration. This PR implements a real connectivity check.

## Changes

- **`packages/core/src/index.ts`** — Extended `BloomreachClientConfig` with optional `apiConfig` field and added `BloomreachStatusResult` interface. Replaced hardcoded `connected: false` with actual credential validation via the existing `validateCredentials()` function (calls `/system/time` endpoint).
- **`packages/mcp/src/bin/bloomreach-mcp.ts`** — Pass the existing `apiConfig` (resolved from env vars) into `BloomreachClient` so the status tool can perform the connectivity check.
- **`packages/core/src/__tests__/client.test.ts`** — Replaced single test with comprehensive suite covering: no credentials, successful validation, invalid credentials, network errors, and fallback error messages.

## Status response (before → after)

**Before:**
```json
{ "connected": false, "environment": "production" }
```

**After (with valid credentials):**
```json
{
  "connected": true,
  "environment": "production",
  "project": "my-project-token",
  "apiConfigured": true,
  "apiBaseUrl": "https://api.exponea.com"
}
```

**After (with invalid/missing credentials):**
```json
{
  "connected": false,
  "environment": "production",
  "apiConfigured": false,
  "error": "API credentials not configured. Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables."
}
```

## Quality Gates

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 4719 tests passed, 0 failures
- ✅ `npm run build` — all 3 packages built

Closes #176
