### PR TITLE
feat #175: implement CAPTCHA-resilient authentication strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ BLOOMREACH_API_SECRET=your-api-secret
 # Optional: Bloomreach environment + token for the legacy BloomreachClient status check
 # BLOOMREACH_ENVIRONMENT=my-env
 # BLOOMREACH_API_TOKEN=my-token
+
+# Optional: Browser authentication settings
+# Directory for Playwright persistent browser profiles (default: ~/.bloomreach-buddy/profiles)
+# BLOOMREACH_PROFILE_DIR=~/.bloomreach-buddy/profiles
+# Override the Bloomreach login URL (default: https://eu.login.bloomreach.com/)
+# BLOOMREACH_LOGIN_URL=https://eu.login.bloomreach.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1840,6 +1840,23 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
@@ -3247,6 +3264,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -4127,6 +4150,18 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -4225,6 +4260,23 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4308,6 +4360,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rolldown": {
@@ -5212,7 +5273,12 @@
     "packages/core": {
       "name": "@bloomreach-buddy/core",
       "version": "0.0.1",
+      "dependencies": {
+        "playwright-core": "^1.52.0",
+        "proper-lockfile": "^4.1.2"
+      },
       "devDependencies": {
+        "@types/proper-lockfile": "^4.1.4",
         "tsup": "^8.0.0",
         "vitest": "^4.1.0"
       }

--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -6,6 +6,7 @@ import { readFileSync } from 'node:fs';
 import {
   BloomreachAccessManagementService,
   BloomreachAssetManagerService,
+  BloomreachAuthService,
   BloomreachCampaignCalendarService,
   BloomreachCampaignSettingsService,
   BloomreachChannelSettingsService,
@@ -40,9 +41,11 @@ import {
   BloomreachVouchersService,
   BloomreachWeblayersService,
   resolveApiConfig,
+  resolveProfilesDir,
   validateCredentials,
   writeEnvFile,
   openBrowserUrl,
+  BloomreachProfileManager,
   BLOOMREACH_API_SETTINGS_URL,
 } from '@bloomreach-buddy/core';
 import type {
@@ -12159,6 +12162,195 @@ program
             status: 'error',
             message: error instanceof Error ? error.message : String(error),
           });
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+program
+  .command('login')
+  .description('Open browser for manual Bloomreach login (captures session for automation)')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--timeout <ms>', 'Login timeout in milliseconds', '300000')
+  .option('--login-url <url>', 'Override login URL')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      profile: string;
+      timeout: string;
+      loginUrl?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const authService = new BloomreachAuthService(profileManager, { profilesDir });
+
+        if (!options.json) {
+          console.log('');
+          console.log('  Opening browser for Bloomreach login...');
+          console.log('  Complete the login in the browser window.');
+          console.log(`  Timeout: ${Number(options.timeout) / 1000}s`);
+          console.log('');
+        }
+
+        const result = await authService.openLogin({
+          profileName: options.profile,
+          timeoutMs: Number(options.timeout),
+          loginUrl: options.loginUrl,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else if (result.timedOut) {
+          console.log('  Login timed out. Please try again.');
+          process.exit(1);
+        } else if (result.authenticated) {
+          console.log('  Login successful! Session captured and encrypted.');
+          console.log(`  Profile: ${result.profileName}`);
+        } else {
+          console.log(`  Login failed: ${result.reason}`);
+          process.exit(1);
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                authenticated: false,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+const auth = program
+  .command('auth')
+  .description('Manage Bloomreach browser authentication');
+
+auth
+  .command('status')
+  .description('Check browser session authentication status')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { profile: string; json?: boolean }) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const authService = new BloomreachAuthService(profileManager, { profilesDir });
+
+        const status = await authService.status({ profileName: options.profile });
+
+        if (options.json) {
+          console.log(JSON.stringify(status, null, 2));
+        } else {
+          console.log('');
+          console.log(`  Authenticated: ${status.authenticated ? 'yes' : 'no'}`);
+          console.log(`  Profile:       ${status.profileName}`);
+          console.log(`  Reason:        ${status.reason}`);
+          if (status.sessionExpired) {
+            console.log('  Session:       expired');
+          }
+          if (status.cookieSummary && status.cookieSummary.length > 0) {
+            console.log(`  Cookies:       ${status.cookieSummary.length} stored`);
+          }
+          console.log('');
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                authenticated: false,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+auth
+  .command('open-login')
+  .description('Open browser for manual Bloomreach login (alias for "bloomreach login")')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--timeout <ms>', 'Login timeout in milliseconds', '300000')
+  .option('--login-url <url>', 'Override login URL')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: {
+      profile: string;
+      timeout: string;
+      loginUrl?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const authService = new BloomreachAuthService(profileManager, { profilesDir });
+
+        if (!options.json) {
+          console.log('');
+          console.log('  Opening browser for Bloomreach login...');
+          console.log('  Complete the login in the browser window.');
+          console.log(`  Timeout: ${Number(options.timeout) / 1000}s`);
+          console.log('');
+        }
+
+        const result = await authService.openLogin({
+          profileName: options.profile,
+          timeoutMs: Number(options.timeout),
+          loginUrl: options.loginUrl,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else if (result.timedOut) {
+          console.log('  Login timed out. Please try again.');
+          process.exit(1);
+        } else if (result.authenticated) {
+          console.log('  Login successful! Session captured and encrypted.');
+          console.log(`  Profile: ${result.profileName}`);
+        } else {
+          console.log(`  Login failed: ${result.reason}`);
+          process.exit(1);
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                authenticated: false,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              null,
+              2,
+            ),
+          );
         } else {
           console.error(
             `Error: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,12 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
+  "dependencies": {
+    "playwright-core": "^1.52.0",
+    "proper-lockfile": "^4.1.2"
+  },
   "devDependencies": {
+    "@types/proper-lockfile": "^4.1.4",
     "tsup": "^8.0.0",
     "vitest": "^4.1.0"
   }

--- a/packages/core/src/__tests__/bloomreachApiClient.test.ts
+++ b/packages/core/src/__tests__/bloomreachApiClient.test.ts
@@ -1233,3 +1233,23 @@ describe('buildWebxpPath', () => {
     );
   });
 });
+
+// ===========================================================================
+// Browser auth error codes
+// ===========================================================================
+
+describe('Browser auth error codes', () => {
+  it.each([
+    'AUTH_REQUIRED',
+    'CAPTCHA_OR_CHALLENGE',
+    'SESSION_EXPIRED',
+    'PROFILE_LOCKED',
+  ] as const)('BloomreachBuddyError can be constructed with code %s', (code) => {
+    const error = new BloomreachBuddyError(code, `Test ${code} message`);
+    expect(error).toBeInstanceOf(BloomreachBuddyError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe(code);
+    expect(error.message).toBe(`Test ${code} message`);
+    expect(error.name).toBe('BloomreachBuddyError');
+  });
+});

--- a/packages/core/src/__tests__/bloomreachAuth.test.ts
+++ b/packages/core/src/__tests__/bloomreachAuth.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BloomreachProfileManager } from '../bloomreachProfileManager.js';
+import type { BloomreachStorageState, StoredSession } from '../bloomreachSessionStore.js';
+import { BloomreachAuthService, isAuthenticatedPage, isLoginPage } from '../bloomreachAuth.js';
+
+vi.mock('../bloomreachSessionStore.js', () => ({
+  loadSession: vi.fn(),
+  saveSession: vi.fn(),
+  isSessionExpired: vi.fn(),
+  summarizeSessionCookies: vi.fn(),
+}));
+
+import {
+  loadSession,
+  saveSession,
+  isSessionExpired,
+  summarizeSessionCookies,
+} from '../bloomreachSessionStore.js';
+
+const mockPage = {
+  goto: vi.fn(),
+  waitForTimeout: vi.fn(async () => undefined),
+  url: vi.fn(),
+};
+
+const mockContext = {
+  pages: () => [mockPage],
+  newPage: vi.fn(),
+  storageState: vi.fn().mockResolvedValue({ cookies: [], origins: [] }),
+  close: vi.fn(),
+};
+
+const mockProfileManager = {
+  runWithPersistentContext: vi.fn().mockImplementation(
+    async (
+      _profile: string,
+      _opts: unknown,
+      callback: (ctx: unknown) => Promise<unknown>,
+    ) => callback(mockContext),
+  ),
+};
+
+const profileManagerForAuth = mockProfileManager as unknown as BloomreachProfileManager;
+
+const validSession: StoredSession = {
+  schemaVersion: 1,
+  metadata: {
+    capturedAt: '2026-01-01T00:00:00.000Z',
+    profileName: 'default',
+    loginUrl: 'https://eu.login.bloomreach.com/',
+    cookieCount: 1,
+    earliestCookieExpiry: '2030-01-01T00:00:00.000Z',
+  },
+  storageState: {
+    cookies: [
+      {
+        name: 'sid',
+        value: 'secret',
+        domain: '.bloomreach.com',
+        path: '/',
+        expires: 1_893_456_000,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax',
+      },
+    ],
+    origins: [],
+  },
+};
+
+const cookieSummary = [
+  {
+    name: 'sid',
+    domain: '.bloomreach.com',
+    expiresAt: '2030-01-01T00:00:00.000Z',
+  },
+];
+
+describe('bloomreachAuth helpers', () => {
+  it('isLoginPage returns expected values', () => {
+    expect(isLoginPage('https://eu.login.bloomreach.com/')).toBe(true);
+    expect(isLoginPage('https://app.bloomreach.com/')).toBe(false);
+    expect(isLoginPage('https://example.com/login')).toBe(true);
+    expect(isLoginPage('not-a-valid-url')).toBe(false);
+  });
+
+  it('isAuthenticatedPage returns expected values', () => {
+    expect(isAuthenticatedPage('https://app.bloomreach.com/project/123')).toBe(true);
+    expect(isAuthenticatedPage('https://eu.login.bloomreach.com/')).toBe(false);
+    expect(isAuthenticatedPage('https://app.bloomreach.com/login')).toBe(false);
+  });
+});
+
+describe('BloomreachAuthService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPage.goto.mockResolvedValue(null);
+    mockPage.waitForTimeout.mockResolvedValue(undefined);
+    mockPage.url.mockReset();
+    mockContext.newPage.mockResolvedValue(mockPage);
+    mockContext.storageState.mockResolvedValue({ cookies: [], origins: [] });
+    vi.mocked(summarizeSessionCookies).mockReturnValue(cookieSummary);
+  });
+
+  it('status returns unauthenticated when no session exists', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.status({ profileName: 'p1' });
+
+    expect(result.authenticated).toBe(false);
+    expect(result.reason).toContain('No stored session found');
+    expect(result.profileName).toBe('p1');
+    expect(result.sessionCookiePresent).toBe(false);
+    expect(result.sessionExpired).toBe(false);
+  });
+
+  it('status returns unauthenticated for expired session', async () => {
+    vi.mocked(loadSession).mockResolvedValue(validSession);
+    vi.mocked(isSessionExpired).mockReturnValue(true);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.status({ profileName: 'p1' });
+
+    expect(result.authenticated).toBe(false);
+    expect(result.sessionCookiePresent).toBe(true);
+    expect(result.sessionExpired).toBe(true);
+    expect(result.cookieSummary).toEqual(cookieSummary);
+  });
+
+  it('status returns authenticated for valid session', async () => {
+    vi.mocked(loadSession).mockResolvedValue(validSession);
+    vi.mocked(isSessionExpired).mockReturnValue(false);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.status({ profileName: 'p1' });
+
+    expect(result.authenticated).toBe(true);
+    expect(result.reason).toBe('Session is valid.');
+    expect(result.profileName).toBe('p1');
+    expect(result.sessionCookiePresent).toBe(true);
+    expect(result.sessionExpired).toBe(false);
+    expect(result.cookieSummary).toEqual(cookieSummary);
+  });
+
+  it('status uses default profile name when omitted', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.status();
+
+    expect(result.profileName).toBe('default');
+    expect(loadSession).toHaveBeenCalledWith('/profiles', 'default');
+  });
+
+  it('openLogin handles successful login and persists session', async () => {
+    const storageState: BloomreachStorageState = {
+      cookies: validSession.storageState.cookies,
+      origins: [],
+    };
+
+    mockPage.url.mockReturnValueOnce('https://app.bloomreach.com/project/123');
+    mockContext.storageState.mockResolvedValue(storageState);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.openLogin({
+      profileName: 'p1',
+      timeoutMs: 60_000,
+      pollIntervalMs: 1,
+    });
+
+    expect(mockProfileManager.runWithPersistentContext).toHaveBeenCalledWith(
+      'p1',
+      { headless: false },
+      expect.any(Function),
+    );
+    expect(mockPage.goto).toHaveBeenCalledWith('https://eu.login.bloomreach.com/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30_000,
+    });
+    expect(saveSession).toHaveBeenCalledWith(
+      '/profiles',
+      'p1',
+      storageState,
+      'https://eu.login.bloomreach.com/',
+    );
+    expect(result.authenticated).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.sessionCookiePresent).toBe(true);
+    expect(result.cookieSummary).toEqual(cookieSummary);
+  });
+
+  it('openLogin returns timedOut true when login does not complete', async () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy
+      .mockImplementationOnce(() => 0)
+      .mockImplementationOnce(() => 0)
+      .mockImplementation(() => 10);
+    mockPage.url.mockReturnValue('https://eu.login.bloomreach.com/');
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.openLogin({
+      profileName: 'p1',
+      timeoutMs: 5,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.authenticated).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(saveSession).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
+  });
+
+  it('ensureAuthenticated returns status when already authenticated', async () => {
+    vi.mocked(loadSession).mockResolvedValue(validSession);
+    vi.mocked(isSessionExpired).mockReturnValue(false);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await auth.ensureAuthenticated({ profileName: 'p1' });
+
+    expect(result.authenticated).toBe(true);
+    expect(result.profileName).toBe('p1');
+  });
+
+  it('ensureAuthenticated throws AUTH_REQUIRED when unauthenticated', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+
+    const auth = new BloomreachAuthService(profileManagerForAuth, {
+      profilesDir: '/profiles',
+    });
+
+    await expect(auth.ensureAuthenticated({ profileName: 'p1' })).rejects.toMatchObject({
+      code: 'AUTH_REQUIRED',
+      name: 'BloomreachBuddyError',
+    });
+  });
+});

--- a/packages/core/src/__tests__/bloomreachProfileManager.test.ts
+++ b/packages/core/src/__tests__/bloomreachProfileManager.test.ts
@@ -1,0 +1,193 @@
+import path from 'node:path';
+import { homedir } from 'node:os';
+import { mkdir } from 'node:fs/promises';
+import lockfile from 'proper-lockfile';
+import { chromium } from 'playwright-core';
+import type { BrowserContext } from 'playwright-core';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BloomreachBuddyError } from '../bloomreachApiClient.js';
+import {
+  BloomreachProfileManager,
+  resolveProfilesDir,
+} from '../bloomreachProfileManager.js';
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+}));
+
+vi.mock('proper-lockfile', () => ({
+  default: {
+    lock: vi.fn(),
+  },
+}));
+
+vi.mock('playwright-core', () => ({
+  chromium: {
+    launchPersistentContext: vi.fn(),
+  },
+}));
+
+const ORIGINAL_ENV = process.env;
+
+describe('resolveProfilesDir', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.BLOOMREACH_PROFILE_DIR;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('uses explicit parameter when provided', () => {
+    process.env.BLOOMREACH_PROFILE_DIR = '/env/profiles';
+
+    const result = resolveProfilesDir('/explicit/profiles');
+
+    expect(result).toBe('/explicit/profiles');
+  });
+
+  it('falls back to BLOOMREACH_PROFILE_DIR environment variable', () => {
+    process.env.BLOOMREACH_PROFILE_DIR = '/env/profiles';
+
+    const result = resolveProfilesDir();
+
+    expect(result).toBe('/env/profiles');
+  });
+
+  it('defaults to ~/.bloomreach-buddy/profiles when explicit and env are missing', () => {
+    const result = resolveProfilesDir();
+
+    expect(result).toBe(path.join(homedir(), '.bloomreach-buddy', 'profiles'));
+  });
+});
+
+describe('BloomreachProfileManager', () => {
+  const manager = new BloomreachProfileManager({ profilesDir: '/profiles' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getProfileUserDataDir', () => {
+    it('returns default profile path when no profile name is provided', () => {
+      expect(manager.getProfileUserDataDir()).toBe(path.join('/profiles', 'default'));
+    });
+
+    it('returns custom profile path when profile name is provided', () => {
+      expect(manager.getProfileUserDataDir('team-a')).toBe(
+        path.join('/profiles', 'team-a'),
+      );
+    });
+  });
+
+  describe('withProfileLock', () => {
+    it('acquires lock, runs callback, and releases lock', async () => {
+      const releaseMock = vi.fn(async () => undefined);
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseMock);
+
+      const callback = vi.fn(async () => 'ok');
+
+      const result = await manager.withProfileLock('default', callback);
+
+      const expectedDir = path.join('/profiles', 'default');
+      expect(result).toBe('ok');
+      expect(mkdir).toHaveBeenCalledWith(expectedDir, { recursive: true });
+      expect(lockfile.lock).toHaveBeenCalledWith(expectedDir, {
+        realpath: false,
+        lockfilePath: path.join(expectedDir, '.profile.lock'),
+        retries: {
+          retries: 20,
+          factor: 1.2,
+          minTimeout: 100,
+          maxTimeout: 1000,
+        },
+      });
+      expect(callback).toHaveBeenCalledWith(expectedDir);
+      expect(releaseMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps lock failures to PROFILE_LOCKED', async () => {
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(lockfile.lock).mockRejectedValue(new Error('busy'));
+      const callback = vi.fn(async () => 'ok');
+
+      await expect(manager.withProfileLock('shared', callback)).rejects.toMatchObject({
+        code: 'PROFILE_LOCKED',
+        message: 'Browser profile "shared" is locked by another process.',
+      });
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runWithPersistentContext', () => {
+    it('launches persistent context with expected options and closes on success', async () => {
+      const releaseMock = vi.fn(async () => undefined);
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseMock);
+
+      const closeMock = vi.fn(async () => undefined);
+      const context = {
+        close: closeMock,
+      } as unknown as BrowserContext;
+
+      vi.mocked(chromium.launchPersistentContext).mockResolvedValue(context);
+
+      const callback = vi.fn(async () => 'done');
+
+      const result = await manager.runWithPersistentContext(
+        'qa',
+        {
+          headless: false,
+          args: ['--window-size=1280,720'],
+        },
+        callback,
+      );
+
+      const expectedDir = path.join('/profiles', 'qa');
+      expect(result).toBe('done');
+      expect(chromium.launchPersistentContext).toHaveBeenCalledWith(expectedDir, {
+        headless: false,
+        args: [
+          '--disable-blink-features=AutomationControlled',
+          '--no-first-run',
+          '--no-default-browser-check',
+          '--window-size=1280,720',
+        ],
+      });
+      expect(callback).toHaveBeenCalledWith(context);
+      expect(closeMock).toHaveBeenCalledTimes(1);
+      expect(releaseMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes context when callback throws and rethrows the error', async () => {
+      const releaseMock = vi.fn(async () => undefined);
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseMock);
+
+      const closeMock = vi.fn(async () => undefined);
+      const context = {
+        close: closeMock,
+      } as unknown as BrowserContext;
+
+      vi.mocked(chromium.launchPersistentContext).mockResolvedValue(context);
+
+      const failure = new BloomreachBuddyError('NETWORK_ERROR', 'callback failed');
+
+      await expect(
+        manager.runWithPersistentContext('qa', {}, async () => {
+          throw failure;
+        }),
+      ).rejects.toBe(failure);
+
+      expect(closeMock).toHaveBeenCalledTimes(1);
+      expect(releaseMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/__tests__/bloomreachSessionStore.test.ts
+++ b/packages/core/src/__tests__/bloomreachSessionStore.test.ts
@@ -1,0 +1,250 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual('node:os') as Record<string, unknown>;
+  return {
+    ...actual,
+    hostname: () => 'test-host',
+    userInfo: () => ({
+      ...(actual.userInfo as () => Record<string, unknown>)(),
+      username: 'test-user',
+    }),
+  };
+});
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual('node:fs/promises') as Record<string, unknown>;
+  return {
+    ...actual,
+    chmod: vi.fn(async () => undefined),
+  };
+});
+
+import {
+  deriveEncryptionKey,
+  getSessionFilePath,
+  isSessionExpired,
+  loadSession,
+  saveSession,
+  summarizeSessionCookies,
+  type BloomreachStorageState,
+  type StoredSession,
+} from '../bloomreachSessionStore.js';
+
+function makeStorageState(nowSeconds: number): BloomreachStorageState {
+  return {
+    cookies: [
+      {
+        name: 'auth',
+        value: 'secret-cookie-value',
+        domain: '.bloomreach.com',
+        path: '/',
+        expires: nowSeconds + 3600,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax',
+      },
+      {
+        name: 'session-only',
+        value: 'session-value',
+        domain: '.bloomreach.com',
+        path: '/',
+        expires: -1,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Strict',
+      },
+    ],
+    origins: [
+      {
+        origin: 'https://app.bloomreach.com',
+        localStorage: [{ name: 'token', value: 'abc123' }],
+      },
+    ],
+  };
+}
+
+describe('bloomreachSessionStore', () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), 'bloomreach-session-store-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('deriveEncryptionKey is deterministic, unique per profile, and 32 bytes', () => {
+    const first = deriveEncryptionKey('profile-a');
+    const second = deriveEncryptionKey('profile-a');
+    const different = deriveEncryptionKey('profile-b');
+
+    expect(first.equals(second)).toBe(true);
+    expect(first.equals(different)).toBe(false);
+    expect(first.length).toBe(32);
+  });
+
+  it('getSessionFilePath builds profile session path', () => {
+    const result = getSessionFilePath('/tmp/profiles', 'my-profile');
+    expect(result).toBe(path.join('/tmp/profiles', 'my-profile', '.session.enc.json'));
+  });
+
+  it('saveSession and loadSession round-trip encrypted session data', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const storageState = makeStorageState(nowSeconds);
+
+    const filePath = await saveSession(
+      tempRoot,
+      'alpha',
+      storageState,
+      'https://app.bloomreach.com/login',
+    );
+
+    const encryptedOnDisk = await readFile(filePath, 'utf8');
+    expect(encryptedOnDisk).toContain('"algorithm": "aes-256-gcm"');
+    expect(encryptedOnDisk).toContain('"metadata"');
+    expect(encryptedOnDisk).not.toContain('secret-cookie-value');
+    expect(encryptedOnDisk).not.toContain('"storageState"');
+
+    const loaded = await loadSession(tempRoot, 'alpha');
+    expect(loaded).not.toBeNull();
+
+    expect(loaded?.schemaVersion).toBe(1);
+    expect(loaded?.storageState).toEqual(storageState);
+    expect(loaded?.metadata.profileName).toBe('alpha');
+    expect(loaded?.metadata.loginUrl).toBe('https://app.bloomreach.com/login');
+    expect(loaded?.metadata.cookieCount).toBe(2);
+    expect(loaded?.metadata.earliestCookieExpiry).toBe(
+      new Date((nowSeconds + 3600) * 1000).toISOString(),
+    );
+    expect(new Date(loaded?.metadata.capturedAt ?? '').toString()).not.toBe('Invalid Date');
+  });
+
+  it('loadSession returns null for missing file', async () => {
+    const loaded = await loadSession(tempRoot, 'does-not-exist');
+    expect(loaded).toBeNull();
+  });
+
+  it('loadSession returns null for corrupt file', async () => {
+    const sessionFilePath = getSessionFilePath(tempRoot, 'broken');
+    await mkdir(path.dirname(sessionFilePath), { recursive: true });
+    await writeFile(sessionFilePath, 'this is not valid json', 'utf8');
+
+    const loaded = await loadSession(tempRoot, 'broken');
+    expect(loaded).toBeNull();
+  });
+
+  it('isSessionExpired handles expired, valid, session-only, and empty cookie sets', () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    const expiredSession: StoredSession = {
+      schemaVersion: 1,
+      metadata: {
+        capturedAt: new Date().toISOString(),
+        profileName: 'p',
+        loginUrl: 'https://example.com',
+        cookieCount: 1,
+        earliestCookieExpiry: new Date((nowSeconds - 100) * 1000).toISOString(),
+      },
+      storageState: {
+        cookies: [
+          {
+            name: 'old',
+            value: 'x',
+            domain: 'example.com',
+            path: '/',
+            expires: nowSeconds - 100,
+            httpOnly: true,
+            secure: true,
+            sameSite: 'Lax',
+          },
+        ],
+        origins: [],
+      },
+    };
+
+    const validSession: StoredSession = {
+      ...expiredSession,
+      storageState: {
+        cookies: [
+          {
+            ...expiredSession.storageState.cookies[0],
+            expires: nowSeconds + 100,
+          },
+        ],
+        origins: [],
+      },
+    };
+
+    const sessionOnlyCookies: StoredSession = {
+      ...expiredSession,
+      storageState: {
+        cookies: [
+          {
+            ...expiredSession.storageState.cookies[0],
+            expires: -1,
+          },
+        ],
+        origins: [],
+      },
+    };
+
+    const noCookies: StoredSession = {
+      ...expiredSession,
+      storageState: {
+        cookies: [],
+        origins: [],
+      },
+    };
+
+    expect(isSessionExpired(expiredSession)).toBe(true);
+    expect(isSessionExpired(validSession)).toBe(false);
+    expect(isSessionExpired(sessionOnlyCookies)).toBe(false);
+    expect(isSessionExpired(noCookies)).toBe(true);
+  });
+
+  it('summarizeSessionCookies returns cookie metadata with nullable expiresAt', () => {
+    const cookies: BloomreachStorageState['cookies'] = [
+      {
+        name: 'persistent',
+        value: 'v1',
+        domain: '.bloomreach.com',
+        path: '/',
+        expires: 1893456000,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'None',
+      },
+      {
+        name: 'session',
+        value: 'v2',
+        domain: '.bloomreach.com',
+        path: '/',
+        expires: -1,
+        httpOnly: false,
+        secure: false,
+        sameSite: 'Strict',
+      },
+    ];
+
+    const summary = summarizeSessionCookies(cookies);
+
+    expect(summary).toEqual([
+      {
+        name: 'persistent',
+        domain: '.bloomreach.com',
+        expiresAt: '2030-01-01T00:00:00.000Z',
+      },
+      {
+        name: 'session',
+        domain: '.bloomreach.com',
+        expiresAt: null,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/bloomreachApiClient.ts
+++ b/packages/core/src/bloomreachApiClient.ts
@@ -20,7 +20,11 @@ export type BloomreachErrorCode =
   | 'TIMEOUT'
   | 'RATE_LIMITED'
   | 'API_ERROR'
-  | 'NETWORK_ERROR';
+  | 'NETWORK_ERROR'
+  | 'AUTH_REQUIRED'
+  | 'CAPTCHA_OR_CHALLENGE'
+  | 'SESSION_EXPIRED'
+  | 'PROFILE_LOCKED';
 
 /**
  * Base error class for all Bloomreach Buddy errors.

--- a/packages/core/src/bloomreachAuth.ts
+++ b/packages/core/src/bloomreachAuth.ts
@@ -1,0 +1,190 @@
+import type { BrowserContext, Page } from 'playwright-core';
+import { BloomreachBuddyError } from './bloomreachApiClient.js';
+import type {
+  BloomreachProfileManager,
+  PersistentContextOptions,
+} from './bloomreachProfileManager.js';
+import {
+  loadSession,
+  saveSession,
+  isSessionExpired,
+  summarizeSessionCookies,
+} from './bloomreachSessionStore.js';
+import type { BloomreachStorageState, StoredSession } from './bloomreachSessionStore.js';
+
+export const BLOOMREACH_LOGIN_URL = 'https://eu.login.bloomreach.com/';
+export const BLOOMREACH_APP_URL = 'https://app.bloomreach.com/';
+
+export const DEFAULT_LOGIN_TIMEOUT_MS = 300_000;
+export const DEFAULT_LOGIN_POLL_INTERVAL_MS = 2_000;
+
+export interface BloomreachSessionStatus {
+  authenticated: boolean;
+  checkedAt: string;
+  reason: string;
+  profileName: string;
+  sessionCookiePresent: boolean;
+  sessionExpired: boolean;
+  cookieSummary?: Array<{ name: string; domain: string; expiresAt: string | null }>;
+}
+
+export interface BloomreachSessionOptions {
+  profileName?: string;
+}
+
+export interface BloomreachOpenLoginOptions extends BloomreachSessionOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  loginUrl?: string;
+}
+
+export interface BloomreachOpenLoginResult extends BloomreachSessionStatus {
+  timedOut: boolean;
+}
+
+export interface BloomreachAuthConfig {
+  profilesDir: string;
+  loginUrl?: string;
+}
+
+export function isLoginPage(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.includes('login.bloomreach.com') || parsed.pathname === '/login';
+  } catch {
+    return false;
+  }
+}
+
+export function isAuthenticatedPage(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.includes('app.bloomreach.com') && parsed.pathname !== '/login';
+  } catch {
+    return false;
+  }
+}
+
+export class BloomreachAuthService {
+  private readonly profileManager: BloomreachProfileManager;
+  private readonly profilesDir: string;
+  private readonly loginUrl: string;
+
+  constructor(profileManager: BloomreachProfileManager, config: BloomreachAuthConfig) {
+    this.profileManager = profileManager;
+    this.profilesDir = config.profilesDir;
+    this.loginUrl = config.loginUrl ?? process.env.BLOOMREACH_LOGIN_URL ?? BLOOMREACH_LOGIN_URL;
+  }
+
+  async status(options?: BloomreachSessionOptions): Promise<BloomreachSessionStatus> {
+    const profileName = options?.profileName ?? 'default';
+    const checkedAt = new Date().toISOString();
+
+    const session: StoredSession | null = await loadSession(this.profilesDir, profileName);
+
+    if (!session) {
+      return {
+        authenticated: false,
+        checkedAt,
+        reason: 'No stored session found. Run "bloomreach login" to authenticate.',
+        profileName,
+        sessionCookiePresent: false,
+        sessionExpired: false,
+      };
+    }
+
+    if (isSessionExpired(session)) {
+      return {
+        authenticated: false,
+        checkedAt,
+        reason: 'Stored session has expired. Run "bloomreach login" to re-authenticate.',
+        profileName,
+        sessionCookiePresent: true,
+        sessionExpired: true,
+        cookieSummary: summarizeSessionCookies(session.storageState.cookies),
+      };
+    }
+
+    return {
+      authenticated: true,
+      checkedAt,
+      reason: 'Session is valid.',
+      profileName,
+      sessionCookiePresent: true,
+      sessionExpired: false,
+      cookieSummary: summarizeSessionCookies(session.storageState.cookies),
+    };
+  }
+
+  async openLogin(options?: BloomreachOpenLoginOptions): Promise<BloomreachOpenLoginResult> {
+    const profileName = options?.profileName ?? 'default';
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS;
+    const pollIntervalMs = options?.pollIntervalMs ?? DEFAULT_LOGIN_POLL_INTERVAL_MS;
+    const loginUrl = options?.loginUrl ?? this.loginUrl;
+    const persistentOptions: PersistentContextOptions = { headless: false };
+
+    return this.profileManager.runWithPersistentContext(
+      profileName,
+      persistentOptions,
+      async (context: BrowserContext) => {
+        const page: Page = context.pages()[0] ?? (await context.newPage());
+
+        await page.goto(loginUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+        const deadline = Date.now() + timeoutMs;
+        let authenticated = false;
+
+        while (Date.now() < deadline) {
+          await page.waitForTimeout(pollIntervalMs);
+          const currentUrl = page.url();
+
+          if (isAuthenticatedPage(currentUrl)) {
+            authenticated = true;
+            break;
+          }
+        }
+
+        const checkedAt = new Date().toISOString();
+
+        if (!authenticated) {
+          return {
+            authenticated: false,
+            checkedAt,
+            reason: 'Login timed out. The browser was closed or login was not completed in time.',
+            profileName,
+            sessionCookiePresent: false,
+            sessionExpired: false,
+            timedOut: true,
+          };
+        }
+
+        const storageState = (await context.storageState()) as unknown as BloomreachStorageState;
+
+        await saveSession(this.profilesDir, profileName, storageState, loginUrl);
+
+        return {
+          authenticated: true,
+          checkedAt,
+          reason: 'Login successful. Session captured and encrypted.',
+          profileName,
+          sessionCookiePresent: true,
+          sessionExpired: false,
+          timedOut: false,
+          cookieSummary: summarizeSessionCookies(storageState.cookies),
+        };
+      },
+    );
+  }
+
+  async ensureAuthenticated(options?: BloomreachSessionOptions): Promise<BloomreachSessionStatus> {
+    const sessionStatus = await this.status(options);
+    if (sessionStatus.authenticated) {
+      return sessionStatus;
+    }
+
+    throw new BloomreachBuddyError(
+      'AUTH_REQUIRED',
+      `Browser session is not authenticated: ${sessionStatus.reason}`,
+    );
+  }
+}

--- a/packages/core/src/bloomreachProfileManager.ts
+++ b/packages/core/src/bloomreachProfileManager.ts
@@ -1,0 +1,104 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { homedir } from 'node:os';
+import lockfile from 'proper-lockfile';
+import { chromium } from 'playwright-core';
+import type { BrowserContext, LaunchOptions } from 'playwright-core';
+import { BloomreachBuddyError } from './bloomreachApiClient.js';
+
+export interface ProfileManagerConfig {
+  /** Base directory for browser profiles. Default: ~/.bloomreach-buddy/profiles */
+  profilesDir: string;
+}
+
+export interface PersistentContextOptions {
+  /** Run in headless mode. Default: true */
+  headless?: boolean;
+  /** Extra Chromium launch arguments */
+  args?: string[];
+}
+
+export function resolveProfilesDir(explicit?: string): string {
+  return (
+    explicit ??
+    process.env.BLOOMREACH_PROFILE_DIR ??
+    path.join(homedir(), '.bloomreach-buddy', 'profiles')
+  );
+}
+
+export class BloomreachProfileManager {
+  readonly profilesDir: string;
+
+  constructor(config: ProfileManagerConfig) {
+    this.profilesDir = config.profilesDir;
+  }
+
+  getProfileUserDataDir(profileName?: string): string {
+    return path.join(this.profilesDir, profileName || 'default');
+  }
+
+  async withProfileLock<T>(
+    profileName: string,
+    callback: (userDataDir: string) => Promise<T>,
+  ): Promise<T> {
+    const userDataDir = this.getProfileUserDataDir(profileName);
+    await mkdir(userDataDir, { recursive: true });
+
+    let release: (() => Promise<void>) | undefined;
+
+    try {
+      release = await lockfile.lock(userDataDir, {
+        realpath: false,
+        lockfilePath: path.join(userDataDir, '.profile.lock'),
+        retries: {
+          retries: 20,
+          factor: 1.2,
+          minTimeout: 100,
+          maxTimeout: 1000,
+        },
+      });
+    } catch {
+      throw new BloomreachBuddyError(
+        'PROFILE_LOCKED',
+        `Browser profile "${profileName}" is locked by another process.`,
+      );
+    }
+
+    try {
+      return await callback(userDataDir);
+    } finally {
+      if (release !== undefined) {
+        await release();
+      }
+    }
+  }
+
+  async runWithPersistentContext<T>(
+    profileName: string,
+    options: PersistentContextOptions,
+    callback: (context: BrowserContext) => Promise<T>,
+  ): Promise<T> {
+    return this.withProfileLock(profileName, async (userDataDir) => {
+      const launchOptions: LaunchOptions = {
+        headless: options.headless ?? true,
+        args: [
+          '--disable-blink-features=AutomationControlled',
+          '--no-first-run',
+          '--no-default-browser-check',
+          ...(options.args ?? []),
+        ],
+      };
+
+      const context = await chromium.launchPersistentContext(
+        userDataDir,
+        launchOptions,
+      );
+
+      try {
+        return await callback(context);
+      } finally {
+        await context.close();
+      }
+    });
+  }
+}

--- a/packages/core/src/bloomreachSessionStore.ts
+++ b/packages/core/src/bloomreachSessionStore.ts
@@ -1,0 +1,191 @@
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { hostname, userInfo } from 'node:os';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BloomreachStorageState {
+  cookies: BloomreachCookie[];
+  origins: BloomreachOriginState[];
+}
+
+export interface BloomreachCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number; // epoch seconds, -1 for session cookies
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: 'Strict' | 'Lax' | 'None';
+}
+
+export interface BloomreachOriginState {
+  origin: string;
+  localStorage: Array<{ name: string; value: string }>;
+}
+
+export interface SessionMetadata {
+  capturedAt: string; // ISO-8601
+  profileName: string;
+  loginUrl: string;
+  cookieCount: number;
+  earliestCookieExpiry: string | null; // ISO-8601 or null if all session cookies
+}
+
+export interface StoredSession {
+  schemaVersion: 1;
+  metadata: SessionMetadata;
+  storageState: BloomreachStorageState;
+}
+
+// Internal encrypted envelope (written to disk)
+interface EncryptedEnvelope {
+  version: 1;
+  algorithm: 'aes-256-gcm';
+  ciphertext: string; // base64url
+  iv: string; // base64url
+  tag: string; // base64url
+  metadata: SessionMetadata;
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation
+// ---------------------------------------------------------------------------
+
+export function deriveEncryptionKey(profileName: string): Buffer {
+  // SHA-256 hash of: hostname + '\0' + username + '\0' + profileName + '\0' + 'bloomreach-buddy'
+  // This makes the key machine-bound (stolen files can't be decrypted elsewhere)
+  return createHash('sha256')
+    .update(hostname())
+    .update('\0')
+    .update(userInfo().username)
+    .update('\0')
+    .update(profileName)
+    .update('\0')
+    .update('bloomreach-buddy')
+    .digest();
+}
+
+// ---------------------------------------------------------------------------
+// Session path helpers
+// ---------------------------------------------------------------------------
+
+export function getSessionFilePath(profilesDir: string, profileName: string): string {
+  return path.join(profilesDir, profileName, '.session.enc.json');
+}
+
+function buildMetadata(
+  profileName: string,
+  loginUrl: string,
+  cookies: BloomreachCookie[],
+): SessionMetadata {
+  const persistentExpiries = cookies.filter((cookie) => cookie.expires > 0).map((cookie) => cookie.expires);
+  const earliestCookieExpiry =
+    persistentExpiries.length > 0
+      ? new Date(Math.min(...persistentExpiries) * 1000).toISOString()
+      : null;
+
+  return {
+    capturedAt: new Date().toISOString(),
+    profileName,
+    loginUrl,
+    cookieCount: cookies.length,
+    earliestCookieExpiry,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Save / Load
+// ---------------------------------------------------------------------------
+
+export async function saveSession(
+  profilesDir: string,
+  profileName: string,
+  storageState: BloomreachStorageState,
+  loginUrl: string,
+): Promise<string> {
+  const metadata = buildMetadata(profileName, loginUrl, storageState.cookies);
+  const storedSession: StoredSession = {
+    schemaVersion: 1,
+    metadata,
+    storageState,
+  };
+
+  const key = deriveEncryptionKey(profileName);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+
+  const plaintext = Buffer.from(JSON.stringify(storedSession), 'utf8');
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const envelope: EncryptedEnvelope = {
+    version: 1,
+    algorithm: 'aes-256-gcm',
+    ciphertext: ciphertext.toString('base64url'),
+    iv: iv.toString('base64url'),
+    tag: tag.toString('base64url'),
+    metadata,
+  };
+
+  const filePath = getSessionFilePath(profilesDir, profileName);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(envelope, null, 2) + '\n', 'utf8');
+  await chmod(filePath, 0o600);
+
+  return filePath;
+}
+
+export async function loadSession(
+  profilesDir: string,
+  profileName: string,
+): Promise<StoredSession | null> {
+  const filePath = getSessionFilePath(profilesDir, profileName);
+
+  try {
+    const content = await readFile(filePath, 'utf8');
+    const envelope = JSON.parse(content) as EncryptedEnvelope;
+
+    const key = deriveEncryptionKey(profileName);
+    const iv = Buffer.from(envelope.iv, 'base64url');
+    const tag = Buffer.from(envelope.tag, 'base64url');
+    const ciphertext = Buffer.from(envelope.ciphertext, 'base64url');
+
+    const decipher = createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(tag);
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    return JSON.parse(decrypted) as StoredSession;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session analysis
+// ---------------------------------------------------------------------------
+
+export function isSessionExpired(session: StoredSession): boolean {
+  // Check if ALL non-session cookies have expired
+  // Session cookies (expires === -1) are considered valid
+  // If there are no cookies at all, return true
+  const now = Date.now() / 1000; // epoch seconds
+  const persistentCookies = session.storageState.cookies.filter((c) => c.expires > 0);
+  if (persistentCookies.length === 0 && session.storageState.cookies.length === 0) return true;
+  if (persistentCookies.length === 0) return false; // only session cookies
+  return persistentCookies.every((c) => c.expires < now);
+}
+
+export function summarizeSessionCookies(
+  cookies: BloomreachCookie[],
+): Array<{ name: string; domain: string; expiresAt: string | null }> {
+  return cookies.map((c) => ({
+    name: c.name,
+    domain: c.domain,
+    expiresAt: c.expires > 0 ? new Date(c.expires * 1000).toISOString() : null,
+  }));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,9 @@ export * from './bloomreachAccessManagement.js';
 export * from './bloomreachApiClient.js';
 export * from './bloomreachSetup.js';
 export * from './bloomreachTracking.js';
+export * from './bloomreachProfileManager.js';
+export * from './bloomreachSessionStore.js';
+export * from './bloomreachAuth.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */

--- a/packages/mcp/src/__tests__/toolConstants.test.ts
+++ b/packages/mcp/src/__tests__/toolConstants.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { BLOOMREACH_MCP_TOOL_NAMES } from '../index.js';
 
 describe('tool constants', () => {
-  it('exports 259 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
-    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(259);
+  it('exports 260 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(260);
   });
 
   it('all tool names follow bloomreach.<domain>.<action> dot-notation', () => {

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -98,6 +98,32 @@ const tools: ToolRoute[] = [
     inputSchema: createInputSchema(false),
   },
   {
+    name: toolNames.BLOOMREACH_SESSION_OPEN_LOGIN_TOOL,
+    description:
+      'Open a headed browser window for manual Bloomreach authentication. ' +
+      'The user must complete login (including any CAPTCHA challenges) in the visible browser window. ' +
+      'Session cookies are captured and encrypted for future headless use. ' +
+      'Returns authentication status with a timedOut flag indicating if login completed within the timeout period.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'string',
+          description: 'Browser profile name (default: "default")',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Login timeout in milliseconds (default: 300000 — 5 minutes)',
+        },
+        loginUrl: {
+          type: 'string',
+          description: 'Override the login URL (default: https://eu.login.bloomreach.com/)',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
     name: toolNames.BLOOMREACH_DASHBOARDS_LIST_TOOL,
     description:
       'List all dashboards in the project. Use when you need this data from Bloomreach project workflows. Returns { error: string }; currently returns an error - requires browser automation (not yet implemented).',
@@ -6010,14 +6036,44 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const args = isPlainObject(request.params.arguments) ? request.params.arguments : {};
 
   try {
-if (name === toolNames.BLOOMREACH_STATUS_TOOL) {
-  const client = new core.BloomreachClient({
-    environment: process.env.BLOOMREACH_ENVIRONMENT ?? 'not-configured',
-    apiToken: process.env.BLOOMREACH_API_TOKEN ?? '',
-    apiConfig,
-  });
-  return toToolResult(await client.status());
-}
+    if (name === toolNames.BLOOMREACH_STATUS_TOOL) {
+      const client = new core.BloomreachClient({
+        environment: process.env.BLOOMREACH_ENVIRONMENT ?? 'not-configured',
+        apiToken: process.env.BLOOMREACH_API_TOKEN ?? '',
+        apiConfig,
+      });
+      const apiStatus = await client.status();
+
+      // Also check browser session status
+      let browserSession: core.BloomreachSessionStatus | undefined;
+      try {
+        const profilesDir = core.resolveProfilesDir();
+        const profileManager = new core.BloomreachProfileManager({ profilesDir });
+        const authService = new core.BloomreachAuthService(profileManager, { profilesDir });
+        const profileName = typeof args.profile === 'string' ? args.profile : 'default';
+        browserSession = await authService.status({ profileName });
+      } catch {
+        // Browser session check is best-effort — don't fail the status tool
+      }
+
+      return toToolResult({
+        ...apiStatus,
+        browserSession:
+          browserSession ?? { authenticated: false, reason: 'Could not check browser session.' },
+      });
+    }
+
+    if (name === toolNames.BLOOMREACH_SESSION_OPEN_LOGIN_TOOL) {
+      const profilesDir = core.resolveProfilesDir();
+      const profileManager = new core.BloomreachProfileManager({ profilesDir });
+      const authService = new core.BloomreachAuthService(profileManager, { profilesDir });
+      const result = await authService.openLogin({
+        profileName: typeof args.profile === 'string' ? args.profile : undefined,
+        timeoutMs: typeof args.timeoutMs === 'number' ? args.timeoutMs : undefined,
+        loginUrl: typeof args.loginUrl === 'string' ? args.loginUrl : undefined,
+      });
+      return toToolResult(result);
+    }
 
     const route = toolByName.get(name);
     if (!route || !route.serviceClass || !route.methodName) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,6 +4,7 @@ export * from './toolArgs.js';
 export * from './toolResults.js';
 
 export const BLOOMREACH_STATUS_TOOL = 'bloomreach.session.status';
+export const BLOOMREACH_SESSION_OPEN_LOGIN_TOOL = 'bloomreach.session.open_login';
 export const BLOOMREACH_DASHBOARDS_LIST_TOOL = 'bloomreach.dashboards.list';
 export const BLOOMREACH_DASHBOARDS_PREPARE_CREATE_TOOL = 'bloomreach.dashboards.prepare_create';
 export const BLOOMREACH_DASHBOARDS_PREPARE_SET_HOME_TOOL = 'bloomreach.dashboards.prepare_set_home';
@@ -366,6 +367,7 @@ export const BLOOMREACH_TRACKING_TRACK_CONSENT_TOOL = 'bloomreach.tracking.track
 export const BLOOMREACH_TRACKING_TRACK_CAMPAIGN_TOOL = 'bloomreach.tracking.track_campaign';
 export const BLOOMREACH_MCP_TOOL_NAMES = [
   BLOOMREACH_STATUS_TOOL,
+  BLOOMREACH_SESSION_OPEN_LOGIN_TOOL,
   BLOOMREACH_DASHBOARDS_LIST_TOOL,
   BLOOMREACH_DASHBOARDS_PREPARE_CREATE_TOOL,
   BLOOMREACH_DASHBOARDS_PREPARE_SET_HOME_TOOL,

--- a/packages/mcp/src/toolResults.ts
+++ b/packages/mcp/src/toolResults.ts
@@ -41,6 +41,14 @@ export function buildRecoveryHint(error: unknown): string {
       return 'Bloomreach API returned an error response. Check input parameters and project permissions, then retry.';
     case 'NETWORK_ERROR':
       return 'A network error occurred. Verify connectivity to Bloomreach API endpoints and retry.';
+    case 'AUTH_REQUIRED':
+      return 'Browser session is not authenticated. Run "bloomreach login" to open a browser and log in manually.';
+    case 'CAPTCHA_OR_CHALLENGE':
+      return 'A CAPTCHA or security challenge was detected. Run "bloomreach login" in headed mode to solve it manually.';
+    case 'SESSION_EXPIRED':
+      return 'The stored browser session has expired. Run "bloomreach login" to re-authenticate.';
+    case 'PROFILE_LOCKED':
+      return 'The browser profile is locked by another process. Close other instances and retry.';
     default:
       return 'The operation failed. Check the error details and retry with corrected input.';
   }


### PR DESCRIPTION
## Summary

Implements CAPTCHA-resilient authentication for Bloomreach Buddy, enabling automated browser sessions despite Google reCAPTCHA v2 on the login page.

**Strategy**: Persistent browser profiles + headed manual login. Users authenticate once in a visible browser (solving CAPTCHA manually), and the session is captured, encrypted, and reused for all subsequent headless operations.

## Changes

### Core Infrastructure (3 new modules)

- **`bloomreachProfileManager.ts`** — Manages Playwright persistent browser contexts with file-locked profile directories (`proper-lockfile`). Stealth launch args disable automation detection.
- **`bloomreachSessionStore.ts`** — Encrypted session persistence using AES-256-GCM with machine-bound keys (hostname + username). Cookies stored encrypted; metadata available without decryption.
- **`bloomreachAuth.ts`** — Auth service orchestrating profile manager + session store. Provides `status()` (offline cookie check), `openLogin()` (headed browser + polling), and `ensureAuthenticated()`.

### CLI Commands

- `bloomreach login` — Opens headed browser for manual Bloomreach login, captures session
- `bloomreach auth status` — Fast offline check of session validity
- `bloomreach auth open-login` — Alias for login command

### MCP Tools

- Enhanced `bloomreach.session.status` — Now includes browser session status alongside API connectivity
- New `bloomreach.session.open_login` — Opens headed browser for manual auth via MCP

### Extended Error Handling

4 new error codes: `AUTH_REQUIRED`, `CAPTCHA_OR_CHALLENGE`, `SESSION_EXPIRED`, `PROFILE_LOCKED` with recovery hints in MCP tool results.

### Config

- `BLOOMREACH_PROFILE_DIR` — Custom profile directory (default: `~/.bloomreach-buddy/profiles`)
- `BLOOMREACH_LOGIN_URL` — Configurable login URL (default: EU region)

## Test Results

- **4745 tests pass** across 44 test files (26 new tests added)
- All quality gates pass: typecheck, lint, build
- Manual QA: `bloomreach auth status --json` returns correct unauthenticated state

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/bloomreachProfileManager.ts` | **New** — Profile manager |
| `packages/core/src/bloomreachSessionStore.ts` | **New** — Encrypted session store |
| `packages/core/src/bloomreachAuth.ts` | **New** — Auth service |
| `packages/core/src/__tests__/bloomreachProfileManager.test.ts` | **New** — 9 tests |
| `packages/core/src/__tests__/bloomreachSessionStore.test.ts` | **New** — 7 tests |
| `packages/core/src/__tests__/bloomreachAuth.test.ts` | **New** — 10 tests |
| `packages/core/src/bloomreachApiClient.ts` | Extended `BloomreachErrorCode` union |
| `packages/core/src/index.ts` | 3 new barrel exports |
| `packages/core/package.json` | Added `playwright-core`, `proper-lockfile` deps |
| `packages/cli/src/bin/bloomreach.ts` | Added login + auth commands |
| `packages/mcp/src/index.ts` | New tool constant + array entry |
| `packages/mcp/src/bin/bloomreach-mcp.ts` | New tool route + enhanced status handler |
| `packages/mcp/src/toolResults.ts` | Recovery hints for new error codes |
| `.env.example` | Browser auth config section |

Closes #175
