### PR TITLE
fix #178: implement two-phase commit system with SQLite persistence and confirm tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,6 +1791,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2319,6 +2329,60 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -2354,6 +2418,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-require": {
@@ -2451,6 +2539,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
@@ -2582,6 +2676,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2602,7 +2720,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2635,6 +2752,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2927,6 +3053,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3089,6 +3224,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -3178,6 +3319,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3238,6 +3385,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -3339,6 +3492,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3363,6 +3536,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -3860,6 +4039,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3875,6 +4066,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.1",
@@ -3935,6 +4141,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3949,6 +4161,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.88.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
+      "integrity": "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -4234,6 +4458,33 @@
         }
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4290,6 +4541,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4337,6 +4598,35 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -4466,6 +4756,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4476,7 +4786,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4648,6 +4957,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -4691,6 +5045,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -4722,6 +5094,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thenify": {
@@ -4898,6 +5298,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4995,6 +5407,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5274,10 +5692,12 @@
       "name": "@bloomreach-buddy/core",
       "version": "0.0.1",
       "dependencies": {
+        "better-sqlite3": "12.8.0",
         "playwright-core": "^1.52.0",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "7.6.13",
         "@types/proper-lockfile": "^4.1.4",
         "tsup": "^8.0.0",
         "vitest": "^4.1.0"

--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -3,10 +3,14 @@
 import { Command } from 'commander';
 import { input, password, confirm } from '@inquirer/prompts';
 import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import * as core from '@bloomreach-buddy/core';
 import {
   BloomreachAccessManagementService,
   BloomreachAssetManagerService,
   BloomreachAuthService,
+  BloomreachDatabase,
   BloomreachCampaignCalendarService,
   BloomreachCampaignSettingsService,
   BloomreachChannelSettingsService,
@@ -40,6 +44,7 @@ import {
   BloomreachTrendsService,
   BloomreachVouchersService,
   BloomreachWeblayersService,
+  TwoPhaseCommitService,
   resolveApiConfig,
   resolveProfilesDir,
   validateCredentials,
@@ -49,6 +54,7 @@ import {
   BLOOMREACH_API_SETTINGS_URL,
 } from '@bloomreach-buddy/core';
 import type {
+  ActionExecutor,
   BloomreachApiConfig,
   CustomerIds,
   DataSelection,
@@ -101,6 +107,55 @@ function tryResolveApiConfig(projectToken?: string): BloomreachApiConfig | undef
   }
 }
 
+const apiConfig = tryResolveApiConfig();
+
+function collectAllExecutors(
+  config?: BloomreachApiConfig,
+): Record<string, ActionExecutor> {
+  const executors: Record<string, ActionExecutor> = {};
+  const factories: Array<() => Record<string, ActionExecutor>> = [
+    () => core.createCustomerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createDashboardActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createScenarioActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createEmailCampaignActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSurveyActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createCampaignCalendarActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createTrendActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createFunnelActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createRetentionActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createFlowActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createGeoAnalysisActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createVoucherActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createAssetManagerActionExecutors() as Record<string, ActionExecutor>,
+    () => core.createTagManagerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createMetricActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createDataManagerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createExportActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createIntegrationActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createInitiativeActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createProjectSettingsActionExecutors() as Record<string, ActionExecutor>,
+    () => core.createCampaignSettingsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSecuritySettingsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createEvaluationSettingsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createWeblayerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createReportActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSegmentationActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSqlReportActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createCatalogActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createImportsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createUseCaseActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createAccessActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createRecommendationActionExecutors() as Record<string, ActionExecutor>,
+    () => core.createChannelSettingsActionExecutors() as Record<string, ActionExecutor>,
+  ];
+
+  for (const factory of factories) {
+    Object.assign(executors, factory());
+  }
+
+  return executors;
+}
+
 const program = new Command();
 
 program
@@ -123,6 +178,75 @@ program
     console.log('-----------------');
     console.log(`Environment: ${result.environment}`);
     console.log(`Connected:   ${result.connected}`);
+  });
+
+const actions = program.command('actions').description('Manage two-phase commit actions');
+
+actions
+  .command('confirm')
+  .description('Confirm and execute a prepared action')
+  .requiredOption('--token <token>', 'Confirmation token from a prepare command')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { token: string; json?: boolean }) => {
+    const dbPath =
+      process.env.BLOOMREACH_BUDDY_DB_PATH ?? join(homedir(), '.bloomreach-buddy', 'state.db');
+    const db = new BloomreachDatabase(dbPath);
+    const allExecutors = collectAllExecutors(apiConfig);
+    const tpc = new TwoPhaseCommitService(db, allExecutors);
+
+    try {
+      const result = await tpc.confirmByToken({ confirmToken: options.token });
+      if (options.json) {
+        printJson(result);
+      } else {
+        console.log(`Action ${result.preparedActionId} confirmed and executed.`);
+        console.log(`Type: ${result.actionType}`);
+        console.log(`Status: ${result.status}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    } finally {
+      db.close();
+    }
+  });
+
+actions
+  .command('list')
+  .description('List prepared actions')
+  .option('--status <status>', 'Filter by status (prepared, executed, failed)')
+  .option('--limit <n>', 'Maximum results', '50')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { status?: string; limit: string; json?: boolean }) => {
+    const dbPath =
+      process.env.BLOOMREACH_BUDDY_DB_PATH ?? join(homedir(), '.bloomreach-buddy', 'state.db');
+    const db = new BloomreachDatabase(dbPath);
+    const tpc = new TwoPhaseCommitService(db, {});
+
+    try {
+      const parsedLimit = Number.parseInt(options.limit, 10);
+      const actionsList = tpc.listPreparedActions({
+        status: options.status,
+        limit: Number.isNaN(parsedLimit) ? 50 : parsedLimit,
+      });
+
+      if (options.json) {
+        printJson(actionsList);
+      } else if (actionsList.length === 0) {
+        console.log('No prepared actions found.');
+      } else {
+        for (const action of actionsList) {
+          console.log(
+            `${action.preparedActionId}  ${action.actionType}  ${action.status}  expires:${new Date(action.expiresAtMs).toISOString()}`,
+          );
+        }
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    } finally {
+      db.close();
+    }
   });
 
 const dashboards = program

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,10 +21,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "better-sqlite3": "12.8.0",
     "playwright-core": "^1.52.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "7.6.13",
     "@types/proper-lockfile": "^4.1.4",
     "tsup": "^8.0.0",
     "vitest": "^4.1.0"

--- a/packages/core/src/__tests__/database.test.ts
+++ b/packages/core/src/__tests__/database.test.ts
@@ -1,0 +1,198 @@
+import type Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  BloomreachDatabase,
+  type InsertPreparedActionInput,
+} from '../db/database.js';
+
+function createPreparedActionInput(
+  overrides: Partial<InsertPreparedActionInput> = {},
+): InsertPreparedActionInput {
+  const id = overrides.id ?? `pa_${Math.random().toString(36).slice(2)}`;
+  const suffix = id.slice(-6);
+  return {
+    id,
+    actionType: overrides.actionType ?? 'test.echo',
+    targetJson: overrides.targetJson ?? JSON.stringify({ id: suffix }),
+    payloadJson: overrides.payloadJson ?? JSON.stringify({ text: `payload-${suffix}` }),
+    previewJson: overrides.previewJson ?? JSON.stringify({ text: `preview-${suffix}` }),
+    payloadHash: overrides.payloadHash ?? `payload-hash-${suffix}`,
+    previewHash: overrides.previewHash ?? `preview-hash-${suffix}`,
+    status: overrides.status ?? 'prepared',
+    confirmTokenHash: overrides.confirmTokenHash ?? `token-hash-${suffix}`,
+    expiresAtMs: overrides.expiresAtMs ?? 1_800_000_000_000,
+    createdAtMs: overrides.createdAtMs ?? 1_700_000_000_000,
+    operatorNote: overrides.operatorNote ?? null,
+  };
+}
+
+function getRawDb(db: BloomreachDatabase): Database.Database {
+  return Reflect.get(db, 'db') as Database.Database;
+}
+
+describe('BloomreachDatabase', () => {
+  let database: BloomreachDatabase | null = null;
+
+  afterEach(() => {
+    database?.close();
+    database = null;
+  });
+
+  it('constructor creates schema', () => {
+    database = new BloomreachDatabase(':memory:');
+    const row = getRawDb(database)
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'prepared_action'")
+      .get() as { name: string } | undefined;
+
+    expect(row).toEqual({ name: 'prepared_action' });
+  });
+
+  it('insertPreparedAction and getPreparedActionById round-trip', () => {
+    database = new BloomreachDatabase(':memory:');
+    const input = createPreparedActionInput();
+
+    database.insertPreparedAction(input);
+    const row = database.getPreparedActionById(input.id);
+
+    expect(row).not.toBeNull();
+    expect(row?.id).toBe(input.id);
+    expect(row?.action_type).toBe(input.actionType);
+    expect(row?.status).toBe('prepared');
+    expect(row?.operator_note).toBeNull();
+  });
+
+  it('getPreparedActionById returns null for unknown ID', () => {
+    database = new BloomreachDatabase(':memory:');
+    expect(database.getPreparedActionById('pa_missing')).toBeNull();
+  });
+
+  it('getPreparedActionByConfirmTokenHash finds correct row', () => {
+    database = new BloomreachDatabase(':memory:');
+    const first = createPreparedActionInput({ confirmTokenHash: 'same-hash', createdAtMs: 10 });
+    const second = createPreparedActionInput({ confirmTokenHash: 'same-hash', createdAtMs: 20 });
+
+    database.insertPreparedAction(first);
+    database.insertPreparedAction(second);
+
+    const row = database.getPreparedActionByConfirmTokenHash('same-hash');
+    expect(row?.id).toBe(second.id);
+  });
+
+  it('getPreparedActionByConfirmTokenHash returns null for unknown hash', () => {
+    database = new BloomreachDatabase(':memory:');
+    expect(database.getPreparedActionByConfirmTokenHash('missing-hash')).toBeNull();
+  });
+
+  it('markPreparedActionExecuted transitions prepared to executed', () => {
+    database = new BloomreachDatabase(':memory:');
+    const input = createPreparedActionInput();
+    database.insertPreparedAction(input);
+
+    const changed = database.markPreparedActionExecuted({
+      id: input.id,
+      confirmedAtMs: 100,
+      executedAtMs: 200,
+      executionResultJson: JSON.stringify({ ok: true }),
+    });
+
+    const row = database.getPreparedActionById(input.id);
+    expect(changed).toBe(true);
+    expect(row?.status).toBe('executed');
+    expect(row?.confirmed_at).toBe(100);
+    expect(row?.executed_at).toBe(200);
+    expect(row?.execution_result_json).toBe(JSON.stringify({ ok: true }));
+  });
+
+  it('markPreparedActionExecuted returns false for non-prepared status', () => {
+    database = new BloomreachDatabase(':memory:');
+    const input = createPreparedActionInput({ status: 'executed' });
+    database.insertPreparedAction(input);
+
+    const changed = database.markPreparedActionExecuted({
+      id: input.id,
+      confirmedAtMs: 100,
+      executedAtMs: 200,
+      executionResultJson: JSON.stringify({ ok: true }),
+    });
+
+    expect(changed).toBe(false);
+  });
+
+  it('markPreparedActionFailed transitions prepared to failed', () => {
+    database = new BloomreachDatabase(':memory:');
+    const input = createPreparedActionInput();
+    database.insertPreparedAction(input);
+
+    const changed = database.markPreparedActionFailed({
+      id: input.id,
+      confirmedAtMs: 150,
+      executedAtMs: 250,
+      errorCode: 'UNKNOWN',
+      errorMessage: 'boom',
+    });
+
+    const row = database.getPreparedActionById(input.id);
+    expect(changed).toBe(true);
+    expect(row?.status).toBe('failed');
+    expect(row?.confirmed_at).toBe(150);
+    expect(row?.executed_at).toBe(250);
+    expect(row?.error_code).toBe('UNKNOWN');
+    expect(row?.error_message).toBe('boom');
+  });
+
+  it('markPreparedActionFailed returns false for non-prepared status', () => {
+    database = new BloomreachDatabase(':memory:');
+    const input = createPreparedActionInput({ status: 'failed' });
+    database.insertPreparedAction(input);
+
+    const changed = database.markPreparedActionFailed({
+      id: input.id,
+      confirmedAtMs: 150,
+      executedAtMs: 250,
+      errorCode: 'UNKNOWN',
+      errorMessage: 'boom',
+    });
+
+    expect(changed).toBe(false);
+  });
+
+  it('listPreparedActions returns all actions', () => {
+    database = new BloomreachDatabase(':memory:');
+    const first = createPreparedActionInput({ id: 'pa_a', createdAtMs: 10 });
+    const second = createPreparedActionInput({ id: 'pa_b', createdAtMs: 20 });
+
+    database.insertPreparedAction(first);
+    database.insertPreparedAction(second);
+
+    const rows = database.listPreparedActions();
+    expect(rows.map((row) => row.id)).toEqual(['pa_b', 'pa_a']);
+  });
+
+  it('listPreparedActions filters by status', () => {
+    database = new BloomreachDatabase(':memory:');
+    database.insertPreparedAction(createPreparedActionInput({ id: 'pa_prepared', status: 'prepared' }));
+    database.insertPreparedAction(createPreparedActionInput({ id: 'pa_failed', status: 'failed' }));
+
+    const rows = database.listPreparedActions({ status: 'failed' });
+    expect(rows.map((row) => row.id)).toEqual(['pa_failed']);
+  });
+
+  it('listPreparedActions respects limit', () => {
+    database = new BloomreachDatabase(':memory:');
+    database.insertPreparedAction(createPreparedActionInput({ id: 'pa_1', createdAtMs: 1 }));
+    database.insertPreparedAction(createPreparedActionInput({ id: 'pa_2', createdAtMs: 2 }));
+    database.insertPreparedAction(createPreparedActionInput({ id: 'pa_3', createdAtMs: 3 }));
+
+    const rows = database.listPreparedActions({ limit: 2 });
+    expect(rows.map((row) => row.id)).toEqual(['pa_3', 'pa_2']);
+  });
+
+  it('close works cleanly', () => {
+    database = new BloomreachDatabase(':memory:');
+    const rawDb = getRawDb(database);
+
+    expect(() => database?.close()).not.toThrow();
+    database = null;
+    expect(() => rawDb.prepare('SELECT 1').get()).toThrow();
+  });
+});

--- a/packages/core/src/__tests__/twoPhaseCommit.test.ts
+++ b/packages/core/src/__tests__/twoPhaseCommit.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import { BloomreachBuddyError } from '../bloomreachApiClient.js';
+import { BloomreachDatabase } from '../db/database.js';
+import {
+  DEFAULT_TOKEN_TTL_MS,
+  type ActionExecutor,
+  generateConfirmToken,
+  generatePreparedActionId,
+  hashConfirmToken,
+  TwoPhaseCommitService,
+} from '../twoPhaseCommit.js';
+
+class TestEchoExecutor implements ActionExecutor {
+  readonly actionType = 'test.echo';
+
+  async execute(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return { echo: payload.text ?? 'default' };
+  }
+}
+
+class TestFailExecutor implements ActionExecutor {
+  readonly actionType = 'test.fail';
+
+  async execute(): Promise<Record<string, unknown>> {
+    throw new BloomreachBuddyError('TARGET_NOT_FOUND', 'simulated failure');
+  }
+}
+
+describe('two-phase commit token utilities', () => {
+  it("generateConfirmToken starts with 'ct_' and length > 20", () => {
+    const token = generateConfirmToken();
+    expect(token.startsWith('ct_')).toBe(true);
+    expect(token.length).toBeGreaterThan(20);
+  });
+
+  it('two calls produce different tokens', () => {
+    expect(generateConfirmToken()).not.toBe(generateConfirmToken());
+  });
+
+  it('hashConfirmToken is deterministic', () => {
+    const token = 'ct_test_token';
+    expect(hashConfirmToken(token)).toBe(hashConfirmToken(token));
+  });
+
+  it('hashConfirmToken produces different hashes for different inputs', () => {
+    expect(hashConfirmToken('ct_a')).not.toBe(hashConfirmToken('ct_b'));
+  });
+
+  it("generatePreparedActionId starts with 'pa_'", () => {
+    expect(generatePreparedActionId().startsWith('pa_')).toBe(true);
+  });
+});
+
+describe('TwoPhaseCommitService.prepare', () => {
+  it('returns a valid PrepareResult and persists hashed token', () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+
+    const before = Date.now();
+    const result = service.prepare({
+      actionType: 'test.echo',
+      target: { id: 't-1' },
+      payload: { text: 'hello' },
+      preview: { action: 'echo' },
+      operatorNote: 'note',
+    });
+    const after = Date.now();
+
+    expect(result.preparedActionId.startsWith('pa_')).toBe(true);
+    expect(result.confirmToken.startsWith('ct_')).toBe(true);
+    expect(result.confirmToken.startsWith('ct_stub_')).toBe(false);
+    expect(result.expiresAtMs).toBeGreaterThanOrEqual(before + DEFAULT_TOKEN_TTL_MS);
+    expect(result.expiresAtMs).toBeLessThanOrEqual(after + DEFAULT_TOKEN_TTL_MS);
+
+    const row = db.getPreparedActionById(result.preparedActionId);
+    expect(row).not.toBeNull();
+    expect(row?.confirm_token_hash).toBe(hashConfirmToken(result.confirmToken));
+    expect(row?.confirm_token_hash).not.toContain(result.confirmToken);
+
+    db.close();
+  });
+});
+
+describe('TwoPhaseCommitService.confirmByToken', () => {
+  it('happy path: prepare then confirm succeeds', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+    const prepared = service.prepare({
+      actionType: 'test.echo',
+      target: { id: '1' },
+      payload: { text: 'hello' },
+      preview: { action: 'echo' },
+    });
+
+    const result = await service.confirmByToken({ confirmToken: prepared.confirmToken });
+
+    expect(result).toEqual({
+      preparedActionId: prepared.preparedActionId,
+      status: 'executed',
+      actionType: 'test.echo',
+      result: { echo: 'hello' },
+    });
+
+    const row = db.getPreparedActionById(prepared.preparedActionId);
+    expect(row?.status).toBe('executed');
+    db.close();
+  });
+
+  it('rejects unknown token with TARGET_NOT_FOUND', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+
+    await expect(service.confirmByToken({ confirmToken: 'ct_unknown' })).rejects.toMatchObject({
+      code: 'TARGET_NOT_FOUND',
+    });
+    db.close();
+  });
+
+  it('rejects expired token with ACTION_PRECONDITION_FAILED', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+    const prepared = service.prepare({
+      actionType: 'test.echo',
+      target: { id: '1' },
+      payload: { text: 'hello' },
+      preview: { action: 'echo' },
+      nowMs: 1_000,
+      expiresInMs: 10,
+    });
+
+    await expect(
+      service.confirmByToken({
+        confirmToken: prepared.confirmToken,
+        nowMs: 1_011,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTION_PRECONDITION_FAILED' });
+    db.close();
+  });
+
+  it('rejects already-executed token with ACTION_PRECONDITION_FAILED', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+    const prepared = service.prepare({
+      actionType: 'test.echo',
+      target: { id: '1' },
+      payload: { text: 'hello' },
+      preview: { action: 'echo' },
+    });
+
+    await service.confirmByToken({ confirmToken: prepared.confirmToken });
+    await expect(service.confirmByToken({ confirmToken: prepared.confirmToken })).rejects.toMatchObject({
+      code: 'ACTION_PRECONDITION_FAILED',
+    });
+    db.close();
+  });
+
+  it('rejects unknown action type with ACTION_PRECONDITION_FAILED', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {});
+    const prepared = service.prepare({
+      actionType: 'test.unknown',
+      target: { id: '1' },
+      payload: { text: 'hello' },
+      preview: { action: 'unknown' },
+    });
+
+    await expect(service.confirmByToken({ confirmToken: prepared.confirmToken })).rejects.toMatchObject({
+      code: 'ACTION_PRECONDITION_FAILED',
+    });
+    db.close();
+  });
+
+  it('records executor failure and re-throws error', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.fail': new TestFailExecutor(),
+    });
+    const prepared = service.prepare({
+      actionType: 'test.fail',
+      target: { id: '1' },
+      payload: { text: 'hello' },
+      preview: { action: 'fail' },
+    });
+
+    await expect(service.confirmByToken({ confirmToken: prepared.confirmToken })).rejects.toThrow(
+      'simulated failure',
+    );
+
+    const row = db.getPreparedActionById(prepared.preparedActionId);
+    expect(row?.status).toBe('failed');
+    expect(row?.error_code).toBe('TARGET_NOT_FOUND');
+    expect(row?.error_message).toBe('simulated failure');
+    db.close();
+  });
+});
+
+describe('TwoPhaseCommitService.registerExecutors', () => {
+  it('dynamically adds executors', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {});
+    service.registerExecutors({ 'test.echo': new TestEchoExecutor() });
+
+    const prepared = service.prepare({
+      actionType: 'test.echo',
+      target: { id: '1' },
+      payload: { text: 'dynamic' },
+      preview: { action: 'echo' },
+    });
+
+    const result = await service.confirmByToken({ confirmToken: prepared.confirmToken });
+    expect(result.result).toEqual({ echo: 'dynamic' });
+    db.close();
+  });
+});
+
+describe('TwoPhaseCommitService.listPreparedActions', () => {
+  it('returns prepared actions', () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+
+    service.prepare({
+      actionType: 'test.echo',
+      target: { id: '1' },
+      payload: { text: 'one' },
+      preview: { label: 'one' },
+      nowMs: 1_000,
+    });
+    service.prepare({
+      actionType: 'test.echo',
+      target: { id: '2' },
+      payload: { text: 'two' },
+      preview: { label: 'two' },
+      nowMs: 2_000,
+    });
+
+    const actions = service.listPreparedActions();
+    expect(actions).toHaveLength(2);
+    expect(actions[0].preview).toEqual({ label: 'two' });
+    expect(actions[1].preview).toEqual({ label: 'one' });
+    db.close();
+  });
+
+  it('filters by status', async () => {
+    const db = new BloomreachDatabase(':memory:');
+    const service = new TwoPhaseCommitService(db, {
+      'test.echo': new TestEchoExecutor(),
+    });
+
+    const prepared = service.prepare({
+      actionType: 'test.echo',
+      target: { id: '1' },
+      payload: { text: 'hello' },
+      preview: { label: 'prepared' },
+    });
+    await service.confirmByToken({ confirmToken: prepared.confirmToken });
+
+    service.prepare({
+      actionType: 'test.echo',
+      target: { id: '2' },
+      payload: { text: 'still prepared' },
+      preview: { label: 'pending' },
+    });
+
+    const preparedRows = service.listPreparedActions({ status: 'prepared' });
+    expect(preparedRows).toHaveLength(1);
+    expect(preparedRows[0].status).toBe('prepared');
+    db.close();
+  });
+});

--- a/packages/core/src/bloomreachApiClient.ts
+++ b/packages/core/src/bloomreachApiClient.ts
@@ -24,7 +24,9 @@ export type BloomreachErrorCode =
   | 'AUTH_REQUIRED'
   | 'CAPTCHA_OR_CHALLENGE'
   | 'SESSION_EXPIRED'
-  | 'PROFILE_LOCKED';
+  | 'PROFILE_LOCKED'
+  | 'ACTION_PRECONDITION_FAILED'
+  | 'TARGET_NOT_FOUND';
 
 /**
  * Base error class for all Bloomreach Buddy errors.

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -1,0 +1,223 @@
+import Database from 'better-sqlite3';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface InsertPreparedActionInput {
+  id: string;
+  actionType: string;
+  targetJson: string;
+  payloadJson: string;
+  previewJson: string;
+  payloadHash: string;
+  previewHash: string;
+  status: string;
+  confirmTokenHash: string;
+  expiresAtMs: number;
+  createdAtMs: number;
+  operatorNote: string | null;
+}
+
+export interface PreparedActionRow {
+  id: string;
+  action_type: string;
+  target_json: string;
+  payload_json: string;
+  preview_json: string;
+  payload_hash: string;
+  preview_hash: string;
+  status: string;
+  confirm_token_hash: string;
+  expires_at: number;
+  created_at: number;
+  confirmed_at: number | null;
+  operator_note: string | null;
+  executed_at: number | null;
+  execution_result_json: string | null;
+  error_code: string | null;
+  error_message: string | null;
+}
+
+export interface MarkExecutedInput {
+  id: string;
+  confirmedAtMs: number;
+  executedAtMs: number;
+  executionResultJson: string;
+}
+
+export interface MarkFailedInput {
+  id: string;
+  confirmedAtMs: number;
+  executedAtMs: number;
+  errorCode: string;
+  errorMessage: string;
+}
+
+export interface ListPreparedActionsOptions {
+  status?: string;
+  limit?: number;
+}
+
+export class BloomreachDatabase {
+  private readonly db: Database.Database;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const directoryPath = dirname(dbPath);
+      if (!existsSync(directoryPath)) {
+        mkdirSync(directoryPath, { recursive: true });
+      }
+    }
+
+    this.db = new Database(dbPath);
+    this.db.pragma('foreign_keys = ON');
+    this.db.pragma('journal_mode = WAL');
+    this.createSchema();
+  }
+
+  private createSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS prepared_action (
+        id                     TEXT PRIMARY KEY,
+        action_type            TEXT NOT NULL,
+        target_json            TEXT NOT NULL,
+        payload_json           TEXT NOT NULL,
+        preview_json           TEXT NOT NULL,
+        payload_hash           TEXT NOT NULL,
+        preview_hash           TEXT NOT NULL,
+        status                 TEXT NOT NULL DEFAULT 'prepared',
+        confirm_token_hash     TEXT NOT NULL,
+        expires_at             INTEGER NOT NULL,
+        created_at             INTEGER NOT NULL,
+        confirmed_at           INTEGER,
+        operator_note          TEXT,
+        executed_at            INTEGER,
+        execution_result_json  TEXT,
+        error_code             TEXT,
+        error_message          TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_pa_status ON prepared_action(status, expires_at);
+      CREATE INDEX IF NOT EXISTS idx_pa_token_hash ON prepared_action(confirm_token_hash);
+    `);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  insertPreparedAction(input: InsertPreparedActionInput): void {
+    this.db
+      .prepare(
+        `
+          INSERT INTO prepared_action (
+            id,
+            action_type,
+            target_json,
+            payload_json,
+            preview_json,
+            payload_hash,
+            preview_hash,
+            status,
+            confirm_token_hash,
+            expires_at,
+            created_at,
+            operator_note
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run(
+        input.id,
+        input.actionType,
+        input.targetJson,
+        input.payloadJson,
+        input.previewJson,
+        input.payloadHash,
+        input.previewHash,
+        input.status,
+        input.confirmTokenHash,
+        input.expiresAtMs,
+        input.createdAtMs,
+        input.operatorNote,
+      );
+  }
+
+  getPreparedActionById(id: string): PreparedActionRow | null {
+    const row = this.db
+      .prepare('SELECT * FROM prepared_action WHERE id = ?')
+      .get(id) as PreparedActionRow | undefined;
+    return row ?? null;
+  }
+
+  getPreparedActionByConfirmTokenHash(hash: string): PreparedActionRow | null {
+    const row = this.db
+      .prepare(
+        'SELECT * FROM prepared_action WHERE confirm_token_hash = ? ORDER BY created_at DESC LIMIT 1',
+      )
+      .get(hash) as PreparedActionRow | undefined;
+    return row ?? null;
+  }
+
+  markPreparedActionExecuted(input: MarkExecutedInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+          UPDATE prepared_action
+          SET
+            status = 'executed',
+            confirmed_at = ?,
+            executed_at = ?,
+            execution_result_json = ?
+          WHERE id = ? AND status = 'prepared'
+        `,
+      )
+      .run(input.confirmedAtMs, input.executedAtMs, input.executionResultJson, input.id);
+    return result.changes === 1;
+  }
+
+  markPreparedActionFailed(input: MarkFailedInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+          UPDATE prepared_action
+          SET
+            status = 'failed',
+            confirmed_at = ?,
+            executed_at = ?,
+            error_code = ?,
+            error_message = ?
+          WHERE id = ? AND status = 'prepared'
+        `,
+      )
+      .run(
+        input.confirmedAtMs,
+        input.executedAtMs,
+        input.errorCode,
+        input.errorMessage,
+        input.id,
+      );
+    return result.changes === 1;
+  }
+
+  listPreparedActions(options?: ListPreparedActionsOptions): PreparedActionRow[] {
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (options?.status !== undefined) {
+      conditions.push('status = ?');
+      params.push(options.status);
+    }
+
+    let sql = 'SELECT * FROM prepared_action';
+    if (conditions.length > 0) {
+      sql += ` WHERE ${conditions.join(' AND ')}`;
+    }
+    sql += ' ORDER BY created_at DESC';
+
+    if (options?.limit !== undefined) {
+      sql += ' LIMIT ?';
+      params.push(options.limit);
+    }
+
+    return this.db.prepare(sql).all(...params) as PreparedActionRow[];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateCredentials } from './bloomreachSetup.js';
 
+export * from "./db/database.js";
+export * from "./twoPhaseCommit.js";
 export * from './bloomreachCampaignCalendar.js';
 export * from './bloomreachCampaignSettings.js';
 export * from './bloomreachCatalogs.js';

--- a/packages/core/src/twoPhaseCommit.ts
+++ b/packages/core/src/twoPhaseCommit.ts
@@ -1,0 +1,204 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import type { BloomreachDatabase, PreparedActionRow } from './db/database.js';
+import { BloomreachBuddyError } from './bloomreachApiClient.js';
+
+export const DEFAULT_TOKEN_TTL_MS = 30 * 60 * 1000;
+
+export function generateConfirmToken(entropyBytes: number = 24): string {
+  return `ct_${randomBytes(entropyBytes).toString('base64url')}`;
+}
+
+export function hashConfirmToken(token: string): string {
+  return createHash('sha256').update(token).digest('base64url');
+}
+
+export function hashJsonPayload(json: string): string {
+  return createHash('sha256').update(json).digest('base64url');
+}
+
+export function generatePreparedActionId(): string {
+  return `pa_${randomUUID().replaceAll('-', '')}`;
+}
+
+export function isTokenExpired(expiresAtMs: number, nowMs: number = Date.now()): boolean {
+  return nowMs > expiresAtMs;
+}
+
+export interface ActionExecutor {
+  readonly actionType: string;
+  execute(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+export interface PrepareInput {
+  actionType: string;
+  target: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  preview: Record<string, unknown>;
+  operatorNote?: string;
+  expiresInMs?: number;
+  nowMs?: number;
+}
+
+export interface PrepareResult {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}
+
+export interface ConfirmByTokenInput {
+  confirmToken: string;
+  nowMs?: number;
+}
+
+export interface ConfirmResult {
+  preparedActionId: string;
+  status: 'executed';
+  actionType: string;
+  result: Record<string, unknown>;
+}
+
+export interface PreparedActionSummary {
+  preparedActionId: string;
+  actionType: string;
+  status: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+  operatorNote: string | null;
+  createdAtMs: number;
+}
+
+export class TwoPhaseCommitService {
+  private executors: Record<string, ActionExecutor>;
+
+  constructor(
+    private readonly db: BloomreachDatabase,
+    executors: Record<string, ActionExecutor> = {},
+  ) {
+    this.executors = { ...executors };
+  }
+
+  registerExecutors(newExecutors: Record<string, ActionExecutor>): void {
+    Object.assign(this.executors, newExecutors);
+  }
+
+  prepare(input: PrepareInput): PrepareResult {
+    const nowMs = input.nowMs ?? Date.now();
+    const expiresInMs = input.expiresInMs ?? DEFAULT_TOKEN_TTL_MS;
+    const preparedActionId = generatePreparedActionId();
+    const confirmToken = generateConfirmToken();
+    const confirmTokenHash = hashConfirmToken(confirmToken);
+    const expiresAtMs = nowMs + expiresInMs;
+
+    const targetJson = JSON.stringify(input.target);
+    const payloadJson = JSON.stringify(input.payload);
+    const previewJson = JSON.stringify(input.preview);
+
+    this.db.insertPreparedAction({
+      id: preparedActionId,
+      actionType: input.actionType,
+      targetJson,
+      payloadJson,
+      previewJson,
+      payloadHash: hashJsonPayload(payloadJson),
+      previewHash: hashJsonPayload(previewJson),
+      status: 'prepared',
+      confirmTokenHash,
+      expiresAtMs,
+      createdAtMs: nowMs,
+      operatorNote: input.operatorNote ?? null,
+    });
+
+    return {
+      preparedActionId,
+      confirmToken,
+      expiresAtMs,
+      preview: input.preview,
+    };
+  }
+
+  async confirmByToken(input: ConfirmByTokenInput): Promise<ConfirmResult> {
+    const nowMs = input.nowMs ?? Date.now();
+    const confirmTokenHash = hashConfirmToken(input.confirmToken);
+    const row = this.db.getPreparedActionByConfirmTokenHash(confirmTokenHash);
+
+    if (!row) {
+      throw new BloomreachBuddyError(
+        'TARGET_NOT_FOUND',
+        'Prepared action not found for the provided confirmation token.',
+      );
+    }
+
+    if (row.status !== 'prepared') {
+      throw new BloomreachBuddyError(
+        'ACTION_PRECONDITION_FAILED',
+        `Prepared action ${row.id} is not pending confirmation (status: ${row.status}).`,
+      );
+    }
+
+    if (isTokenExpired(row.expires_at, nowMs)) {
+      throw new BloomreachBuddyError(
+        'ACTION_PRECONDITION_FAILED',
+        `Confirmation token expired for action ${row.id}.`,
+      );
+    }
+
+    const executor = this.executors[row.action_type];
+    if (!executor) {
+      throw new BloomreachBuddyError(
+        'ACTION_PRECONDITION_FAILED',
+        `No executor registered for action type "${row.action_type}".`,
+      );
+    }
+
+    const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+
+    let executionResult: Record<string, unknown>;
+    try {
+      executionResult = await executor.execute(payload);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorCode = error instanceof BloomreachBuddyError ? error.code : 'UNKNOWN';
+      this.db.markPreparedActionFailed({
+        id: row.id,
+        confirmedAtMs: nowMs,
+        executedAtMs: nowMs,
+        errorCode,
+        errorMessage,
+      });
+      throw error;
+    }
+
+    this.db.markPreparedActionExecuted({
+      id: row.id,
+      confirmedAtMs: nowMs,
+      executedAtMs: nowMs,
+      executionResultJson: JSON.stringify(executionResult),
+    });
+
+    return {
+      preparedActionId: row.id,
+      status: 'executed',
+      actionType: row.action_type,
+      result: executionResult,
+    };
+  }
+
+  getPreparedActionByToken(confirmToken: string): PreparedActionRow | null {
+    const hash = hashConfirmToken(confirmToken);
+    return this.db.getPreparedActionByConfirmTokenHash(hash);
+  }
+
+  listPreparedActions(options?: { status?: string; limit?: number }): PreparedActionSummary[] {
+    const rows = this.db.listPreparedActions(options);
+    return rows.map((row) => ({
+      preparedActionId: row.id,
+      actionType: row.action_type,
+      status: row.status,
+      expiresAtMs: row.expires_at,
+      preview: JSON.parse(row.preview_json) as Record<string, unknown>,
+      operatorNote: row.operator_note,
+      createdAtMs: row.created_at,
+    }));
+  }
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   dts: { compilerOptions: { composite: false } },
   clean: true,
   sourcemap: true,
+  external: ['better-sqlite3'],
 });

--- a/packages/mcp/src/__tests__/toolConstants.test.ts
+++ b/packages/mcp/src/__tests__/toolConstants.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { BLOOMREACH_MCP_TOOL_NAMES } from '../index.js';
 
 describe('tool constants', () => {
-  it('exports 260 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
-    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(260);
+  it('exports 262 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(262);
   });
 
   it('all tool names follow bloomreach.<domain>.<action> dot-notation', () => {
@@ -30,6 +30,14 @@ describe('tool constants', () => {
     expect(BLOOMREACH_MCP_TOOL_NAMES).toContain('bloomreach.dashboards.list');
   });
 
+  it('includes bloomreach.actions.confirm tool', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toContain('bloomreach.actions.confirm');
+  });
+
+  it('includes bloomreach.actions.list tool', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toContain('bloomreach.actions.list');
+  });
+
   it('includes prepare tools with prepare_ in name', () => {
     const prepareTools = BLOOMREACH_MCP_TOOL_NAMES.filter((name) => name.includes('prepare_'));
     expect(prepareTools.length).toBeGreaterThan(0);
@@ -38,9 +46,10 @@ describe('tool constants', () => {
     }
   });
 
-  it('covers all 33 expected service domains', () => {
+  it('covers all 34 expected service domains', () => {
     const domains = new Set(BLOOMREACH_MCP_TOOL_NAMES.map((name) => name.split('.')[1]));
     const expectedDomains = [
+      'actions',
       'access',
       'assets',
       'campaign_settings',

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -3,6 +3,13 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import * as core from '@bloomreach-buddy/core';
+import {
+  BloomreachDatabase,
+  TwoPhaseCommitService,
+  type ActionExecutor,
+} from '@bloomreach-buddy/core';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import * as toolNames from '../index.js';
 import { toToolResult, toErrorResult } from '../toolResults.js';
 import { isPlainObject, validateToolArgValueAgainstSchema } from '../toolSchema.js';
@@ -22,6 +29,58 @@ const apiConfig: core.BloomreachApiConfig | undefined =
         apiSecret: process.env.BLOOMREACH_API_SECRET,
       }
     : undefined;
+
+function collectAllExecutors(
+  config?: core.BloomreachApiConfig,
+): Record<string, ActionExecutor> {
+  const executors: Record<string, ActionExecutor> = {};
+  const factories: Array<() => Record<string, ActionExecutor>> = [
+    () => core.createCustomerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createDashboardActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createScenarioActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createEmailCampaignActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSurveyActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createCampaignCalendarActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createTrendActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createFunnelActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createRetentionActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createFlowActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createGeoAnalysisActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createVoucherActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createAssetManagerActionExecutors() as Record<string, ActionExecutor>,
+    () => core.createTagManagerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createMetricActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createDataManagerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createExportActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createIntegrationActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createInitiativeActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createProjectSettingsActionExecutors() as Record<string, ActionExecutor>,
+    () => core.createCampaignSettingsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSecuritySettingsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createEvaluationSettingsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createWeblayerActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createReportActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSegmentationActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createSqlReportActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createCatalogActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createImportsActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createUseCaseActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createAccessActionExecutors(config) as Record<string, ActionExecutor>,
+    () => core.createRecommendationActionExecutors() as Record<string, ActionExecutor>,
+    () => core.createChannelSettingsActionExecutors() as Record<string, ActionExecutor>,
+  ];
+
+  for (const factory of factories) {
+    Object.assign(executors, factory());
+  }
+
+  return executors;
+}
+
+const dbPath = process.env.BLOOMREACH_BUDDY_DB_PATH ?? join(homedir(), '.bloomreach-buddy', 'state.db');
+const db = new BloomreachDatabase(dbPath);
+const allExecutors = collectAllExecutors(apiConfig);
+const twoPhaseCommit = new TwoPhaseCommitService(db, allExecutors);
 
 interface InputSchemaProperty {
   type: 'string' | 'number' | 'boolean' | 'object' | 'array';
@@ -118,6 +177,44 @@ const tools: ToolRoute[] = [
         loginUrl: {
           type: 'string',
           description: 'Override the login URL (default: https://eu.login.bloomreach.com/)',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: toolNames.BLOOMREACH_ACTIONS_CONFIRM_TOOL,
+    description:
+      'Confirm and execute a previously prepared action using its confirmation token. ' +
+      'The token is returned by any prepare_* tool. Once confirmed, the action is executed ' +
+      'and cannot be confirmed again. Tokens expire after 30 minutes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        confirmToken: {
+          type: 'string',
+          description: 'The confirmation token returned by the prepare_* tool.',
+        },
+      },
+      required: ['confirmToken'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: toolNames.BLOOMREACH_ACTIONS_LIST_TOOL,
+    description:
+      'List prepared actions with optional status filter. ' +
+      'Returns a summary of each action including its ID, type, status, expiry, and preview.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          description: 'Filter by status: "prepared", "executed", or "failed".',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of actions to return (default 50).',
         },
       },
       additionalProperties: false,
@@ -6075,6 +6172,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return toToolResult(result);
     }
 
+    if (name === toolNames.BLOOMREACH_ACTIONS_CONFIRM_TOOL) {
+      const confirmToken = typeof args.confirmToken === 'string' ? args.confirmToken : '';
+      if (!confirmToken) {
+        return toErrorResult(new Error('confirmToken is required.'));
+      }
+      const result = await twoPhaseCommit.confirmByToken({ confirmToken });
+      return toToolResult(result);
+    }
+
+    if (name === toolNames.BLOOMREACH_ACTIONS_LIST_TOOL) {
+      const status = typeof args.status === 'string' ? args.status : undefined;
+      const limit = typeof args.limit === 'number' ? args.limit : undefined;
+      const actions = twoPhaseCommit.listPreparedActions({ status, limit });
+      return toToolResult(actions);
+    }
+
     const route = toolByName.get(name);
     if (!route || !route.serviceClass || !route.methodName) {
       return toErrorResult(new Error(`Unknown tool: ${name}`));
@@ -6102,6 +6215,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const result = await Promise.resolve(
       methodCandidate.call(service, normalizeInput(args, project)),
     );
+
+    if (route.methodName && route.methodName.startsWith('prepare') && result && typeof result === 'object') {
+      const prepareResult = result as Record<string, unknown>;
+      const preview = prepareResult.preview as Record<string, unknown> | undefined;
+      if (preview && typeof preview.action === 'string') {
+        const tpcResult = twoPhaseCommit.prepare({
+          actionType: preview.action,
+          target: preview,
+          payload: preview,
+          preview,
+          operatorNote:
+            typeof preview.operatorNote === 'string' ? preview.operatorNote : undefined,
+        });
+        return toToolResult(tpcResult);
+      }
+    }
+
     return toToolResult(result);
   } catch (error) {
     return toErrorResult(error);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -357,6 +357,8 @@ export const BLOOMREACH_ACCESS_PREPARE_CREATE_API_KEY_TOOL =
   'bloomreach.access.prepare_create_api_key';
 export const BLOOMREACH_ACCESS_PREPARE_DELETE_API_KEY_TOOL =
   'bloomreach.access.prepare_delete_api_key';
+export const BLOOMREACH_ACTIONS_CONFIRM_TOOL = 'bloomreach.actions.confirm';
+export const BLOOMREACH_ACTIONS_LIST_TOOL = 'bloomreach.actions.list';
 
 
 // --- Tracking tools (issue #177) ---
@@ -626,6 +628,8 @@ export const BLOOMREACH_MCP_TOOL_NAMES = [
   BLOOMREACH_TRACKING_TRACK_CUSTOMER_TOOL,
   BLOOMREACH_TRACKING_TRACK_CONSENT_TOOL,
   BLOOMREACH_TRACKING_TRACK_CAMPAIGN_TOOL,
+  BLOOMREACH_ACTIONS_CONFIRM_TOOL,
+  BLOOMREACH_ACTIONS_LIST_TOOL,
 ] as const;
 
 export type BloomreachMcpToolName = (typeof BLOOMREACH_MCP_TOOL_NAMES)[number];

--- a/packages/mcp/src/toolResults.ts
+++ b/packages/mcp/src/toolResults.ts
@@ -39,6 +39,10 @@ export function buildRecoveryHint(error: unknown): string {
       return 'Bloomreach rate limit reached. Wait for the rate-limit window to reset before retrying.';
     case 'API_ERROR':
       return 'Bloomreach API returned an error response. Check input parameters and project permissions, then retry.';
+    case 'ACTION_PRECONDITION_FAILED':
+      return 'Action precondition not met. The confirm token may be expired, already used, or invalid. Prepare a new action and retry.';
+    case 'TARGET_NOT_FOUND':
+      return 'The requested resource was not found. Verify the identifier and retry.';
     case 'NETWORK_ERROR':
       return 'A network error occurred. Verify connectivity to Bloomreach API endpoints and retry.';
     case 'AUTH_REQUIRED':


### PR DESCRIPTION
## Summary

Implements a fully functional two-phase commit system for all write operations, replacing the stub-only `ct_stub_*` tokens with cryptographically secure tokens backed by SQLite persistence.

**Closes #178**

## Changes

### New Files
- **`packages/core/src/db/database.ts`** — SQLite layer (`better-sqlite3`) with `prepared_action` table, indexes, and CRUD methods
- **`packages/core/src/twoPhaseCommit.ts`** — `TwoPhaseCommitService` with `prepare()`, `confirmByToken()`, and `listPreparedActions()`
- **`packages/core/src/__tests__/database.test.ts`** — 13 test cases for database layer
- **`packages/core/src/__tests__/twoPhaseCommit.test.ts`** — 19 test cases for TPC service

### Modified Files
- **`packages/core/package.json`** — Added `better-sqlite3` dependency
- **`packages/core/src/bloomreachApiClient.ts`** — Added `ACTION_PRECONDITION_FAILED` and `TARGET_NOT_FOUND` error codes
- **`packages/core/src/index.ts`** — Barrel exports for new modules
- **`packages/core/tsup.config.ts`** — Externalize `better-sqlite3` native module
- **`packages/mcp/src/index.ts`** — Added `bloomreach.actions.confirm` and `bloomreach.actions.list` tool constants (247 total)
- **`packages/mcp/src/bin/bloomreach-mcp.ts`** — Confirm/list tool handlers + prepare wrapping through TPC
- **`packages/mcp/src/toolResults.ts`** — Recovery hints for new error codes
- **`packages/mcp/src/__tests__/toolConstants.test.ts`** — Updated tool count and domain assertions
- **`packages/cli/src/bin/bloomreach.ts`** — Added `actions confirm` and `actions list` CLI commands

### Architecture

MCP-layer wrapping approach: the 34 existing feature services remain **unchanged**. The MCP handler intercepts `prepare_*` results, pipes them through `TwoPhaseCommitService` for real crypto tokens and SQLite persistence. A new `bloomreach.actions.confirm` tool dispatches to the correct executor.

**Data flow:**
```
prepare_* tool → service validates + previews → TPC persists + generates real token → returns to client
actions.confirm → TPC hashes token → DB lookup → expiry check → executor dispatch → result stored
```

**Token format:** `ct_<base64url(randomBytes(24))>` — stored as SHA-256 hash only
**ID format:** `pa_<uuid>` — globally unique

## Test Results

```
Core:  39 passed, 4655 tests ✅
MCP:    4 passed,   94 tests ✅
Total: 4749 tests passing
Typecheck: clean ✅
Lint: clean ✅
Build: all 3 packages ✅
```
