### PR TITLE
fix #180: use BloomreachBuddyError everywhere with structured codes and recovery hints

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import { input, password, confirm } from '@inquirer/prompts';
 import { readFileSync } from 'node:fs';
+import { BloomreachBuddyError } from "@bloomreach-buddy/core";
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as core from '@bloomreach-buddy/core';
@@ -6321,7 +6322,7 @@ projectSettings
   .action(async (options: { project: string; accepted: string; note?: string; json?: boolean }) => {
     try {
       if (options.accepted !== 'true' && options.accepted !== 'false') {
-        throw new Error('Option --accepted must be "true" or "false".');
+        throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Option --accepted must be "true" or "false".');
       }
 
       const service = new BloomreachProjectSettingsService(options.project);

--- a/packages/core/src/bloomreachAccessManagement.ts
+++ b/packages/core/src/bloomreachAccessManagement.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -113,12 +114,12 @@ const MAX_API_KEY_NAME_LENGTH = 200;
 export function validateEmail(email: string): string {
   const trimmed = email.trim();
   if (trimmed.length === 0) {
-    throw new Error('Email must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email must not be empty.');
   }
 
   const atIndex = trimmed.indexOf('@');
   if (atIndex <= 0 || atIndex === trimmed.length - 1) {
-    throw new Error('Email must contain "@" with text on both sides.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email must contain "@" with text on both sides.');
   }
 
   return trimmed;
@@ -126,9 +127,7 @@ export function validateEmail(email: string): string {
 
 export function validateMemberRole(role: string): TeamMemberRole {
   if (!TEAM_MEMBER_ROLES.includes(role as TeamMemberRole)) {
-    throw new Error(
-      `role must be one of: ${TEAM_MEMBER_ROLES.join(', ')} (got "${role}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `role must be one of: ${TEAM_MEMBER_ROLES.join(', ')} (got "${role}").`);
   }
   return role as TeamMemberRole;
 }
@@ -136,7 +135,7 @@ export function validateMemberRole(role: string): TeamMemberRole {
 export function validateMemberId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Member ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Member ID must not be empty.');
   }
   return trimmed;
 }
@@ -144,12 +143,10 @@ export function validateMemberId(id: string): string {
 export function validateApiKeyName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length === 0) {
-    throw new Error('API key name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'API key name must not be empty.');
   }
   if (trimmed.length > MAX_API_KEY_NAME_LENGTH) {
-    throw new Error(
-      `API key name must not exceed ${MAX_API_KEY_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `API key name must not exceed ${MAX_API_KEY_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -157,7 +154,7 @@ export function validateApiKeyName(name: string): string {
 export function validateApiKeyId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('API key ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'API key ID must not be empty.');
   }
   return trimmed;
 }
@@ -179,9 +176,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -210,10 +207,8 @@ class InviteTeamMemberExecutor implements AccessActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'InviteTeamMemberExecutor: not yet implemented. ' +
-        'Team member invitation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'InviteTeamMemberExecutor: not yet implemented. ' +
+      'Team member invitation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -229,10 +224,8 @@ class UpdateMemberRoleExecutor implements AccessActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateMemberRoleExecutor: not yet implemented. ' +
-        'Member role updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateMemberRoleExecutor: not yet implemented. ' +
+      'Member role updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -248,10 +241,8 @@ class RemoveTeamMemberExecutor implements AccessActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'RemoveTeamMemberExecutor: not yet implemented. ' +
-        'Team member removal is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'RemoveTeamMemberExecutor: not yet implemented. ' +
+      'Team member removal is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -267,10 +258,8 @@ class CreateApiKeyExecutor implements AccessActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateApiKeyExecutor: not yet implemented. ' +
-        'API key creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateApiKeyExecutor: not yet implemented. ' +
+      'API key creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -286,10 +275,8 @@ class DeleteApiKeyExecutor implements AccessActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteApiKeyExecutor: not yet implemented. ' +
-        'API key deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteApiKeyExecutor: not yet implemented. ' +
+      'API key deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -332,10 +319,8 @@ export class BloomreachAccessManagementService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listTeamMembers: not yet implemented. the Bloomreach API does not provide an endpoint for team members. ' +
-        'Team members must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Project Team).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listTeamMembers: not yet implemented. the Bloomreach API does not provide an endpoint for team members. ' +
+      'Team members must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Project Team).', { not_implemented: true });
   }
 
   async listApiKeys(input?: ListApiKeysInput): Promise<BloomreachApiKey[]> {
@@ -343,10 +328,8 @@ export class BloomreachAccessManagementService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listApiKeys: not yet implemented. the Bloomreach API does not provide an endpoint for API keys. ' +
-        'API keys must be managed through the Bloomreach Engagement UI (navigate to Project Settings > API).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listApiKeys: not yet implemented. the Bloomreach API does not provide an endpoint for API keys. ' +
+      'API keys must be managed through the Bloomreach Engagement UI (navigate to Project Settings > API).', { not_implemented: true });
   }
 
   prepareInviteTeamMember(input: InviteTeamMemberInput): PreparedAccessAction {

--- a/packages/core/src/bloomreachApiClient.ts
+++ b/packages/core/src/bloomreachApiClient.ts
@@ -1,4 +1,18 @@
 // ---------------------------------------------------------------------------
+// Re-export error hierarchy from canonical location
+// ---------------------------------------------------------------------------
+
+export {
+  BloomreachBuddyError,
+  BloomreachApiError,
+  toErrorPayload,
+  ERROR_CODES,
+} from './errors.js';
+export type { BloomreachErrorCode, ErrorCode, ErrorPayload } from './errors.js';
+
+import { BloomreachBuddyError, BloomreachApiError } from './errors.js';
+
+// ---------------------------------------------------------------------------
 // Types & config
 // ---------------------------------------------------------------------------
 
@@ -10,53 +24,6 @@ export interface BloomreachApiConfig {
 }
 
 const DEFAULT_BASE_URL = 'https://api.exponea.com';
-
-// ---------------------------------------------------------------------------
-// Error hierarchy
-// ---------------------------------------------------------------------------
-
-export type BloomreachErrorCode =
-  | 'CONFIG_MISSING'
-  | 'TIMEOUT'
-  | 'RATE_LIMITED'
-  | 'API_ERROR'
-  | 'NETWORK_ERROR'
-  | 'AUTH_REQUIRED'
-  | 'CAPTCHA_OR_CHALLENGE'
-  | 'SESSION_EXPIRED'
-  | 'PROFILE_LOCKED'
-  | 'ACTION_PRECONDITION_FAILED'
-  | 'TARGET_NOT_FOUND';
-
-/**
- * Base error class for all Bloomreach Buddy errors.
- * Every error carries a machine-readable `code` for programmatic handling.
- */
-export class BloomreachBuddyError extends Error {
-  readonly code: BloomreachErrorCode;
-
-  constructor(code: BloomreachErrorCode, message: string) {
-    super(message);
-    this.name = 'BloomreachBuddyError';
-    this.code = code;
-  }
-}
-
-/**
- * Thrown on non-2xx API responses. Carries the HTTP status code and the
- * parsed (or raw) response body for inspection.
- */
-export class BloomreachApiError extends BloomreachBuddyError {
-  readonly statusCode: number;
-  readonly responseBody: unknown;
-
-  constructor(message: string, statusCode: number, responseBody: unknown) {
-    super('API_ERROR', message);
-    this.name = 'BloomreachApiError';
-    this.statusCode = statusCode;
-    this.responseBody = responseBody;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Config resolution
@@ -84,18 +51,21 @@ export function resolveApiConfig(
     throw new BloomreachBuddyError(
       'CONFIG_MISSING',
       'Bloomreach project token is required. Set BLOOMREACH_PROJECT_TOKEN or pass --project-token.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN'] },
     );
   }
   if (apiKeyId.trim().length === 0) {
     throw new BloomreachBuddyError(
       'CONFIG_MISSING',
       'Bloomreach API key ID is required. Set BLOOMREACH_API_KEY_ID or pass --api-key-id.',
+      { missing: ['BLOOMREACH_API_KEY_ID'] },
     );
   }
   if (apiSecret.trim().length === 0) {
     throw new BloomreachBuddyError(
       'CONFIG_MISSING',
       'Bloomreach API secret is required. Set BLOOMREACH_API_SECRET or pass --api-secret.',
+      { missing: ['BLOOMREACH_API_SECRET'] },
     );
   }
 

--- a/packages/core/src/bloomreachAssetManager.ts
+++ b/packages/core/src/bloomreachAssetManager.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 
 export const CREATE_EMAIL_TEMPLATE_ACTION_TYPE =
   'asset_manager.create_email_template';
@@ -230,12 +231,10 @@ type CloneableAssetType = (typeof CLONEABLE_ASSET_TYPES)[number];
 export function validateAssetName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_ASSET_NAME_LENGTH) {
-    throw new Error('Asset name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Asset name must not be empty.');
   }
   if (trimmed.length > MAX_ASSET_NAME_LENGTH) {
-    throw new Error(
-      `Asset name must not exceed ${MAX_ASSET_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Asset name must not exceed ${MAX_ASSET_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -243,7 +242,7 @@ export function validateAssetName(name: string): string {
 /** @throws {Error} If `type` is not a recognised asset type. */
 export function validateAssetType(type: string): AssetType {
   if (!ASSET_TYPES.includes(type as AssetType)) {
-    throw new Error(`assetType must be one of: ${ASSET_TYPES.join(', ')} (got "${type}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `assetType must be one of: ${ASSET_TYPES.join(', ')} (got "${type}").`);
   }
   return type as AssetType;
 }
@@ -251,9 +250,7 @@ export function validateAssetType(type: string): AssetType {
 /** @throws {Error} If `status` is not a recognised template status. */
 export function validateTemplateStatus(status: string): TemplateStatus {
   if (!TEMPLATE_STATUSES.includes(status as TemplateStatus)) {
-    throw new Error(
-      `status must be one of: ${TEMPLATE_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${TEMPLATE_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as TemplateStatus;
 }
@@ -261,9 +258,7 @@ export function validateTemplateStatus(status: string): TemplateStatus {
 /** @throws {Error} If `category` is not a recognised file category. */
 export function validateFileCategory(category: string): FileCategory {
   if (!FILE_CATEGORIES.includes(category as FileCategory)) {
-    throw new Error(
-      `category must be one of: ${FILE_CATEGORIES.join(', ')} (got "${category}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `category must be one of: ${FILE_CATEGORIES.join(', ')} (got "${category}").`);
   }
   return category as FileCategory;
 }
@@ -271,9 +266,7 @@ export function validateFileCategory(category: string): FileCategory {
 /** @throws {Error} If `language` is not a recognised snippet language. */
 export function validateSnippetLanguage(language: string): SnippetLanguage {
   if (!SNIPPET_LANGUAGES.includes(language as SnippetLanguage)) {
-    throw new Error(
-      `language must be one of: ${SNIPPET_LANGUAGES.join(', ')} (got "${language}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `language must be one of: ${SNIPPET_LANGUAGES.join(', ')} (got "${language}").`);
   }
   return language as SnippetLanguage;
 }
@@ -281,9 +274,7 @@ export function validateSnippetLanguage(language: string): SnippetLanguage {
 /** @throws {Error} If `type` is not a recognised builder type. */
 export function validateBuilderType(type: string): TemplateBuilderType {
   if (!TEMPLATE_BUILDER_TYPES.includes(type as TemplateBuilderType)) {
-    throw new Error(
-      `builderType must be one of: ${TEMPLATE_BUILDER_TYPES.join(', ')} (got "${type}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `builderType must be one of: ${TEMPLATE_BUILDER_TYPES.join(', ')} (got "${type}").`);
   }
   return type as TemplateBuilderType;
 }
@@ -291,12 +282,10 @@ export function validateBuilderType(type: string): TemplateBuilderType {
 /** @throws {Error} If snippet content is empty or exceeds 100000 characters. */
 export function validateSnippetContent(content: string): string {
   if (content.trim().length === 0) {
-    throw new Error('Snippet content must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Snippet content must not be empty.');
   }
   if (content.length > MAX_SNIPPET_CONTENT_LENGTH) {
-    throw new Error(
-      `Snippet content must not exceed ${MAX_SNIPPET_CONTENT_LENGTH} characters (got ${content.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Snippet content must not exceed ${MAX_SNIPPET_CONTENT_LENGTH} characters (got ${content.length}).`);
   }
   return content;
 }
@@ -305,10 +294,10 @@ export function validateSnippetContent(content: string): string {
 export function validateMimeType(mimeType: string): string {
   const trimmed = mimeType.trim();
   if (trimmed.length === 0) {
-    throw new Error('MIME type must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'MIME type must not be empty.');
   }
   if (!trimmed.includes('/')) {
-    throw new Error('MIME type must include a "/" separator.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'MIME type must include a "/" separator.');
   }
   return trimmed;
 }
@@ -317,7 +306,7 @@ export function validateMimeType(mimeType: string): string {
 export function validateAssetId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Asset ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Asset ID must not be empty.');
   }
   return trimmed;
 }
@@ -325,9 +314,7 @@ export function validateAssetId(id: string): string {
 function validateCloneableAssetType(type: string): CloneableAssetType {
   const assetType = validateAssetType(type);
   if (!CLONEABLE_ASSET_TYPES.includes(assetType as CloneableAssetType)) {
-    throw new Error(
-      `assetType must be one of cloneable types: ${CLONEABLE_ASSET_TYPES.join(', ')} (got "${type}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `assetType must be one of cloneable types: ${CLONEABLE_ASSET_TYPES.join(', ')} (got "${type}").`);
   }
   return assetType as CloneableAssetType;
 }
@@ -369,9 +356,7 @@ class CreateEmailTemplateExecutor implements AssetManagerActionExecutor {
   readonly actionType = CREATE_EMAIL_TEMPLATE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateEmailTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateEmailTemplateExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -379,9 +364,7 @@ class CreateWeblayerTemplateExecutor implements AssetManagerActionExecutor {
   readonly actionType = CREATE_WEBLAYER_TEMPLATE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateWeblayerTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateWeblayerTemplateExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -389,9 +372,7 @@ class CreateBlockExecutor implements AssetManagerActionExecutor {
   readonly actionType = CREATE_BLOCK_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateBlockExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateBlockExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -399,9 +380,7 @@ class CreateCustomRowExecutor implements AssetManagerActionExecutor {
   readonly actionType = CREATE_CUSTOM_ROW_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateCustomRowExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateCustomRowExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -409,9 +388,7 @@ class CreateSnippetExecutor implements AssetManagerActionExecutor {
   readonly actionType = CREATE_SNIPPET_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateSnippetExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateSnippetExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -419,9 +396,7 @@ class EditSnippetExecutor implements AssetManagerActionExecutor {
   readonly actionType = EDIT_SNIPPET_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'EditSnippetExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EditSnippetExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -429,9 +404,7 @@ class UploadFileExecutor implements AssetManagerActionExecutor {
   readonly actionType = UPLOAD_FILE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UploadFileExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UploadFileExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -439,9 +412,7 @@ class DeleteFileExecutor implements AssetManagerActionExecutor {
   readonly actionType = DELETE_FILE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'DeleteFileExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteFileExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -449,9 +420,7 @@ class CloneTemplateExecutor implements AssetManagerActionExecutor {
   readonly actionType = CLONE_TEMPLATE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CloneTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneTemplateExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -459,9 +428,7 @@ class ArchiveTemplateExecutor implements AssetManagerActionExecutor {
   readonly actionType = ARCHIVE_TEMPLATE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ArchiveTemplateExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveTemplateExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -538,9 +505,7 @@ export class BloomreachAssetManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listEmailTemplates: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listEmailTemplates: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -551,9 +516,7 @@ export class BloomreachAssetManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listWeblayerTemplates: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listWeblayerTemplates: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -562,9 +525,7 @@ export class BloomreachAssetManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listBlocks: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listBlocks: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -573,9 +534,7 @@ export class BloomreachAssetManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listCustomRows: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listCustomRows: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -584,9 +543,7 @@ export class BloomreachAssetManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listSnippets: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listSnippets: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -598,9 +555,7 @@ export class BloomreachAssetManagerService {
       }
     }
 
-    throw new Error(
-      'listFiles: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listFiles: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   /** @throws {Error} If input validation fails. */

--- a/packages/core/src/bloomreachAuth.ts
+++ b/packages/core/src/bloomreachAuth.ts
@@ -1,5 +1,5 @@
 import type { BrowserContext, Page } from 'playwright-core';
-import { BloomreachBuddyError } from './bloomreachApiClient.js';
+import { BloomreachBuddyError } from './errors.js';
 import type {
   BloomreachProfileManager,
   PersistentContextOptions,

--- a/packages/core/src/bloomreachCampaignCalendar.ts
+++ b/packages/core/src/bloomreachCampaignCalendar.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const EXPORT_CALENDAR_ACTION_TYPE = 'campaign_calendar.export';
@@ -109,11 +110,11 @@ const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 export function validateDateFormat(date: string): string {
   const trimmed = date.trim();
   if (!ISO_DATE_REGEX.test(trimmed)) {
-    throw new Error(`Date must be in YYYY-MM-DD format (got "${trimmed}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Date must be in YYYY-MM-DD format (got "${trimmed}").`);
   }
   const parsed = new Date(trimmed);
   if (isNaN(parsed.getTime())) {
-    throw new Error(`Date is not a valid calendar date (got "${trimmed}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Date is not a valid calendar date (got "${trimmed}").`);
   }
   return trimmed;
 }
@@ -126,9 +127,7 @@ export function validateCalendarDateRange(startDate: string, endDate: string): C
   const validStart = validateDateFormat(startDate);
   const validEnd = validateDateFormat(endDate);
   if (new Date(validStart) > new Date(validEnd)) {
-    throw new Error(
-      `Start date must not be after end date (start: "${validStart}", end: "${validEnd}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Start date must not be after end date (start: "${validStart}", end: "${validEnd}").`);
   }
   return { startDate: validStart, endDate: validEnd };
 }
@@ -136,9 +135,7 @@ export function validateCalendarDateRange(startDate: string, endDate: string): C
 /** @throws {Error} If `type` is not a recognised campaign type. */
 export function validateCalendarCampaignType(type: string): CampaignCalendarCampaignType {
   if (!CAMPAIGN_CALENDAR_CAMPAIGN_TYPES.includes(type as CampaignCalendarCampaignType)) {
-    throw new Error(
-      `Campaign type must be one of: ${CAMPAIGN_CALENDAR_CAMPAIGN_TYPES.join(', ')} (got "${type}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign type must be one of: ${CAMPAIGN_CALENDAR_CAMPAIGN_TYPES.join(', ')} (got "${type}").`);
   }
   return type as CampaignCalendarCampaignType;
 }
@@ -146,9 +143,7 @@ export function validateCalendarCampaignType(type: string): CampaignCalendarCamp
 /** @throws {Error} If `status` is not a recognised campaign calendar status. */
 export function validateCalendarCampaignStatus(status: string): CampaignCalendarStatus {
   if (!CAMPAIGN_CALENDAR_STATUSES.includes(status as CampaignCalendarStatus)) {
-    throw new Error(
-      `Campaign status must be one of: ${CAMPAIGN_CALENDAR_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign status must be one of: ${CAMPAIGN_CALENDAR_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as CampaignCalendarStatus;
 }
@@ -156,9 +151,7 @@ export function validateCalendarCampaignStatus(status: string): CampaignCalendar
 /** @throws {Error} If `channel` is not a recognised campaign channel. */
 export function validateCalendarChannel(channel: string): CampaignCalendarChannel {
   if (!CAMPAIGN_CALENDAR_CHANNELS.includes(channel as CampaignCalendarChannel)) {
-    throw new Error(
-      `Channel must be one of: ${CAMPAIGN_CALENDAR_CHANNELS.join(', ')} (got "${channel}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Channel must be one of: ${CAMPAIGN_CALENDAR_CHANNELS.join(', ')} (got "${channel}").`);
   }
   return channel as CampaignCalendarChannel;
 }
@@ -166,9 +159,7 @@ export function validateCalendarChannel(channel: string): CampaignCalendarChanne
 /** @throws {Error} If `format` is not a recognised export format. */
 export function validateExportFormat(format: string): CampaignCalendarExportFormat {
   if (!CAMPAIGN_CALENDAR_EXPORT_FORMATS.includes(format as CampaignCalendarExportFormat)) {
-    throw new Error(
-      `Export format must be one of: ${CAMPAIGN_CALENDAR_EXPORT_FORMATS.join(', ')} (got "${format}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export format must be one of: ${CAMPAIGN_CALENDAR_EXPORT_FORMATS.join(', ')} (got "${format}").`);
   }
   return format as CampaignCalendarExportFormat;
 }
@@ -182,9 +173,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -211,10 +202,8 @@ class ExportCalendarExecutor implements CampaignCalendarActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ExportCalendarExecutor: not yet implemented. ' +
-        'Calendar export is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ExportCalendarExecutor: not yet implemented. ' +
+      'Calendar export is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -263,10 +252,8 @@ export class BloomreachCampaignCalendarService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'viewCampaignCalendar: the Bloomreach API does not provide a calendar view endpoint. ' +
-        'Campaign calendar is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewCampaignCalendar: the Bloomreach API does not provide a calendar view endpoint. ' +
+      'Campaign calendar is only available through the Bloomreach Engagement UI.');
   }
 
   async filterCampaignCalendar(
@@ -294,10 +281,8 @@ export class BloomreachCampaignCalendarService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'filterCampaignCalendar: the Bloomreach API does not provide a calendar filter endpoint. ' +
-        'Campaign calendar is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'filterCampaignCalendar: the Bloomreach API does not provide a calendar filter endpoint. ' +
+      'Campaign calendar is only available through the Bloomreach Engagement UI.');
   }
 
   prepareExportCalendar(input: ExportCalendarInput): PreparedCalendarAction {

--- a/packages/core/src/bloomreachCampaignSettings.ts
+++ b/packages/core/src/bloomreachCampaignSettings.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -450,12 +451,10 @@ const MAX_PAGE_VARIABLE_VALUE_LENGTH = 5000;
 export function validateTimezoneName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_TIMEZONE_NAME_LENGTH) {
-    throw new Error('Timezone name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Timezone name must not be empty.');
   }
   if (trimmed.length > MAX_TIMEZONE_NAME_LENGTH) {
-    throw new Error(
-      `Timezone name must not exceed ${MAX_TIMEZONE_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Timezone name must not exceed ${MAX_TIMEZONE_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -463,7 +462,7 @@ export function validateTimezoneName(name: string): string {
 export function validateTimezoneId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Timezone ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Timezone ID must not be empty.');
   }
   return trimmed;
 }
@@ -471,12 +470,10 @@ export function validateTimezoneId(id: string): string {
 export function validateLanguageCode(code: string): string {
   const trimmed = code.trim();
   if (trimmed.length < MIN_LANGUAGE_CODE_LENGTH) {
-    throw new Error('Language code must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Language code must not be empty.');
   }
   if (trimmed.length > MAX_LANGUAGE_CODE_LENGTH) {
-    throw new Error(
-      `Language code must not exceed ${MAX_LANGUAGE_CODE_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Language code must not exceed ${MAX_LANGUAGE_CODE_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -484,12 +481,10 @@ export function validateLanguageCode(code: string): string {
 export function validateLanguageName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_LANGUAGE_NAME_LENGTH) {
-    throw new Error('Language name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Language name must not be empty.');
   }
   if (trimmed.length > MAX_LANGUAGE_NAME_LENGTH) {
-    throw new Error(
-      `Language name must not exceed ${MAX_LANGUAGE_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Language name must not exceed ${MAX_LANGUAGE_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -497,12 +492,10 @@ export function validateLanguageName(name: string): string {
 export function validateFontName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_FONT_NAME_LENGTH) {
-    throw new Error('Font name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font name must not be empty.');
   }
   if (trimmed.length > MAX_FONT_NAME_LENGTH) {
-    throw new Error(
-      `Font name must not exceed ${MAX_FONT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Font name must not exceed ${MAX_FONT_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -510,7 +503,7 @@ export function validateFontName(name: string): string {
 export function validateFontId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Font ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font ID must not be empty.');
   }
   return trimmed;
 }
@@ -518,12 +511,10 @@ export function validateFontId(id: string): string {
 export function validatePolicyName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_POLICY_NAME_LENGTH) {
-    throw new Error('Policy name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Policy name must not be empty.');
   }
   if (trimmed.length > MAX_POLICY_NAME_LENGTH) {
-    throw new Error(
-      `Policy name must not exceed ${MAX_POLICY_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Policy name must not exceed ${MAX_POLICY_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -531,7 +522,7 @@ export function validatePolicyName(name: string): string {
 export function validatePolicyId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Policy ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Policy ID must not be empty.');
   }
   return trimmed;
 }
@@ -539,12 +530,10 @@ export function validatePolicyId(id: string): string {
 export function validateConsentCategory(category: string): string {
   const trimmed = category.trim();
   if (trimmed.length < MIN_CONSENT_CATEGORY_LENGTH) {
-    throw new Error('Consent category must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Consent category must not be empty.');
   }
   if (trimmed.length > MAX_CONSENT_CATEGORY_LENGTH) {
-    throw new Error(
-      `Consent category must not exceed ${MAX_CONSENT_CATEGORY_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Consent category must not exceed ${MAX_CONSENT_CATEGORY_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -552,7 +541,7 @@ export function validateConsentCategory(category: string): string {
 export function validateConsentId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Consent ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Consent ID must not be empty.');
   }
   return trimmed;
 }
@@ -560,12 +549,10 @@ export function validateConsentId(id: string): string {
 export function validateUrlListName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_URL_LIST_NAME_LENGTH) {
-    throw new Error('URL list name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list name must not be empty.');
   }
   if (trimmed.length > MAX_URL_LIST_NAME_LENGTH) {
-    throw new Error(
-      `URL list name must not exceed ${MAX_URL_LIST_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `URL list name must not exceed ${MAX_URL_LIST_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -573,7 +560,7 @@ export function validateUrlListName(name: string): string {
 export function validateUrlListId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('URL list ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list ID must not be empty.');
   }
   return trimmed;
 }
@@ -581,12 +568,10 @@ export function validateUrlListId(id: string): string {
 export function validatePageVariableName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_PAGE_VARIABLE_NAME_LENGTH) {
-    throw new Error('Page variable name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page variable name must not be empty.');
   }
   if (trimmed.length > MAX_PAGE_VARIABLE_NAME_LENGTH) {
-    throw new Error(
-      `Page variable name must not exceed ${MAX_PAGE_VARIABLE_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Page variable name must not exceed ${MAX_PAGE_VARIABLE_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -594,7 +579,7 @@ export function validatePageVariableName(name: string): string {
 export function validatePageVariableId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Page variable ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page variable ID must not be empty.');
   }
   return trimmed;
 }
@@ -602,9 +587,7 @@ export function validatePageVariableId(id: string): string {
 export function validatePageVariableValue(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length > MAX_PAGE_VARIABLE_VALUE_LENGTH) {
-    throw new Error(
-      `Page variable value must not exceed ${MAX_PAGE_VARIABLE_VALUE_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Page variable value must not exceed ${MAX_PAGE_VARIABLE_VALUE_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -654,9 +637,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -683,10 +666,8 @@ class UpdateCampaignDefaultsExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateCampaignDefaultsExecutor: not yet implemented. ' +
-        'Campaign defaults updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateCampaignDefaultsExecutor: not yet implemented. ' +
+      'Campaign defaults updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -700,10 +681,8 @@ class CreateTimezoneExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateTimezoneExecutor: not yet implemented. ' +
-        'Timezone creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateTimezoneExecutor: not yet implemented. ' +
+      'Timezone creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -717,10 +696,8 @@ class UpdateTimezoneExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateTimezoneExecutor: not yet implemented. ' +
-        'Timezone updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateTimezoneExecutor: not yet implemented. ' +
+      'Timezone updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -734,10 +711,8 @@ class DeleteTimezoneExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteTimezoneExecutor: not yet implemented. ' +
-        'Timezone deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteTimezoneExecutor: not yet implemented. ' +
+      'Timezone deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -751,10 +726,8 @@ class CreateLanguageExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateLanguageExecutor: not yet implemented. ' +
-        'Language creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateLanguageExecutor: not yet implemented. ' +
+      'Language creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -768,10 +741,8 @@ class UpdateLanguageExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateLanguageExecutor: not yet implemented. ' +
-        'Language updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateLanguageExecutor: not yet implemented. ' +
+      'Language updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -785,10 +756,8 @@ class DeleteLanguageExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteLanguageExecutor: not yet implemented. ' +
-        'Language deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteLanguageExecutor: not yet implemented. ' +
+      'Language deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -802,10 +771,8 @@ class CreateFontExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateFontExecutor: not yet implemented. ' +
-        'Font creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateFontExecutor: not yet implemented. ' +
+      'Font creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -819,10 +786,8 @@ class UpdateFontExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateFontExecutor: not yet implemented. ' +
-        'Font updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateFontExecutor: not yet implemented. ' +
+      'Font updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -836,10 +801,8 @@ class DeleteFontExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteFontExecutor: not yet implemented. ' +
-        'Font deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteFontExecutor: not yet implemented. ' +
+      'Font deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -853,10 +816,8 @@ class CreateThroughputPolicyExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateThroughputPolicyExecutor: not yet implemented. ' +
-        'Throughput policy creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateThroughputPolicyExecutor: not yet implemented. ' +
+      'Throughput policy creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -870,10 +831,8 @@ class UpdateThroughputPolicyExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateThroughputPolicyExecutor: not yet implemented. ' +
-        'Throughput policy updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateThroughputPolicyExecutor: not yet implemented. ' +
+      'Throughput policy updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -887,10 +846,8 @@ class DeleteThroughputPolicyExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteThroughputPolicyExecutor: not yet implemented. ' +
-        'Throughput policy deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteThroughputPolicyExecutor: not yet implemented. ' +
+      'Throughput policy deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -904,10 +861,8 @@ class CreateFrequencyPolicyExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateFrequencyPolicyExecutor: not yet implemented. ' +
-        'Frequency policy creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateFrequencyPolicyExecutor: not yet implemented. ' +
+      'Frequency policy creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -921,10 +876,8 @@ class UpdateFrequencyPolicyExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateFrequencyPolicyExecutor: not yet implemented. ' +
-        'Frequency policy updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateFrequencyPolicyExecutor: not yet implemented. ' +
+      'Frequency policy updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -938,10 +891,8 @@ class DeleteFrequencyPolicyExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteFrequencyPolicyExecutor: not yet implemented. ' +
-        'Frequency policy deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteFrequencyPolicyExecutor: not yet implemented. ' +
+      'Frequency policy deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -955,10 +906,8 @@ class CreateConsentExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateConsentExecutor: not yet implemented. ' +
-        'Consent creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateConsentExecutor: not yet implemented. ' +
+      'Consent creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -972,10 +921,8 @@ class UpdateConsentExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateConsentExecutor: not yet implemented. ' +
-        'Consent updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateConsentExecutor: not yet implemented. ' +
+      'Consent updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -989,10 +936,8 @@ class DeleteConsentExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteConsentExecutor: not yet implemented. ' +
-        'Consent deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteConsentExecutor: not yet implemented. ' +
+      'Consent deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1006,10 +951,8 @@ class CreateUrlListExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateUrlListExecutor: not yet implemented. ' +
-        'URL list creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateUrlListExecutor: not yet implemented. ' +
+      'URL list creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1023,10 +966,8 @@ class UpdateUrlListExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateUrlListExecutor: not yet implemented. ' +
-        'URL list updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateUrlListExecutor: not yet implemented. ' +
+      'URL list updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1040,10 +981,8 @@ class DeleteUrlListExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteUrlListExecutor: not yet implemented. ' +
-        'URL list deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteUrlListExecutor: not yet implemented. ' +
+      'URL list deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1057,10 +996,8 @@ class CreatePageVariableExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreatePageVariableExecutor: not yet implemented. ' +
-        'Page variable creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreatePageVariableExecutor: not yet implemented. ' +
+      'Page variable creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1074,10 +1011,8 @@ class UpdatePageVariableExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdatePageVariableExecutor: not yet implemented. ' +
-        'Page variable updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdatePageVariableExecutor: not yet implemented. ' +
+      'Page variable updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1091,10 +1026,8 @@ class DeletePageVariableExecutor implements CampaignSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeletePageVariableExecutor: not yet implemented. ' +
-        'Page variable deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeletePageVariableExecutor: not yet implemented. ' +
+      'Page variable deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -1204,10 +1137,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewCampaignDefaults: not yet implemented. the Bloomreach API does not provide an endpoint for campaign defaults. ' +
-        'Campaign defaults must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Campaigns).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewCampaignDefaults: not yet implemented. the Bloomreach API does not provide an endpoint for campaign defaults. ' +
+      'Campaign defaults must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Campaigns).', { not_implemented: true });
   }
 
   async listTimezones(input?: ListTimezonesInput): Promise<BloomreachTimezone[]> {
@@ -1215,10 +1146,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listTimezones: not yet implemented. the Bloomreach API does not provide an endpoint for timezones. ' +
-        'Timezones must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Timezones).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listTimezones: not yet implemented. the Bloomreach API does not provide an endpoint for timezones. ' +
+      'Timezones must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Timezones).', { not_implemented: true });
   }
 
   async listLanguages(input?: ListLanguagesInput): Promise<BloomreachLanguage[]> {
@@ -1226,10 +1155,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listLanguages: not yet implemented. the Bloomreach API does not provide an endpoint for languages. ' +
-        'Languages must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Languages).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listLanguages: not yet implemented. the Bloomreach API does not provide an endpoint for languages. ' +
+      'Languages must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Languages).', { not_implemented: true });
   }
 
   async listFonts(input?: ListFontsInput): Promise<BloomreachFont[]> {
@@ -1237,10 +1164,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listFonts: not yet implemented. the Bloomreach API does not provide an endpoint for fonts. ' +
-        'Fonts must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Fonts).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listFonts: not yet implemented. the Bloomreach API does not provide an endpoint for fonts. ' +
+      'Fonts must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Fonts).', { not_implemented: true });
   }
 
   async listThroughputPolicies(
@@ -1250,10 +1175,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listThroughputPolicies: not yet implemented. the Bloomreach API does not provide an endpoint for throughput policies. ' +
-        'Throughput policies must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Throughput Policy).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listThroughputPolicies: not yet implemented. the Bloomreach API does not provide an endpoint for throughput policies. ' +
+      'Throughput policies must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Throughput Policy).', { not_implemented: true });
   }
 
   async listFrequencyPolicies(
@@ -1263,10 +1186,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listFrequencyPolicies: not yet implemented. the Bloomreach API does not provide an endpoint for frequency policies. ' +
-        'Frequency policies must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Campaign Frequency Policies).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listFrequencyPolicies: not yet implemented. the Bloomreach API does not provide an endpoint for frequency policies. ' +
+      'Frequency policies must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Campaign Frequency Policies).', { not_implemented: true });
   }
 
   async listConsents(input?: ListConsentsInput): Promise<BloomreachConsent[]> {
@@ -1274,10 +1195,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listConsents: not yet implemented. the Bloomreach API does not provide an endpoint for consents. ' +
-        'Consents must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Consents).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listConsents: not yet implemented. the Bloomreach API does not provide an endpoint for consents. ' +
+      'Consents must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Consents).', { not_implemented: true });
   }
 
   async listUrlLists(input?: ListUrlListsInput): Promise<BloomreachUrlList[]> {
@@ -1285,10 +1204,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listUrlLists: not yet implemented. the Bloomreach API does not provide an endpoint for URL lists. ' +
-        'URL lists must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Global URL Lists).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listUrlLists: not yet implemented. the Bloomreach API does not provide an endpoint for URL lists. ' +
+      'URL lists must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Global URL Lists).', { not_implemented: true });
   }
 
   async listPageVariables(input?: ListPageVariablesInput): Promise<BloomreachPageVariable[]> {
@@ -1296,10 +1213,8 @@ export class BloomreachCampaignSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listPageVariables: not yet implemented. the Bloomreach API does not provide an endpoint for page variables. ' +
-        'Page variables must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Page Variables).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listPageVariables: not yet implemented. the Bloomreach API does not provide an endpoint for page variables. ' +
+      'Page variables must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Page Variables).', { not_implemented: true });
   }
 
   prepareUpdateCampaignDefaults(
@@ -1329,7 +1244,7 @@ export class BloomreachCampaignSettingsService {
       defaultUtmMedium === undefined &&
       defaultUtmCampaign === undefined
     ) {
-      throw new Error('At least one campaign default field must be provided for defaults update.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one campaign default field must be provided for defaults update.');
     }
 
     const preview = {
@@ -1379,9 +1294,7 @@ export class BloomreachCampaignSettingsService {
     const name = input.name !== undefined ? validateTimezoneName(input.name) : undefined;
 
     if (name === undefined && input.utcOffset === undefined && input.isDefault === undefined) {
-      throw new Error(
-        'At least one of name, utcOffset, or isDefault must be provided for timezone update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of name, utcOffset, or isDefault must be provided for timezone update.');
     }
 
     const preview = {
@@ -1450,9 +1363,7 @@ export class BloomreachCampaignSettingsService {
     const name = input.name !== undefined ? validateLanguageName(input.name) : undefined;
 
     if (code === undefined && name === undefined && input.isDefault === undefined) {
-      throw new Error(
-        'At least one of code, name, or isDefault must be provided for language update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of code, name, or isDefault must be provided for language update.');
     }
 
     const preview = {
@@ -1497,7 +1408,7 @@ export class BloomreachCampaignSettingsService {
     const name = validateFontName(input.name);
     const type = input.type.trim();
     if (type.length === 0) {
-      throw new Error('Font type must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font type must not be empty.');
     }
 
     const preview = {
@@ -1524,11 +1435,11 @@ export class BloomreachCampaignSettingsService {
     const type = input.type !== undefined ? input.type.trim() : undefined;
 
     if (type !== undefined && type.length === 0) {
-      throw new Error('Font type must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font type must not be empty.');
     }
 
     if (name === undefined && type === undefined && input.fileUrl === undefined) {
-      throw new Error('At least one of name, type, or fileUrl must be provided for font update.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of name, type, or fileUrl must be provided for font update.');
     }
 
     const preview = {
@@ -1607,9 +1518,7 @@ export class BloomreachCampaignSettingsService {
       input.periodSeconds === undefined &&
       input.description === undefined
     ) {
-      throw new Error(
-        'At least one modifiable field must be provided for throughput policy update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one modifiable field must be provided for throughput policy update.');
     }
 
     const preview = {
@@ -1690,9 +1599,7 @@ export class BloomreachCampaignSettingsService {
       input.channels === undefined &&
       input.description === undefined
     ) {
-      throw new Error(
-        'At least one modifiable field must be provided for frequency policy update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one modifiable field must be provided for frequency policy update.');
     }
 
     const preview = {
@@ -1769,9 +1676,7 @@ export class BloomreachCampaignSettingsService {
       input.consentType === undefined &&
       input.legitimateInterest === undefined
     ) {
-      throw new Error(
-        'At least one of category, description, consentType, or legitimateInterest must be provided for consent update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of category, description, consentType, or legitimateInterest must be provided for consent update.');
     }
 
     const preview = {
@@ -1817,7 +1722,7 @@ export class BloomreachCampaignSettingsService {
     const name = validateUrlListName(input.name);
     const listType = input.listType.trim();
     if (listType.length === 0) {
-      throw new Error('URL list type must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list type must not be empty.');
     }
 
     const preview = {
@@ -1845,7 +1750,7 @@ export class BloomreachCampaignSettingsService {
     const listType = input.listType !== undefined ? input.listType.trim() : undefined;
 
     if (listType !== undefined && listType.length === 0) {
-      throw new Error('URL list type must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list type must not be empty.');
     }
 
     if (
@@ -1854,9 +1759,7 @@ export class BloomreachCampaignSettingsService {
       input.urls === undefined &&
       input.description === undefined
     ) {
-      throw new Error(
-        'At least one of name, listType, urls, or description must be provided for URL list update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of name, listType, urls, or description must be provided for URL list update.');
     }
 
     const preview = {
@@ -1926,9 +1829,7 @@ export class BloomreachCampaignSettingsService {
     const value = input.value !== undefined ? validatePageVariableValue(input.value) : undefined;
 
     if (name === undefined && value === undefined && input.description === undefined) {
-      throw new Error(
-        'At least one of name, value, or description must be provided for page variable update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of name, value, or description must be provided for page variable update.');
     }
 
     const preview = {

--- a/packages/core/src/bloomreachCatalogs.ts
+++ b/packages/core/src/bloomreachCatalogs.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -98,12 +99,10 @@ const MIN_CATALOG_NAME_LENGTH = 1;
 export function validateCatalogName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_CATALOG_NAME_LENGTH) {
-    throw new Error('Catalog name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog name must not be empty.');
   }
   if (trimmed.length > MAX_CATALOG_NAME_LENGTH) {
-    throw new Error(
-      `Catalog name must not exceed ${MAX_CATALOG_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Catalog name must not exceed ${MAX_CATALOG_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -111,7 +110,7 @@ export function validateCatalogName(name: string): string {
 export function validateCatalogId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Catalog ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog ID must not be empty.');
   }
   return trimmed;
 }
@@ -119,20 +118,18 @@ export function validateCatalogId(id: string): string {
 export function validateCatalogSchema(schema: Record<string, string>): Record<string, string> {
   const entries = Object.entries(schema);
   if (entries.length === 0) {
-    throw new Error('Catalog schema must include at least one field.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog schema must include at least one field.');
   }
 
   const normalizedSchema: Record<string, string> = {};
   for (const [fieldName, fieldType] of entries) {
     const normalizedFieldName = fieldName.trim();
     if (normalizedFieldName.length === 0) {
-      throw new Error('Catalog schema field names must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog schema field names must not be empty.');
     }
     if (!VALID_CATALOG_FIELD_TYPES.has(fieldType)) {
-      throw new Error(
-        `Invalid catalog field type "${fieldType}" for field "${normalizedFieldName}". ` +
-          `Valid types: ${[...VALID_CATALOG_FIELD_TYPES].join(', ')}.`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid catalog field type "${fieldType}" for field "${normalizedFieldName}". ` +
+        `Valid types: ${[...VALID_CATALOG_FIELD_TYPES].join(', ')}.`);
     }
     normalizedSchema[normalizedFieldName] = fieldType;
   }
@@ -142,7 +139,7 @@ export function validateCatalogSchema(schema: Record<string, string>): Record<st
 
 export function validateCatalogItems(items: Record<string, unknown>[]): Record<string, unknown>[] {
   if (items.length === 0) {
-    throw new Error('Catalog items must include at least one item.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog items must include at least one item.');
   }
   return items;
 }
@@ -151,13 +148,13 @@ export function validateCatalogItemUpdates(
   items: { id: string; properties: Record<string, unknown> }[],
 ): { id: string; properties: Record<string, unknown> }[] {
   if (items.length === 0) {
-    throw new Error('Catalog item updates must include at least one item.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog item updates must include at least one item.');
   }
 
   return items.map((item) => {
     const id = item.id.trim();
     if (id.length === 0) {
-      throw new Error('Catalog item ID must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog item ID must not be empty.');
     }
     return {
       id,
@@ -180,9 +177,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -335,12 +332,12 @@ export class BloomreachCatalogsService {
     validateCatalogId(input.catalogId);
     if (input.page !== undefined) {
       if (!Number.isInteger(input.page) || input.page <= 0) {
-        throw new Error(`page must be a positive integer (got ${input.page}).`);
+        throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `page must be a positive integer (got ${input.page}).`);
       }
     }
     if (input.pageSize !== undefined) {
       if (!Number.isInteger(input.pageSize) || input.pageSize <= 0) {
-        throw new Error(`pageSize must be a positive integer (got ${input.pageSize}).`);
+        throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `pageSize must be a positive integer (got ${input.pageSize}).`);
       }
     }
 

--- a/packages/core/src/bloomreachChannelSettings.ts
+++ b/packages/core/src/bloomreachChannelSettings.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Action type constants
@@ -157,12 +158,10 @@ const MAX_SENDER_NUMBER_LENGTH = 30;
 export function validateDomain(domain: string): string {
   const trimmed = domain.trim();
   if (trimmed.length === 0) {
-    throw new Error('Domain must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Domain must not be empty.');
   }
   if (trimmed.length > MAX_DOMAIN_LENGTH) {
-    throw new Error(
-      `Domain must not exceed ${MAX_DOMAIN_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Domain must not exceed ${MAX_DOMAIN_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -170,12 +169,10 @@ export function validateDomain(domain: string): string {
 export function validateProviderName(provider: string): string {
   const trimmed = provider.trim();
   if (trimmed.length === 0) {
-    throw new Error('Provider name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Provider name must not be empty.');
   }
   if (trimmed.length > MAX_PROVIDER_NAME_LENGTH) {
-    throw new Error(
-      `Provider name must not exceed ${MAX_PROVIDER_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Provider name must not exceed ${MAX_PROVIDER_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -183,12 +180,10 @@ export function validateProviderName(provider: string): string {
 export function validateSenderNumber(number: string): string {
   const trimmed = number.trim();
   if (trimmed.length === 0) {
-    throw new Error('Sender number must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Sender number must not be empty.');
   }
   if (trimmed.length > MAX_SENDER_NUMBER_LENGTH) {
-    throw new Error(
-      `Sender number must not exceed ${MAX_SENDER_NUMBER_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Sender number must not exceed ${MAX_SENDER_NUMBER_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -196,7 +191,7 @@ export function validateSenderNumber(number: string): string {
 export function validatePageId(pageId: string): string {
   const trimmed = pageId.trim();
   if (trimmed.length === 0) {
-    throw new Error('Page ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page ID must not be empty.');
   }
   return trimmed;
 }
@@ -242,9 +237,7 @@ class ConfigureEmailDomainExecutor implements ChannelSettingsActionExecutor {
   readonly actionType = CONFIGURE_EMAIL_DOMAIN_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigureEmailDomainExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureEmailDomainExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -252,9 +245,7 @@ class ConfigurePushProviderExecutor implements ChannelSettingsActionExecutor {
   readonly actionType = CONFIGURE_PUSH_PROVIDER_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigurePushProviderExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigurePushProviderExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -262,9 +253,7 @@ class ConfigureSmsProviderExecutor implements ChannelSettingsActionExecutor {
   readonly actionType = CONFIGURE_SMS_PROVIDER_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigureSmsProviderExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureSmsProviderExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -272,9 +261,7 @@ class ConfigureMobileMessagingExecutor implements ChannelSettingsActionExecutor 
   readonly actionType = CONFIGURE_MOBILE_MESSAGING_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigureMobileMessagingExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureMobileMessagingExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -282,9 +269,7 @@ class ConfigurePaymentTrackingExecutor implements ChannelSettingsActionExecutor 
   readonly actionType = CONFIGURE_PAYMENT_TRACKING_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigurePaymentTrackingExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigurePaymentTrackingExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -292,9 +277,7 @@ class ConfigureFacebookMessagingExecutor implements ChannelSettingsActionExecuto
   readonly actionType = CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigureFacebookMessagingExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureFacebookMessagingExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -356,47 +339,35 @@ export class BloomreachChannelSettingsService {
   }
 
   async viewEmailSettings(_input?: ViewEmailSettingsInput): Promise<BloomreachEmailSettings> {
-    throw new Error(
-      'viewEmailSettings: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewEmailSettings: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   async viewPushNotificationSettings(
     _input?: ViewPushNotificationSettingsInput,
   ): Promise<BloomreachPushNotificationSettings> {
-    throw new Error(
-      'viewPushNotificationSettings: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewPushNotificationSettings: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   async viewSmsSettings(_input?: ViewSmsSettingsInput): Promise<BloomreachSmsSettings> {
-    throw new Error(
-      'viewSmsSettings: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewSmsSettings: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   async viewMobileMessagingSettings(
     _input?: ViewMobileMessagingSettingsInput,
   ): Promise<BloomreachMobileMessagingSettings> {
-    throw new Error(
-      'viewMobileMessagingSettings: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewMobileMessagingSettings: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   async viewPaymentTrackingSettings(
     _input?: ViewPaymentTrackingSettingsInput,
   ): Promise<BloomreachPaymentTrackingSettings> {
-    throw new Error(
-      'viewPaymentTrackingSettings: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewPaymentTrackingSettings: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   async viewFacebookMessagingSettings(
     _input?: ViewFacebookMessagingSettingsInput,
   ): Promise<BloomreachFacebookMessagingSettings> {
-    throw new Error(
-      'viewFacebookMessagingSettings: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewFacebookMessagingSettings: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   prepareConfigureEmailDomain(input: ConfigureEmailDomainInput): PreparedChannelSettingsAction {

--- a/packages/core/src/bloomreachCustomers.ts
+++ b/packages/core/src/bloomreachCustomers.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import {
   bloomreachApiFetch,
@@ -156,12 +157,10 @@ const MAX_LIST_LIMIT = 1000;
 export function validateCustomerId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Customer ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer ID must not be empty.');
   }
   if (trimmed.length > MAX_CUSTOMER_ID_LENGTH) {
-    throw new Error(
-      `Customer ID must not exceed ${MAX_CUSTOMER_ID_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Customer ID must not exceed ${MAX_CUSTOMER_ID_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -171,7 +170,7 @@ export function validateCustomerIds(ids: CustomerIds): CustomerIds {
     (v) => typeof v === 'string' && v.trim().length > 0,
   );
   if (!hasAtLeastOne) {
-    throw new Error('At least one customer identifier must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one customer identifier must be provided.');
   }
   const validated: CustomerIds = {};
   for (const [key, value] of Object.entries(ids)) {
@@ -185,35 +184,31 @@ export function validateCustomerIds(ids: CustomerIds): CustomerIds {
 export function validateCustomerEventType(eventType: string): string {
   const trimmed = eventType.trim();
   if (trimmed.length === 0) {
-    throw new Error('Event type must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event type must not be empty.');
   }
   if (trimmed.length > 256) {
-    throw new Error(
-      `Event type must not exceed 256 characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event type must not exceed 256 characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateCustomerBatchCommands(commands: CustomerBatchCommand[]): CustomerBatchCommand[] {
   if (!Array.isArray(commands) || commands.length === 0) {
-    throw new Error('At least one batch command must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one batch command must be provided.');
   }
   if (commands.length > 50) {
-    throw new Error(
-      `Batch commands must not exceed 50 (got ${commands.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Batch commands must not exceed 50 (got ${commands.length}).`);
   }
   for (const cmd of commands) {
     if (typeof cmd.name !== 'string' || cmd.name.trim().length === 0) {
-      throw new Error('Each batch command must have a non-empty name.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Each batch command must have a non-empty name.');
     }
     if (
       typeof cmd.data !== 'object' ||
       cmd.data === null ||
       Array.isArray(cmd.data)
     ) {
-      throw new Error('Each batch command must have a non-null data object.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Each batch command must have a non-null data object.');
     }
   }
   return commands;
@@ -222,12 +217,10 @@ export function validateCustomerBatchCommands(commands: CustomerBatchCommand[]):
 export function validateSearchQuery(query: string): string {
   const trimmed = query.trim();
   if (trimmed.length === 0) {
-    throw new Error('Search query must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Search query must not be empty.');
   }
   if (trimmed.length > MAX_SEARCH_QUERY_LENGTH) {
-    throw new Error(
-      `Search query must not exceed ${MAX_SEARCH_QUERY_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Search query must not exceed ${MAX_SEARCH_QUERY_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -237,10 +230,10 @@ export function validateListLimit(limit?: number): number {
     return DEFAULT_LIST_LIMIT;
   }
   if (!Number.isInteger(limit) || limit < 1) {
-    throw new Error('Limit must be a positive integer.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Limit must be a positive integer.');
   }
   if (limit > MAX_LIST_LIMIT) {
-    throw new Error(`Limit must not exceed ${MAX_LIST_LIMIT} (got ${limit}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Limit must not exceed ${MAX_LIST_LIMIT} (got ${limit}).`);
   }
   return limit;
 }
@@ -250,7 +243,7 @@ export function validateListOffset(offset?: number): number {
     return 0;
   }
   if (!Number.isInteger(offset) || offset < 0) {
-    throw new Error('Offset must be a non-negative integer.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Offset must be a non-negative integer.');
   }
   return offset;
 }
@@ -258,7 +251,7 @@ export function validateListOffset(offset?: number): number {
 export function validateIdType(idType?: string): string {
   const trimmed = (idType ?? 'registered').trim();
   if (trimmed.length === 0) {
-    throw new Error('ID type must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ID type must not be empty.');
   }
   return trimmed;
 }
@@ -267,10 +260,10 @@ export function validateProperties(
   properties: Record<string, unknown>,
 ): Record<string, unknown> {
   if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
-    throw new Error('Properties must be a non-null object.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Properties must be a non-null object.');
   }
   if (Object.keys(properties).length === 0) {
-    throw new Error('At least one property must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one property must be provided.');
   }
   return properties;
 }
@@ -289,9 +282,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;

--- a/packages/core/src/bloomreachDashboards.ts
+++ b/packages/core/src/bloomreachDashboards.ts
@@ -1,4 +1,5 @@
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
+import { BloomreachBuddyError } from './errors.js';
 
 export const CREATE_DASHBOARD_ACTION_TYPE = 'dashboards.create_dashboard';
 export const SET_HOME_DASHBOARD_ACTION_TYPE = 'dashboards.set_home_dashboard';
@@ -74,12 +75,10 @@ const MIN_LAYOUT_COLUMNS = 1;
 export function validateDashboardName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_DASHBOARD_NAME_LENGTH) {
-    throw new Error('Dashboard name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard name must not be empty.');
   }
   if (trimmed.length > MAX_DASHBOARD_NAME_LENGTH) {
-    throw new Error(
-      `Dashboard name must not exceed ${MAX_DASHBOARD_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Dashboard name must not exceed ${MAX_DASHBOARD_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -88,7 +87,7 @@ export function validateDashboardName(name: string): string {
 export function validateProject(project: string): string {
   const trimmed = project.trim();
   if (trimmed.length === 0) {
-    throw new Error('Project identifier must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Project identifier must not be empty.');
   }
   return trimmed;
 }
@@ -101,9 +100,7 @@ export function validateLayoutConfig(layout: DashboardLayoutConfig): DashboardLa
       layout.columns < MIN_LAYOUT_COLUMNS ||
       layout.columns > MAX_LAYOUT_COLUMNS
     ) {
-      throw new Error(
-        `Layout columns must be an integer between ${MIN_LAYOUT_COLUMNS} and ${MAX_LAYOUT_COLUMNS} (got ${layout.columns}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Layout columns must be an integer between ${MIN_LAYOUT_COLUMNS} and ${MAX_LAYOUT_COLUMNS} (got ${layout.columns}).`);
     }
   }
   return layout;
@@ -118,9 +115,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -147,10 +144,8 @@ class CreateDashboardExecutor implements DashboardActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateDashboardExecutor: not yet implemented. ' +
-        'Dashboard creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateDashboardExecutor: not yet implemented. ' +
+      'Dashboard creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -164,10 +159,8 @@ class SetHomeDashboardExecutor implements DashboardActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'SetHomeDashboardExecutor: not yet implemented. ' +
-        'Setting the home dashboard is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SetHomeDashboardExecutor: not yet implemented. ' +
+      'Setting the home dashboard is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -181,10 +174,8 @@ class DeleteDashboardExecutor implements DashboardActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteDashboardExecutor: not yet implemented. ' +
-        'Dashboard deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteDashboardExecutor: not yet implemented. ' +
+      'Dashboard deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -219,11 +210,9 @@ export class BloomreachDashboardsService {
   /** @throws {Error} Browser automation not yet available. */
   async listDashboards(_input?: ListDashboardsInput): Promise<BloomreachDashboard[]> {
     void this.apiConfig;
-    throw new Error(
-      'listDashboards: the Bloomreach API does not provide an endpoint for dashboards. ' +
-        'Dashboard data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Dashboards in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listDashboards: the Bloomreach API does not provide an endpoint for dashboards. ' +
+      'Dashboard data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Dashboards in your project).');
   }
 
   /** @throws {Error} If input validation fails. */
@@ -258,7 +247,7 @@ export class BloomreachDashboardsService {
     const project = validateProject(input.project);
     const dashboardId = input.dashboardId.trim();
     if (dashboardId.length === 0) {
-      throw new Error('Dashboard ID must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard ID must not be empty.');
     }
 
     const preview = {
@@ -281,7 +270,7 @@ export class BloomreachDashboardsService {
     const project = validateProject(input.project);
     const dashboardId = input.dashboardId.trim();
     if (dashboardId.length === 0) {
-      throw new Error('Dashboard ID must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard ID must not be empty.');
     }
 
     const preview = {

--- a/packages/core/src/bloomreachDataManager.ts
+++ b/packages/core/src/bloomreachDataManager.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import {
   bloomreachApiFetch,
   buildDataPath,
@@ -220,7 +221,7 @@ const TRANSFORMATION_TYPES = new Set([
 function validateRequiredTrimmed(value: string, fieldName: string): string {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
-    throw new Error(`${fieldName} must not be empty.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not be empty.`);
   }
   return trimmed;
 }
@@ -228,9 +229,7 @@ function validateRequiredTrimmed(value: string, fieldName: string): string {
 function validatePropertyName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Property name');
   if (trimmed.length > MAX_PROPERTY_NAME_LENGTH) {
-    throw new Error(
-      `Property name must not exceed ${MAX_PROPERTY_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Property name must not exceed ${MAX_PROPERTY_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -238,9 +237,7 @@ function validatePropertyName(name: string): string {
 function validateEventName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Event name');
   if (trimmed.length > MAX_EVENT_NAME_LENGTH) {
-    throw new Error(
-      `Event name must not exceed ${MAX_EVENT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event name must not exceed ${MAX_EVENT_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -248,9 +245,7 @@ function validateEventName(name: string): string {
 function validateDefinitionName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Definition name');
   if (trimmed.length > MAX_DEFINITION_NAME_LENGTH) {
-    throw new Error(
-      `Definition name must not exceed ${MAX_DEFINITION_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Definition name must not exceed ${MAX_DEFINITION_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -258,9 +253,7 @@ function validateDefinitionName(name: string): string {
 function validateDescription(description: string): string {
   const trimmed = validateRequiredTrimmed(description, 'Description');
   if (trimmed.length > MAX_DESCRIPTION_LENGTH) {
-    throw new Error(
-      `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -268,9 +261,7 @@ function validateDescription(description: string): string {
 function validatePropertyType(type: string): string {
   const normalized = validateRequiredTrimmed(type, 'Property type').toLowerCase();
   if (!PROPERTY_TYPES.has(normalized)) {
-    throw new Error(
-      `Property type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Property type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -278,9 +269,7 @@ function validatePropertyType(type: string): string {
 function validateEventType(type: string): string {
   const normalized = validateRequiredTrimmed(type, 'Event type').toLowerCase();
   if (!PROPERTY_TYPES.has(normalized)) {
-    throw new Error(
-      `Event type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -288,9 +277,7 @@ function validateEventType(type: string): string {
 function validateFieldType(type: string): string {
   const normalized = validateRequiredTrimmed(type, 'Field type').toLowerCase();
   if (!PROPERTY_TYPES.has(normalized)) {
-    throw new Error(
-      `Field type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Field type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -298,9 +285,7 @@ function validateFieldType(type: string): string {
 function validateSourceType(sourceType: string): string {
   const normalized = validateRequiredTrimmed(sourceType, 'Source type').toLowerCase();
   if (!SOURCE_TYPES.has(normalized)) {
-    throw new Error(
-      `Source type must be one of: ${Array.from(SOURCE_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source type must be one of: ${Array.from(SOURCE_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -308,11 +293,11 @@ function validateSourceType(sourceType: string): string {
 function validateSourceUrl(url: string): string {
   const trimmed = validateRequiredTrimmed(url, 'Source URL');
   if (trimmed.length > MAX_URL_LENGTH) {
-    throw new Error(`Source URL must not exceed ${MAX_URL_LENGTH} characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source URL must not exceed ${MAX_URL_LENGTH} characters (got ${trimmed.length}).`);
   }
 
   if (!/^[a-zA-Z][a-zA-Z\d+.-]*:\/\/.+/.test(trimmed)) {
-    throw new Error('Source URL must be a valid absolute URL.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Source URL must be a valid absolute URL.');
   }
 
   return trimmed;
@@ -321,9 +306,7 @@ function validateSourceUrl(url: string): string {
 function validateSourceName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Source name');
   if (trimmed.length > MAX_SOURCE_NAME_LENGTH) {
-    throw new Error(
-      `Source name must not exceed ${MAX_SOURCE_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source name must not exceed ${MAX_SOURCE_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -331,9 +314,7 @@ function validateSourceName(name: string): string {
 function validateDefinitionId(id: string): string {
   const trimmed = validateRequiredTrimmed(id, 'Definition ID');
   if (trimmed.length > MAX_FIELD_NAME_LENGTH) {
-    throw new Error(
-      `Definition ID must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Definition ID must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -341,9 +322,7 @@ function validateDefinitionId(id: string): string {
 function validateSourceId(id: string): string {
   const trimmed = validateRequiredTrimmed(id, 'Source ID');
   if (trimmed.length > MAX_FIELD_NAME_LENGTH) {
-    throw new Error(
-      `Source ID must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source ID must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -354,16 +333,12 @@ function validateMappingFields(
 ): { sourceField: string; targetField: string } {
   const validatedSourceField = validateRequiredTrimmed(sourceField, 'Source field');
   if (validatedSourceField.length > MAX_FIELD_NAME_LENGTH) {
-    throw new Error(
-      `Source field must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${validatedSourceField.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source field must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${validatedSourceField.length}).`);
   }
 
   const validatedTargetField = validateRequiredTrimmed(targetField, 'Target field');
   if (validatedTargetField.length > MAX_FIELD_NAME_LENGTH) {
-    throw new Error(
-      `Target field must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${validatedTargetField.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Target field must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${validatedTargetField.length}).`);
   }
 
   return {
@@ -375,9 +350,7 @@ function validateMappingFields(
 function validateTransformationType(type: string): string {
   const normalized = validateRequiredTrimmed(type, 'Transformation type').toLowerCase();
   if (!TRANSFORMATION_TYPES.has(normalized)) {
-    throw new Error(
-      `Transformation type must be one of: ${Array.from(TRANSFORMATION_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Transformation type must be one of: ${Array.from(TRANSFORMATION_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -393,7 +366,7 @@ function validateOptionalString(
 
   const trimmed = validateRequiredTrimmed(value, fieldName);
   if (trimmed.length > maxLength) {
-    throw new Error(`${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
   }
 
   return trimmed;
@@ -411,7 +384,7 @@ function validateConfiguration(
     configuration === null ||
     Array.isArray(configuration)
   ) {
-    throw new Error('Configuration must be a non-null object.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Configuration must be a non-null object.');
   }
 
   return configuration;
@@ -436,7 +409,7 @@ function validateEventProperties(
       property.isRequired !== undefined &&
       typeof property.isRequired !== 'boolean'
     ) {
-      throw new Error(`Event property #${index + 1} isRequired must be a boolean.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event property #${index + 1} isRequired must be a boolean.`);
     }
 
     return {
@@ -482,9 +455,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -509,10 +482,8 @@ class AddCustomerPropertyExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'AddCustomerPropertyExecutor: not yet implemented. ' +
-        'Customer property addition is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'AddCustomerPropertyExecutor: not yet implemented. ' +
+      'Customer property addition is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -528,10 +499,8 @@ class EditCustomerPropertyExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EditCustomerPropertyExecutor: not yet implemented. ' +
-        'Customer property editing is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EditCustomerPropertyExecutor: not yet implemented. ' +
+      'Customer property editing is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -547,10 +516,8 @@ class AddEventDefinitionExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'AddEventDefinitionExecutor: not yet implemented. ' +
-        'Event definition creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'AddEventDefinitionExecutor: not yet implemented. ' +
+      'Event definition creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -566,10 +533,8 @@ class AddFieldDefinitionExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'AddFieldDefinitionExecutor: not yet implemented. ' +
-        'Field definition creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'AddFieldDefinitionExecutor: not yet implemented. ' +
+      'Field definition creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -585,10 +550,8 @@ class EditFieldDefinitionExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EditFieldDefinitionExecutor: not yet implemented. ' +
-        'Field definition editing is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EditFieldDefinitionExecutor: not yet implemented. ' +
+      'Field definition editing is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -604,10 +567,8 @@ class ConfigureMappingExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ConfigureMappingExecutor: not yet implemented. ' +
-        'Mapping configuration is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureMappingExecutor: not yet implemented. ' +
+      'Mapping configuration is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -623,10 +584,8 @@ class AddContentSourceExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'AddContentSourceExecutor: not yet implemented. ' +
-        'Content source addition is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'AddContentSourceExecutor: not yet implemented. ' +
+      'Content source addition is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -642,10 +601,8 @@ class EditContentSourceExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EditContentSourceExecutor: not yet implemented. ' +
-        'Content source editing is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EditContentSourceExecutor: not yet implemented. ' +
+      'Content source editing is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -661,10 +618,8 @@ class SaveChangesExecutor implements DataManagerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'SaveChangesExecutor: not yet implemented. ' +
-        'Saving data manager changes is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SaveChangesExecutor: not yet implemented. ' +
+      'Saving data manager changes is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -757,11 +712,9 @@ export class BloomreachDataManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listCustomerProperties: the Bloomreach API does not provide an endpoint for customer properties. ' +
-        'Customer property data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Data Manager in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listCustomerProperties: the Bloomreach API does not provide an endpoint for customer properties. ' +
+      'Customer property data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Data Manager in your project).');
   }
 
   async listEvents(input?: ListEventsInput): Promise<EventDefinition[]> {
@@ -770,11 +723,9 @@ export class BloomreachDataManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listEvents: the Bloomreach API does not provide an endpoint for event definitions. ' +
-        'Event definition data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Data Manager > Events in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listEvents: the Bloomreach API does not provide an endpoint for event definitions. ' +
+      'Event definition data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Data Manager > Events in your project).');
   }
 
   async listFieldDefinitions(
@@ -785,11 +736,9 @@ export class BloomreachDataManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listFieldDefinitions: the Bloomreach API does not provide an endpoint for field definitions. ' +
-        'Field definition data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Data Manager > Definitions in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listFieldDefinitions: the Bloomreach API does not provide an endpoint for field definitions. ' +
+      'Field definition data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Data Manager > Definitions in your project).');
   }
 
   async listMappings(input?: ListMappingsInput): Promise<DataMapping[]> {
@@ -798,11 +747,9 @@ export class BloomreachDataManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listMappings: the Bloomreach API does not provide an endpoint for data mappings. ' +
-        'Data mapping information must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Data Manager > Mapping in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listMappings: the Bloomreach API does not provide an endpoint for data mappings. ' +
+      'Data mapping information must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Data Manager > Mapping in your project).');
   }
 
   async listContentSources(
@@ -813,11 +760,9 @@ export class BloomreachDataManagerService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listContentSources: the Bloomreach API does not provide an endpoint for content sources. ' +
-        'Content source data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Data Manager > Content Sources in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listContentSources: the Bloomreach API does not provide an endpoint for content sources. ' +
+      'Content source data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Data Manager > Content Sources in your project).');
   }
 
   prepareAddCustomerProperty(

--- a/packages/core/src/bloomreachEmailCampaigns.ts
+++ b/packages/core/src/bloomreachEmailCampaigns.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import { bloomreachApiFetch, buildEmailPath } from './bloomreachApiClient.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
@@ -169,12 +170,10 @@ const MAX_AB_TEST_VARIANTS = 10;
 export function validateCampaignName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_CAMPAIGN_NAME_LENGTH) {
-    throw new Error('Campaign name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign name must not be empty.');
   }
   if (trimmed.length > MAX_CAMPAIGN_NAME_LENGTH) {
-    throw new Error(
-      `Campaign name must not exceed ${MAX_CAMPAIGN_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign name must not exceed ${MAX_CAMPAIGN_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -183,12 +182,10 @@ export function validateCampaignName(name: string): string {
 export function validateSubjectLine(subjectLine: string): string {
   const trimmed = subjectLine.trim();
   if (trimmed.length < MIN_SUBJECT_LINE_LENGTH) {
-    throw new Error('Subject line must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Subject line must not be empty.');
   }
   if (trimmed.length > MAX_SUBJECT_LINE_LENGTH) {
-    throw new Error(
-      `Subject line must not exceed ${MAX_SUBJECT_LINE_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Subject line must not exceed ${MAX_SUBJECT_LINE_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -196,9 +193,7 @@ export function validateSubjectLine(subjectLine: string): string {
 /** @throws {Error} If `status` is not a recognised email campaign status. */
 export function validateEmailCampaignStatus(status: string): EmailCampaignStatus {
   if (!EMAIL_CAMPAIGN_STATUSES.includes(status as EmailCampaignStatus)) {
-    throw new Error(
-      `status must be one of: ${EMAIL_CAMPAIGN_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${EMAIL_CAMPAIGN_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as EmailCampaignStatus;
 }
@@ -206,9 +201,7 @@ export function validateEmailCampaignStatus(status: string): EmailCampaignStatus
 /** @throws {Error} If `templateType` is not a recognised template type. */
 export function validateTemplateType(templateType: string): EmailTemplateType {
   if (!EMAIL_TEMPLATE_TYPES.includes(templateType as EmailTemplateType)) {
-    throw new Error(
-      `templateType must be one of: ${EMAIL_TEMPLATE_TYPES.join(', ')} (got "${templateType}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `templateType must be one of: ${EMAIL_TEMPLATE_TYPES.join(', ')} (got "${templateType}").`);
   }
   return templateType as EmailTemplateType;
 }
@@ -216,9 +209,7 @@ export function validateTemplateType(templateType: string): EmailTemplateType {
 /** @throws {Error} If `scheduleType` is not a recognised schedule type. */
 export function validateScheduleType(scheduleType: string): SendScheduleType {
   if (!SEND_SCHEDULE_TYPES.includes(scheduleType as SendScheduleType)) {
-    throw new Error(
-      `schedule type must be one of: ${SEND_SCHEDULE_TYPES.join(', ')} (got "${scheduleType}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `schedule type must be one of: ${SEND_SCHEDULE_TYPES.join(', ')} (got "${scheduleType}").`);
   }
   return scheduleType as SendScheduleType;
 }
@@ -230,15 +221,11 @@ export function validateABTestConfig(config: EmailCampaignABTestConfig): EmailCa
     config.variants < MIN_AB_TEST_VARIANTS ||
     config.variants > MAX_AB_TEST_VARIANTS
   ) {
-    throw new Error(
-      `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${config.variants}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${config.variants}).`);
   }
   if (config.splitPercentage !== undefined) {
     if (config.splitPercentage < 0 || config.splitPercentage > 100) {
-      throw new Error(
-        `A/B test split percentage must be between 0 and 100 (got ${config.splitPercentage}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test split percentage must be between 0 and 100 (got ${config.splitPercentage}).`);
     }
   }
   return config;
@@ -248,7 +235,7 @@ export function validateABTestConfig(config: EmailCampaignABTestConfig): EmailCa
 export function validateCampaignId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Campaign ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign ID must not be empty.');
   }
   return trimmed;
 }
@@ -257,10 +244,10 @@ export function validateCampaignId(id: string): string {
 export function validateSchedule(schedule: EmailCampaignSchedule): EmailCampaignSchedule {
   validateScheduleType(schedule.type);
   if (schedule.type === 'scheduled' && schedule.scheduledAt === undefined) {
-    throw new Error('scheduledAt is required when schedule type is "scheduled".');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'scheduledAt is required when schedule type is "scheduled".');
   }
   if (schedule.type === 'recurring' && schedule.cronExpression === undefined) {
-    throw new Error('cronExpression is required when schedule type is "recurring".');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'cronExpression is required when schedule type is "recurring".');
   }
   return schedule;
 }
@@ -268,7 +255,7 @@ export function validateSchedule(schedule: EmailCampaignSchedule): EmailCampaign
 export function validateEmailIntegrationId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Integration ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Integration ID must not be empty.');
   }
   return trimmed;
 }
@@ -276,10 +263,10 @@ export function validateEmailIntegrationId(id: string): string {
 export function validateEmailAddress(email: string): string {
   const trimmed = email.trim();
   if (trimmed.length === 0) {
-    throw new Error('Email address must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email address must not be empty.');
   }
   if (!trimmed.includes('@')) {
-    throw new Error('Email address must contain an @ symbol.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email address must contain an @ symbol.');
   }
   return trimmed;
 }
@@ -288,9 +275,7 @@ export function validateTransactionalEmailContent(
   content: TransactionalEmailContent,
 ): TransactionalEmailContent {
   if (!content.templateId && !content.html) {
-    throw new Error(
-      'Email content must include either a templateId or raw html.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email content must include either a templateId or raw html.');
   }
   return content;
 }
@@ -304,9 +289,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -327,11 +312,9 @@ class CreateEmailCampaignExecutor implements EmailCampaignActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateEmailCampaignExecutor: not yet implemented. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
-        'For sending individual transactional emails via API, use the sendTransactionalEmail method.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateEmailCampaignExecutor: not yet implemented. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
+      'For sending individual transactional emails via API, use the sendTransactionalEmail method.', { not_implemented: true });
   }
 }
 
@@ -345,11 +328,9 @@ class SendEmailCampaignExecutor implements EmailCampaignActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'SendEmailCampaignExecutor: not yet implemented. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
-        'For sending individual transactional emails via API, use the sendTransactionalEmail method.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SendEmailCampaignExecutor: not yet implemented. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
+      'For sending individual transactional emails via API, use the sendTransactionalEmail method.', { not_implemented: true });
   }
 }
 
@@ -363,11 +344,9 @@ class CloneEmailCampaignExecutor implements EmailCampaignActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneEmailCampaignExecutor: not yet implemented. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
-        'For sending individual transactional emails via API, use the sendTransactionalEmail method.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneEmailCampaignExecutor: not yet implemented. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
+      'For sending individual transactional emails via API, use the sendTransactionalEmail method.', { not_implemented: true });
   }
 }
 
@@ -381,11 +360,9 @@ class ArchiveEmailCampaignExecutor implements EmailCampaignActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveEmailCampaignExecutor: not yet implemented. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
-        'For sending individual transactional emails via API, use the sendTransactionalEmail method.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveEmailCampaignExecutor: not yet implemented. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
+      'For sending individual transactional emails via API, use the sendTransactionalEmail method.', { not_implemented: true });
   }
 }
 
@@ -477,11 +454,9 @@ export class BloomreachEmailCampaignsService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listEmailCampaigns: the Bloomreach API does not provide a list endpoint for email campaigns. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
-        'For sending individual emails via API, use the sendTransactionalEmail method instead.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listEmailCampaigns: the Bloomreach API does not provide a list endpoint for email campaigns. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Email campaigns. ' +
+      'For sending individual emails via API, use the sendTransactionalEmail method instead.');
   }
 
   /**
@@ -493,10 +468,8 @@ export class BloomreachEmailCampaignsService {
     validateCampaignId(input.campaignId);
 
     void this.apiConfig;
-    throw new Error(
-      'viewCampaignResults: the Bloomreach API does not provide a campaign results endpoint for email campaigns. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Email campaigns > [campaign] > Results.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewCampaignResults: the Bloomreach API does not provide a campaign results endpoint for email campaigns. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Email campaigns > [campaign] > Results.');
   }
 
   /** @throws {Error} If input validation fails. */

--- a/packages/core/src/bloomreachEvaluationSettings.ts
+++ b/packages/core/src/bloomreachEvaluationSettings.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -125,24 +126,20 @@ const MAX_MAPPING_FIELD_LENGTH = 200;
 export function validateAttributionModel(model: string): string {
   const trimmed = model.trim();
   if (trimmed.length === 0) {
-    throw new Error('Attribution model must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Attribution model must not be empty.');
   }
   if (trimmed.length > MAX_ATTRIBUTION_MODEL_LENGTH) {
-    throw new Error(
-      `Attribution model must not exceed ${MAX_ATTRIBUTION_MODEL_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Attribution model must not exceed ${MAX_ATTRIBUTION_MODEL_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateAttributionWindow(window: number): number {
   if (!Number.isInteger(window) || window <= 0) {
-    throw new Error('Attribution window must be a positive integer.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Attribution window must be a positive integer.');
   }
   if (window > MAX_ATTRIBUTION_WINDOW_DAYS) {
-    throw new Error(
-      `Attribution window must not exceed ${MAX_ATTRIBUTION_WINDOW_DAYS} days (got ${window}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Attribution window must not exceed ${MAX_ATTRIBUTION_WINDOW_DAYS} days (got ${window}).`);
   }
   return window;
 }
@@ -150,13 +147,13 @@ export function validateAttributionWindow(window: number): number {
 export function validateCurrencyCode(code: string): string {
   const trimmed = code.trim().toUpperCase();
   if (trimmed.length === 0) {
-    throw new Error('Currency code must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Currency code must not be empty.');
   }
   if (trimmed.length !== 3) {
-    throw new Error(`Currency code must be exactly 3 characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Currency code must be exactly 3 characters (got ${trimmed.length}).`);
   }
   if (!/^[A-Z]{3}$/.test(trimmed)) {
-    throw new Error('Currency code must contain uppercase letters only (ISO 4217).');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Currency code must contain uppercase letters only (ISO 4217).');
   }
   return trimmed;
 }
@@ -164,7 +161,7 @@ export function validateCurrencyCode(code: string): string {
 export function validateDashboardId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Dashboard ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard ID must not be empty.');
   }
   return trimmed;
 }
@@ -172,12 +169,10 @@ export function validateDashboardId(id: string): string {
 export function validateMappingField(field: string): string {
   const trimmed = field.trim();
   if (trimmed.length === 0) {
-    throw new Error('Mapping field must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Mapping field must not be empty.');
   }
   if (trimmed.length > MAX_MAPPING_FIELD_LENGTH) {
-    throw new Error(
-      `Mapping field must not exceed ${MAX_MAPPING_FIELD_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Mapping field must not exceed ${MAX_MAPPING_FIELD_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -207,9 +202,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -236,10 +231,8 @@ class ConfigureRevenueAttributionExecutor implements EvaluationSettingsActionExe
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ConfigureRevenueAttributionExecutor: not yet implemented. ' +
-        'Revenue attribution configuration is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureRevenueAttributionExecutor: not yet implemented. ' +
+      'Revenue attribution configuration is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -253,10 +246,8 @@ class SetCurrencyExecutor implements EvaluationSettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'SetCurrencyExecutor: not yet implemented. ' +
-        'Currency configuration is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SetCurrencyExecutor: not yet implemented. ' +
+      'Currency configuration is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -270,10 +261,8 @@ class ConfigureEvaluationDashboardsExecutor implements EvaluationSettingsActionE
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ConfigureEvaluationDashboardsExecutor: not yet implemented. ' +
-        'Evaluation dashboard configuration is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureEvaluationDashboardsExecutor: not yet implemented. ' +
+      'Evaluation dashboard configuration is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -287,10 +276,8 @@ class ConfigureVoucherMappingExecutor implements EvaluationSettingsActionExecuto
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ConfigureVoucherMappingExecutor: not yet implemented. ' +
-        'Voucher mapping configuration is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureVoucherMappingExecutor: not yet implemented. ' +
+      'Voucher mapping configuration is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -349,10 +336,8 @@ export class BloomreachEvaluationSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewRevenueAttribution: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
-        'Revenue attribution must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Revenue Attribution).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewRevenueAttribution: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
+      'Revenue attribution must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Revenue Attribution).', { not_implemented: true });
   }
 
   async viewCurrency(input?: ViewCurrencyInput): Promise<BloomreachCurrencySettings> {
@@ -360,10 +345,8 @@ export class BloomreachEvaluationSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewCurrency: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
-        'Currency must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Currency).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewCurrency: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
+      'Currency must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Currency).', { not_implemented: true });
   }
 
   async viewEvaluationDashboards(
@@ -373,10 +356,8 @@ export class BloomreachEvaluationSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewEvaluationDashboards: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
-        'Evaluation dashboards must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Evaluation Dashboards).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewEvaluationDashboards: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
+      'Evaluation dashboards must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Evaluation Dashboards).', { not_implemented: true });
   }
 
   async viewVoucherMapping(
@@ -386,10 +367,8 @@ export class BloomreachEvaluationSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewVoucherMapping: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
-        'Voucher mapping must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Vouchers).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewVoucherMapping: not yet implemented. the Bloomreach API does not provide an endpoint for evaluation settings. ' +
+      'Voucher mapping must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Vouchers).', { not_implemented: true });
   }
 
   prepareConfigureRevenueAttribution(
@@ -447,7 +426,7 @@ export class BloomreachEvaluationSettingsService {
   ): PreparedEvaluationSettingsAction {
     const project = validateProject(input.project);
     if (input.dashboards.length === 0) {
-      throw new Error('At least one dashboard configuration must be provided.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one dashboard configuration must be provided.');
     }
     const dashboards = input.dashboards.map((dashboard) => ({
       id: validateDashboardId(dashboard.id),

--- a/packages/core/src/bloomreachExports.ts
+++ b/packages/core/src/bloomreachExports.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -136,7 +137,7 @@ const SCHEDULE_FREQUENCIES = new Set(['daily', 'weekly', 'monthly']);
 function validateRequiredTrimmed(value: string, fieldName: string): string {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
-    throw new Error(`${fieldName} must not be empty.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not be empty.`);
   }
   return trimmed;
 }
@@ -144,9 +145,7 @@ function validateRequiredTrimmed(value: string, fieldName: string): string {
 function validateExportName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Export name');
   if (trimmed.length > MAX_EXPORT_NAME_LENGTH) {
-    throw new Error(
-      `Export name must not exceed ${MAX_EXPORT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export name must not exceed ${MAX_EXPORT_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -154,9 +153,7 @@ function validateExportName(name: string): string {
 function validateExportType(exportType: string): string {
   const normalized = validateRequiredTrimmed(exportType, 'Export type').toLowerCase();
   if (!EXPORT_TYPES.has(normalized)) {
-    throw new Error(
-      `Export type must be one of: ${Array.from(EXPORT_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export type must be one of: ${Array.from(EXPORT_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -164,9 +161,7 @@ function validateExportType(exportType: string): string {
 function validateDestinationType(destinationType: string): string {
   const normalized = validateRequiredTrimmed(destinationType, 'Destination type').toLowerCase();
   if (!DESTINATION_TYPES.has(normalized)) {
-    throw new Error(
-      `Destination type must be one of: ${Array.from(DESTINATION_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Destination type must be one of: ${Array.from(DESTINATION_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -174,9 +169,7 @@ function validateDestinationType(destinationType: string): string {
 function validateExportId(exportId: string): string {
   const trimmed = validateRequiredTrimmed(exportId, 'Export ID');
   if (trimmed.length > MAX_EXPORT_ID_LENGTH) {
-    throw new Error(
-      `Export ID must not exceed ${MAX_EXPORT_ID_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export ID must not exceed ${MAX_EXPORT_ID_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -184,9 +177,7 @@ function validateExportId(exportId: string): string {
 function validateScheduleFrequency(frequency: string): string {
   const normalized = validateRequiredTrimmed(frequency, 'Schedule frequency').toLowerCase();
   if (!SCHEDULE_FREQUENCIES.has(normalized)) {
-    throw new Error(
-      `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -202,7 +193,7 @@ function validateOptionalString(
 
   const trimmed = validateRequiredTrimmed(value, fieldName);
   if (trimmed.length > maxLength) {
-    throw new Error(`${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
   }
 
   return trimmed;
@@ -214,12 +205,12 @@ function validateStringArray(values: string[] | undefined, fieldName: string): s
   }
 
   if (!Array.isArray(values)) {
-    throw new Error(`${fieldName} must be an array.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must be an array.`);
   }
 
   const normalized = values.map((value, index) => {
     if (typeof value !== 'string') {
-      throw new Error(`${fieldName}[${index}] must be a string.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName}[${index}] must be a string.`);
     }
     return validateRequiredTrimmed(value, `${fieldName}[${index}]`);
   });
@@ -238,9 +229,7 @@ function validateDataSelection(dataSelection: DataSelection): DataSelection {
     (segments !== undefined && segments.length > 0);
 
   if (!hasSelections) {
-    throw new Error(
-      'Data selection must include at least one non-empty list: attributes, events, or segments.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Data selection must include at least one non-empty list: attributes, events, or segments.');
   }
 
   return {
@@ -298,24 +287,24 @@ function validateDestination(destination: ExportDestination): ExportDestination 
 
   if (destination.port !== undefined) {
     if (!Number.isInteger(destination.port) || destination.port < 1 || destination.port > 65535) {
-      throw new Error('Destination port must be an integer between 1 and 65535.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Destination port must be an integer between 1 and 65535.');
     }
   }
 
   if (type === 'sftp' && (host === undefined || path === undefined)) {
-    throw new Error('SFTP destination requires host and path.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SFTP destination requires host and path.');
   }
 
   if (type === 's3' && (bucket === undefined || path === undefined)) {
-    throw new Error('S3 destination requires bucket and path.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'S3 destination requires bucket and path.');
   }
 
   if (type === 'email' && email === undefined) {
-    throw new Error('Email destination requires email.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email destination requires email.');
   }
 
   if (type === 'webhook' && webhookUrl === undefined) {
-    throw new Error('Webhook destination requires webhookUrl.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Webhook destination requires webhookUrl.');
   }
 
   return {
@@ -339,13 +328,13 @@ function validateTimeFormat(time: string): string {
   const trimmed = validateRequiredTrimmed(time, 'Schedule time');
   const match = /^(\d{2}):(\d{2})$/.exec(trimmed);
   if (match === null) {
-    throw new Error('Schedule time must use HH:MM format.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule time must use HH:MM format.');
   }
 
   const hours = Number(match[1]);
   const minutes = Number(match[2]);
   if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
-    throw new Error('Schedule time must use 24-hour HH:MM values (00-23 and 00-59).');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule time must use 24-hour HH:MM values (00-23 and 00-59).');
   }
 
   return trimmed;
@@ -359,12 +348,12 @@ function validateSchedule(schedule: ExportSchedule): ExportSchedule {
   const daysOfWeek = schedule.daysOfWeek;
   if (daysOfWeek !== undefined) {
     if (!Array.isArray(daysOfWeek) || daysOfWeek.length === 0) {
-      throw new Error('Schedule daysOfWeek must be a non-empty array when provided.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule daysOfWeek must be a non-empty array when provided.');
     }
 
     daysOfWeek.forEach((day, index) => {
       if (!Number.isInteger(day) || day < 0 || day > 6) {
-        throw new Error(`Schedule daysOfWeek[${index}] must be an integer from 0 to 6.`);
+        throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Schedule daysOfWeek[${index}] must be an integer from 0 to 6.`);
       }
     });
   }
@@ -372,16 +361,16 @@ function validateSchedule(schedule: ExportSchedule): ExportSchedule {
   const dayOfMonth = schedule.dayOfMonth;
   if (dayOfMonth !== undefined) {
     if (!Number.isInteger(dayOfMonth) || dayOfMonth < 1 || dayOfMonth > 31) {
-      throw new Error('Schedule dayOfMonth must be an integer from 1 to 31.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule dayOfMonth must be an integer from 1 to 31.');
     }
   }
 
   if (frequency === 'weekly' && daysOfWeek === undefined) {
-    throw new Error('Weekly schedules require daysOfWeek.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Weekly schedules require daysOfWeek.');
   }
 
   if (frequency === 'monthly' && dayOfMonth === undefined) {
-    throw new Error('Monthly schedules require dayOfMonth.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Monthly schedules require dayOfMonth.');
   }
 
   return {
@@ -420,9 +409,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;

--- a/packages/core/src/bloomreachFlows.ts
+++ b/packages/core/src/bloomreachFlows.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
@@ -107,12 +108,10 @@ const MAX_JOURNEY_DEPTH = 20;
 export function validateFlowName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_FLOW_NAME_LENGTH) {
-    throw new Error('Flow name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Flow name must not be empty.');
   }
   if (trimmed.length > MAX_FLOW_NAME_LENGTH) {
-    throw new Error(
-      `Flow name must not exceed ${MAX_FLOW_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Flow name must not exceed ${MAX_FLOW_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -120,7 +119,7 @@ export function validateFlowName(name: string): string {
 export function validateFlowAnalysisId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Flow analysis ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Flow analysis ID must not be empty.');
   }
   return trimmed;
 }
@@ -128,25 +127,25 @@ export function validateFlowAnalysisId(id: string): string {
 export function validateStartingEvent(eventName: string): string {
   const trimmed = eventName.trim();
   if (trimmed.length === 0) {
-    throw new Error('Starting event must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Starting event must not be empty.');
   }
   return trimmed;
 }
 
 export function validateFlowEvents(events: FlowEvent[]): FlowEvent[] {
   if (events.length < 1) {
-    throw new Error('events must contain at least one event to track.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'events must contain at least one event to track.');
   }
 
   return events.map((event, index) => {
     const expectedOrder = index + 1;
     if (event.order !== expectedOrder) {
-      throw new Error(`events[${index}].order must be ${expectedOrder} (got ${event.order}).`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `events[${index}].order must be ${expectedOrder} (got ${event.order}).`);
     }
 
     const eventName = event.eventName.trim();
     if (eventName.length === 0) {
-      throw new Error(`events[${index}].eventName must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `events[${index}].eventName must not be empty.`);
     }
 
     const label = event.label?.trim();
@@ -165,9 +164,7 @@ export function validateMaxJourneyDepth(depth: number | undefined): number | und
   }
 
   if (!Number.isInteger(depth) || depth < MIN_JOURNEY_DEPTH || depth > MAX_JOURNEY_DEPTH) {
-    throw new Error(
-      `maxJourneyDepth must be an integer between ${MIN_JOURNEY_DEPTH} and ${MAX_JOURNEY_DEPTH} (got ${depth}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `maxJourneyDepth must be an integer between ${MIN_JOURNEY_DEPTH} and ${MAX_JOURNEY_DEPTH} (got ${depth}).`);
   }
 
   return depth;
@@ -182,9 +179,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -207,10 +204,8 @@ class CreateFlowExecutor implements FlowActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateFlowExecutor: not yet implemented. ' +
-        'Flow creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateFlowExecutor: not yet implemented. ' +
+      'Flow creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -224,10 +219,8 @@ class CloneFlowExecutor implements FlowActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneFlowExecutor: not yet implemented. ' +
-        'Flow cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneFlowExecutor: not yet implemented. ' +
+      'Flow cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -241,10 +234,8 @@ class ArchiveFlowExecutor implements FlowActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveFlowExecutor: not yet implemented. ' +
-        'Flow archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveFlowExecutor: not yet implemented. ' +
+      'Flow archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -277,11 +268,9 @@ export class BloomreachFlowsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listFlowAnalyses: the Bloomreach API does not provide an endpoint for flow analyses. ' +
-        'Flow data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > Flows in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listFlowAnalyses: the Bloomreach API does not provide an endpoint for flow analyses. ' +
+      'Flow data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > Flows in your project).');
   }
 
   async viewFlowResults(input: ViewFlowResultsInput): Promise<FlowResults> {
@@ -297,11 +286,9 @@ export class BloomreachFlowsService {
       validateDateRange(dateRange);
     }
 
-    throw new Error(
-      'viewFlowResults: the Bloomreach API does not provide an endpoint for flow analysis results. ' +
-        'Flow results must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > Flows and open the analysis).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewFlowResults: the Bloomreach API does not provide an endpoint for flow analysis results. ' +
+      'Flow results must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > Flows and open the analysis).');
   }
 
   prepareCreateFlowAnalysis(input: CreateFlowAnalysisInput): PreparedFlowAction {

--- a/packages/core/src/bloomreachFunnels.ts
+++ b/packages/core/src/bloomreachFunnels.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -100,12 +101,10 @@ const MIN_FUNNEL_NAME_LENGTH = 1;
 export function validateFunnelName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_FUNNEL_NAME_LENGTH) {
-    throw new Error('Funnel name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Funnel name must not be empty.');
   }
   if (trimmed.length > MAX_FUNNEL_NAME_LENGTH) {
-    throw new Error(
-      `Funnel name must not exceed ${MAX_FUNNEL_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Funnel name must not exceed ${MAX_FUNNEL_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -113,25 +112,25 @@ export function validateFunnelName(name: string): string {
 export function validateFunnelAnalysisId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Funnel analysis ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Funnel analysis ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateFunnelSteps(steps: FunnelStep[]): FunnelStep[] {
   if (steps.length < 2) {
-    throw new Error('steps must contain at least two funnel steps.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'steps must contain at least two funnel steps.');
   }
 
   return steps.map((step, index) => {
     const expectedOrder = index + 1;
     if (step.order !== expectedOrder) {
-      throw new Error(`steps[${index}].order must be ${expectedOrder} (got ${step.order}).`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `steps[${index}].order must be ${expectedOrder} (got ${step.order}).`);
     }
 
     const eventName = step.eventName.trim();
     if (eventName.length === 0) {
-      throw new Error(`steps[${index}].eventName must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `steps[${index}].eventName must not be empty.`);
     }
 
     const label = step.label?.trim();
@@ -150,7 +149,7 @@ export function validateTimeLimitMs(ms: number | undefined): number | undefined 
   }
 
   if (!Number.isInteger(ms) || ms <= 0) {
-    throw new Error(`timeLimitMs must be a positive integer when provided (got ${ms}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `timeLimitMs must be a positive integer when provided (got ${ms}).`);
   }
 
   return ms;
@@ -165,9 +164,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -190,10 +189,8 @@ class CreateFunnelExecutor implements FunnelActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateFunnelExecutor: not yet implemented. ' +
-        'Funnel creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateFunnelExecutor: not yet implemented. ' +
+      'Funnel creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -209,10 +206,8 @@ class CloneFunnelExecutor implements FunnelActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneFunnelExecutor: not yet implemented. ' +
-        'Funnel cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneFunnelExecutor: not yet implemented. ' +
+      'Funnel cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -228,10 +223,8 @@ class ArchiveFunnelExecutor implements FunnelActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveFunnelExecutor: not yet implemented. ' +
-        'Funnel archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveFunnelExecutor: not yet implemented. ' +
+      'Funnel archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -263,11 +256,9 @@ export class BloomreachFunnelsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listFunnelAnalyses: the Bloomreach API does not provide a list endpoint for funnels. ' +
-        'Funnel analysis IDs must be obtained from the Bloomreach Engagement UI ' +
-        '(found in the URL when viewing a funnel, e.g. "606488856f8cf6f848b20af8").',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listFunnelAnalyses: the Bloomreach API does not provide a list endpoint for funnels. ' +
+      'Funnel analysis IDs must be obtained from the Bloomreach Engagement UI ' +
+      '(found in the URL when viewing a funnel, e.g. "606488856f8cf6f848b20af8").');
   }
 
   async viewFunnelResults(input: ViewFunnelResultsInput): Promise<FunnelResults> {
@@ -299,7 +290,7 @@ export class BloomreachFunnelsService {
       name?: string;
     };
     if (!data.success || !Array.isArray(data.rows)) {
-      throw new Error('viewFunnelResults: unexpected API response format.');
+      throw new BloomreachBuddyError('API_ERROR', 'viewFunnelResults: unexpected API response format.');
     }
 
     const header = Array.isArray(data.header) ? data.header : [];

--- a/packages/core/src/bloomreachGeoAnalyses.ts
+++ b/packages/core/src/bloomreachGeoAnalyses.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -93,21 +94,17 @@ const MIN_GEO_ANALYSIS_NAME_LENGTH = 1;
 export function validateGeoAnalysisName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_GEO_ANALYSIS_NAME_LENGTH) {
-    throw new Error('Geo analysis name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Geo analysis name must not be empty.');
   }
   if (trimmed.length > MAX_GEO_ANALYSIS_NAME_LENGTH) {
-    throw new Error(
-      `Geo analysis name must not exceed ${MAX_GEO_ANALYSIS_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Geo analysis name must not exceed ${MAX_GEO_ANALYSIS_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateGeoGranularity(granularity: string): GeoGranularity {
   if (!GEO_GRANULARITIES.includes(granularity as GeoGranularity)) {
-    throw new Error(
-      `granularity must be one of: ${GEO_GRANULARITIES.join(', ')} (got "${granularity}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `granularity must be one of: ${GEO_GRANULARITIES.join(', ')} (got "${granularity}").`);
   }
   return granularity as GeoGranularity;
 }
@@ -115,7 +112,7 @@ export function validateGeoGranularity(granularity: string): GeoGranularity {
 export function validateGeoAnalysisId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Geo analysis ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Geo analysis ID must not be empty.');
   }
   return trimmed;
 }
@@ -123,7 +120,7 @@ export function validateGeoAnalysisId(id: string): string {
 export function validateAttribute(attribute: string): string {
   const trimmed = attribute.trim();
   if (trimmed.length === 0) {
-    throw new Error('attribute must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'attribute must not be empty.');
   }
   return trimmed;
 }
@@ -137,9 +134,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -164,10 +161,8 @@ class CreateGeoAnalysisExecutor implements GeoAnalysisActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateGeoAnalysisExecutor: not yet implemented. ' +
-        'Geo analysis creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateGeoAnalysisExecutor: not yet implemented. ' +
+      'Geo analysis creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -183,10 +178,8 @@ class CloneGeoAnalysisExecutor implements GeoAnalysisActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneGeoAnalysisExecutor: not yet implemented. ' +
-        'Geo analysis cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneGeoAnalysisExecutor: not yet implemented. ' +
+      'Geo analysis cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -202,10 +195,8 @@ class ArchiveGeoAnalysisExecutor implements GeoAnalysisActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveGeoAnalysisExecutor: not yet implemented. ' +
-        'Geo analysis archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveGeoAnalysisExecutor: not yet implemented. ' +
+      'Geo analysis archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -240,11 +231,9 @@ export class BloomreachGeoAnalysesService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listGeoAnalyses: the Bloomreach API does not provide an endpoint for geo analyses. ' +
-        'Geo analysis data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > Geo Analyses in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listGeoAnalyses: the Bloomreach API does not provide an endpoint for geo analyses. ' +
+      'Geo analysis data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > Geo Analyses in your project).');
   }
 
   async viewGeoResults(input: ViewGeoResultsInput): Promise<GeoResults> {
@@ -264,11 +253,9 @@ export class BloomreachGeoAnalysesService {
       validateDateRange(dateRange);
     }
 
-    throw new Error(
-      'viewGeoResults: the Bloomreach API does not provide an endpoint for geo analysis results. ' +
-        'Geo results must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > Geo Analyses and open the analysis).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewGeoResults: the Bloomreach API does not provide an endpoint for geo analysis results. ' +
+      'Geo results must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > Geo Analyses and open the analysis).');
   }
 
   prepareCreateGeoAnalysis(

--- a/packages/core/src/bloomreachImports.ts
+++ b/packages/core/src/bloomreachImports.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -143,7 +144,7 @@ const MAPPING_TRANSFORMATION_TYPES = new Set([
 function validateRequiredTrimmed(value: string, fieldName: string): string {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
-    throw new Error(`${fieldName} must not be empty.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not be empty.`);
   }
   return trimmed;
 }
@@ -151,9 +152,7 @@ function validateRequiredTrimmed(value: string, fieldName: string): string {
 function validateImportName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Import name');
   if (trimmed.length > MAX_IMPORT_NAME_LENGTH) {
-    throw new Error(
-      `Import name must not exceed ${MAX_IMPORT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import name must not exceed ${MAX_IMPORT_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -161,9 +160,7 @@ function validateImportName(name: string): string {
 function validateImportType(type: string): string {
   const normalized = validateRequiredTrimmed(type, 'Import type').toLowerCase();
   if (!IMPORT_TYPES.has(normalized)) {
-    throw new Error(
-      `Import type must be one of: ${Array.from(IMPORT_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import type must be one of: ${Array.from(IMPORT_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -171,9 +168,7 @@ function validateImportType(type: string): string {
 function validateImportStatus(status: string): string {
   const normalized = validateRequiredTrimmed(status, 'Import status').toLowerCase();
   if (!IMPORT_STATUSES.has(normalized)) {
-    throw new Error(
-      `Import status must be one of: ${Array.from(IMPORT_STATUSES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import status must be one of: ${Array.from(IMPORT_STATUSES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -181,11 +176,11 @@ function validateImportStatus(status: string): string {
 function validateImportSource(source: string): string {
   const trimmed = validateRequiredTrimmed(source, 'Import source');
   if (trimmed.length > MAX_SOURCE_LENGTH) {
-    throw new Error(`Import source must not exceed ${MAX_SOURCE_LENGTH} characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import source must not exceed ${MAX_SOURCE_LENGTH} characters (got ${trimmed.length}).`);
   }
 
   if (!/^[a-zA-Z][a-zA-Z\d+.-]*:\/\/.+/.test(trimmed)) {
-    throw new Error('Import source must be a valid absolute URL.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Import source must be a valid absolute URL.');
   }
 
   return trimmed;
@@ -194,9 +189,7 @@ function validateImportSource(source: string): string {
 function validateImportId(id: string): string {
   const trimmed = validateRequiredTrimmed(id, 'Import ID');
   if (trimmed.length > MAX_IMPORT_ID_LENGTH) {
-    throw new Error(
-      `Import ID must not exceed ${MAX_IMPORT_ID_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import ID must not exceed ${MAX_IMPORT_ID_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -204,9 +197,7 @@ function validateImportId(id: string): string {
 function validateColumnName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Source column');
   if (trimmed.length > MAX_COLUMN_NAME_LENGTH) {
-    throw new Error(
-      `Source column must not exceed ${MAX_COLUMN_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source column must not exceed ${MAX_COLUMN_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -214,9 +205,7 @@ function validateColumnName(name: string): string {
 function validatePropertyName(name: string): string {
   const trimmed = validateRequiredTrimmed(name, 'Target property');
   if (trimmed.length > MAX_PROPERTY_NAME_LENGTH) {
-    throw new Error(
-      `Target property must not exceed ${MAX_PROPERTY_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Target property must not exceed ${MAX_PROPERTY_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -224,21 +213,19 @@ function validatePropertyName(name: string): string {
 function validateMappingTransformationType(type: string): string {
   const normalized = validateRequiredTrimmed(type, 'Transformation type').toLowerCase();
   if (!MAPPING_TRANSFORMATION_TYPES.has(normalized)) {
-    throw new Error(
-      `Transformation type must be one of: ${Array.from(MAPPING_TRANSFORMATION_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Transformation type must be one of: ${Array.from(MAPPING_TRANSFORMATION_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
 
 function validateMapping(mapping: ImportMapping[]): ImportMapping[] {
   if (!Array.isArray(mapping)) {
-    throw new Error('Mapping must be an array.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Mapping must be an array.');
   }
 
   return mapping.map((entry, index) => {
     if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
-      throw new Error(`Mapping entry #${index + 1} must be an object.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Mapping entry #${index + 1} must be an object.`);
     }
 
     const sourceColumn = validateColumnName(entry.sourceColumn);
@@ -259,9 +246,7 @@ function validateMapping(mapping: ImportMapping[]): ImportMapping[] {
 function validateScheduleFrequency(frequency: string): string {
   const normalized = validateRequiredTrimmed(frequency, 'Schedule frequency').toLowerCase();
   if (!SCHEDULE_FREQUENCIES.has(normalized)) {
-    throw new Error(
-      `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -269,9 +254,7 @@ function validateScheduleFrequency(frequency: string): string {
 function validateCronExpression(cron: string): string {
   const trimmed = validateRequiredTrimmed(cron, 'Cron expression');
   if (trimmed.length > MAX_CRON_LENGTH) {
-    throw new Error(
-      `Cron expression must not exceed ${MAX_CRON_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Cron expression must not exceed ${MAX_CRON_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -282,7 +265,7 @@ function validateScheduleConfig(schedule: ImportScheduleConfig): ImportScheduleC
     schedule === null ||
     Array.isArray(schedule)
   ) {
-    throw new Error('Schedule must be a non-null object.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule must be a non-null object.');
   }
 
   const frequency = validateScheduleFrequency(schedule.frequency);
@@ -296,7 +279,7 @@ function validateScheduleConfig(schedule: ImportScheduleConfig): ImportScheduleC
       ? undefined
       : validateRequiredTrimmed(schedule.startDate, 'Schedule start date');
   if (startDate !== undefined && Number.isNaN(Date.parse(startDate))) {
-    throw new Error('Schedule start date must be a valid date string.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule start date must be a valid date string.');
   }
 
   const endDate =
@@ -304,11 +287,11 @@ function validateScheduleConfig(schedule: ImportScheduleConfig): ImportScheduleC
       ? undefined
       : validateRequiredTrimmed(schedule.endDate, 'Schedule end date');
   if (endDate !== undefined && Number.isNaN(Date.parse(endDate))) {
-    throw new Error('Schedule end date must be a valid date string.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule end date must be a valid date string.');
   }
 
   if (typeof schedule.isActive !== 'boolean') {
-    throw new Error('Schedule isActive must be a boolean.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Schedule isActive must be a boolean.');
   }
 
   return {
@@ -331,7 +314,7 @@ function validateOptionalString(
 
   const trimmed = validateRequiredTrimmed(value, fieldName);
   if (trimmed.length > maxLength) {
-    throw new Error(`${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not exceed ${maxLength} characters (got ${trimmed.length}).`);
   }
 
   return trimmed;
@@ -364,9 +347,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;

--- a/packages/core/src/bloomreachInitiatives.ts
+++ b/packages/core/src/bloomreachInitiatives.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_INITIATIVE_ACTION_TYPE = 'initiatives.create_initiative';
@@ -102,12 +103,10 @@ const MAX_ITEMS_PER_ADD = 100;
 export function validateInitiativeName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_INITIATIVE_NAME_LENGTH) {
-    throw new Error('Initiative name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Initiative name must not be empty.');
   }
   if (trimmed.length > MAX_INITIATIVE_NAME_LENGTH) {
-    throw new Error(
-      `Initiative name must not exceed ${MAX_INITIATIVE_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Initiative name must not exceed ${MAX_INITIATIVE_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -115,18 +114,14 @@ export function validateInitiativeName(name: string): string {
 export function validateInitiativeDescription(description: string): string {
   const trimmed = description.trim();
   if (trimmed.length > MAX_INITIATIVE_DESCRIPTION_LENGTH) {
-    throw new Error(
-      `Initiative description must not exceed ${MAX_INITIATIVE_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Initiative description must not exceed ${MAX_INITIATIVE_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateInitiativeStatus(status: string): InitiativeStatus {
   if (!INITIATIVE_STATUSES.includes(status as InitiativeStatus)) {
-    throw new Error(
-      `status must be one of: ${INITIATIVE_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${INITIATIVE_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as InitiativeStatus;
 }
@@ -134,16 +129,14 @@ export function validateInitiativeStatus(status: string): InitiativeStatus {
 export function validateInitiativeId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Initiative ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Initiative ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateInitiativeItemType(type: string): InitiativeItemType {
   if (!INITIATIVE_ITEM_TYPES.includes(type as InitiativeItemType)) {
-    throw new Error(
-      `Item type must be one of: ${INITIATIVE_ITEM_TYPES.join(', ')} (got "${type}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Item type must be one of: ${INITIATIVE_ITEM_TYPES.join(', ')} (got "${type}").`);
   }
   return type as InitiativeItemType;
 }
@@ -152,16 +145,14 @@ export function validateInitiativeItems(
   items: InitiativeItemReference[],
 ): InitiativeItemReference[] {
   if (items.length === 0) {
-    throw new Error('Items array must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Items array must not be empty.');
   }
   if (items.length > MAX_ITEMS_PER_ADD) {
-    throw new Error(
-      `Cannot add more than ${MAX_ITEMS_PER_ADD} items at once (got ${items.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Cannot add more than ${MAX_ITEMS_PER_ADD} items at once (got ${items.length}).`);
   }
   for (const item of items) {
     if (!item.id || item.id.trim().length === 0) {
-      throw new Error('Each item must have a non-empty ID.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Each item must have a non-empty ID.');
     }
     validateInitiativeItemType(item.type);
   }
@@ -172,7 +163,7 @@ export function validateImportConfiguration(
   configuration: Record<string, unknown>,
 ): Record<string, unknown> {
   if (Object.keys(configuration).length === 0) {
-    throw new Error('Import configuration must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Import configuration must not be empty.');
   }
   return configuration;
 }
@@ -186,9 +177,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -213,9 +204,7 @@ class CreateInitiativeExecutor implements InitiativeActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateInitiativeExecutor: not yet implemented. Initiative creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateInitiativeExecutor: not yet implemented. Initiative creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -231,9 +220,7 @@ class ImportInitiativeExecutor implements InitiativeActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ImportInitiativeExecutor: not yet implemented. Initiative import is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ImportInitiativeExecutor: not yet implemented. Initiative import is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -249,9 +236,7 @@ class AddItemsExecutor implements InitiativeActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'AddItemsExecutor: not yet implemented. Adding items to initiatives is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'AddItemsExecutor: not yet implemented. Adding items to initiatives is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -267,9 +252,7 @@ class ArchiveInitiativeExecutor implements InitiativeActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveInitiativeExecutor: not yet implemented. Initiative archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveInitiativeExecutor: not yet implemented. Initiative archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -315,9 +298,7 @@ export class BloomreachInitiativesService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listInitiatives: the Bloomreach API does not provide an initiative listing endpoint. Initiative management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listInitiatives: the Bloomreach API does not provide an initiative listing endpoint. Initiative management is only available through the Bloomreach Engagement UI.');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -330,9 +311,7 @@ export class BloomreachInitiativesService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'filterInitiatives: the Bloomreach API does not provide an initiative filtering endpoint. Initiative management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'filterInitiatives: the Bloomreach API does not provide an initiative filtering endpoint. Initiative management is only available through the Bloomreach Engagement UI.');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -343,9 +322,7 @@ export class BloomreachInitiativesService {
     validateInitiativeId(input.initiativeId);
 
     void this.apiConfig;
-    throw new Error(
-      'viewInitiative: the Bloomreach API does not provide an initiative detail endpoint. Initiative management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewInitiative: the Bloomreach API does not provide an initiative detail endpoint. Initiative management is only available through the Bloomreach Engagement UI.');
   }
 
   /** @throws {Error} If input validation fails. */

--- a/packages/core/src/bloomreachIntegrations.ts
+++ b/packages/core/src/bloomreachIntegrations.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -157,12 +158,10 @@ const MIN_INTEGRATION_NAME_LENGTH = 1;
 export function validateIntegrationName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_INTEGRATION_NAME_LENGTH) {
-    throw new Error('Integration name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Integration name must not be empty.');
   }
   if (trimmed.length > MAX_INTEGRATION_NAME_LENGTH) {
-    throw new Error(
-      `Integration name must not exceed ${MAX_INTEGRATION_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Integration name must not exceed ${MAX_INTEGRATION_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -171,7 +170,7 @@ export function validateIntegrationName(name: string): string {
 export function validateIntegrationProject(project: string): string {
   const trimmed = project.trim();
   if (trimmed.length === 0) {
-    throw new Error('Project identifier must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Project identifier must not be empty.');
   }
   return trimmed;
 }
@@ -180,7 +179,7 @@ export function validateIntegrationProject(project: string): string {
 export function validateIntegrationId(integrationId: string): string {
   const trimmed = integrationId.trim();
   if (trimmed.length === 0) {
-    throw new Error('Integration ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Integration ID must not be empty.');
   }
   return trimmed;
 }
@@ -188,9 +187,7 @@ export function validateIntegrationId(integrationId: string): string {
 /** @throws {Error} If type is not a valid integration type. */
 export function validateIntegrationType(type: string): IntegrationType {
   if (!INTEGRATION_TYPES.includes(type as IntegrationType)) {
-    throw new Error(
-      `Invalid integration type '${type}'. Must be one of: ${INTEGRATION_TYPES.join(', ')}.`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid integration type '${type}'. Must be one of: ${INTEGRATION_TYPES.join(', ')}.`);
   }
   return type as IntegrationType;
 }
@@ -198,9 +195,7 @@ export function validateIntegrationType(type: string): IntegrationType {
 /** @throws {Error} If status is not a valid integration status. */
 export function validateIntegrationStatus(status: string): IntegrationStatus {
   if (!INTEGRATION_STATUSES.includes(status as IntegrationStatus)) {
-    throw new Error(
-      `Invalid integration status '${status}'. Must be one of: ${INTEGRATION_STATUSES.join(', ')}.`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid integration status '${status}'. Must be one of: ${INTEGRATION_STATUSES.join(', ')}.`);
   }
   return status as IntegrationStatus;
 }
@@ -209,7 +204,7 @@ export function validateIntegrationStatus(status: string): IntegrationStatus {
 export function validateProvider(provider: string): string {
   const trimmed = provider.trim();
   if (trimmed.length === 0) {
-    throw new Error('Provider must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Provider must not be empty.');
   }
   return trimmed;
 }
@@ -227,9 +222,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -260,9 +255,7 @@ class CreateIntegrationExecutor implements IntegrationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateIntegrationExecutor: not yet implemented. Integration creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateIntegrationExecutor: not yet implemented. Integration creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -276,9 +269,7 @@ class ConfigureIntegrationExecutor implements IntegrationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ConfigureIntegrationExecutor: not yet implemented. Integration configuration is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureIntegrationExecutor: not yet implemented. Integration configuration is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -292,9 +283,7 @@ class EnableIntegrationExecutor implements IntegrationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EnableIntegrationExecutor: not yet implemented. Integration management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EnableIntegrationExecutor: not yet implemented. Integration management is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -308,9 +297,7 @@ class DisableIntegrationExecutor implements IntegrationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DisableIntegrationExecutor: not yet implemented. Integration management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DisableIntegrationExecutor: not yet implemented. Integration management is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -324,9 +311,7 @@ class DeleteIntegrationExecutor implements IntegrationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteIntegrationExecutor: not yet implemented. Integration deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteIntegrationExecutor: not yet implemented. Integration deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -340,9 +325,7 @@ class TestIntegrationExecutor implements IntegrationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'TestIntegrationExecutor: not yet implemented. Integration testing is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'TestIntegrationExecutor: not yet implemented. Integration testing is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -391,9 +374,7 @@ export class BloomreachIntegrationsService {
         validateIntegrationStatus(input.status);
       }
     }
-    throw new Error(
-      'listIntegrations: not yet implemented. The Bloomreach API does not provide an endpoint for integrations. Integrations must be managed through the Bloomreach Engagement UI (navigate to Data & Assets > Integrations).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listIntegrations: not yet implemented. The Bloomreach API does not provide an endpoint for integrations. Integrations must be managed through the Bloomreach Engagement UI (navigate to Data & Assets > Integrations).', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -401,9 +382,7 @@ export class BloomreachIntegrationsService {
     void this.apiConfig;
     validateProject(input.project);
     validateIntegrationId(input.integrationId);
-    throw new Error(
-      'viewIntegration: not yet implemented. The Bloomreach API does not provide an endpoint for integration details. Integrations must be managed through the Bloomreach Engagement UI (navigate to Data & Assets > Integrations).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewIntegration: not yet implemented. The Bloomreach API does not provide an endpoint for integration details. Integrations must be managed through the Bloomreach Engagement UI (navigate to Data & Assets > Integrations).', { not_implemented: true });
   }
 
   /** @throws {Error} If input validation fails. */

--- a/packages/core/src/bloomreachMetrics.ts
+++ b/packages/core/src/bloomreachMetrics.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
@@ -96,12 +97,10 @@ const PROPERTY_REQUIRED_AGGREGATION_TYPES = new Set(['sum', 'average', 'min', 'm
 export function validateMetricName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_METRIC_NAME_LENGTH) {
-    throw new Error('Metric name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Metric name must not be empty.');
   }
   if (trimmed.length > MAX_METRIC_NAME_LENGTH) {
-    throw new Error(
-      `Metric name must not exceed ${MAX_METRIC_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Metric name must not exceed ${MAX_METRIC_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -109,7 +108,7 @@ export function validateMetricName(name: string): string {
 export function validateMetricId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Metric ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Metric ID must not be empty.');
   }
   return trimmed;
 }
@@ -117,12 +116,10 @@ export function validateMetricId(id: string): string {
 export function validateDescription(description: string): string {
   const trimmed = description.trim();
   if (trimmed.length === 0) {
-    throw new Error('Description must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Description must not be empty.');
   }
   if (trimmed.length > MAX_DESCRIPTION_LENGTH) {
-    throw new Error(
-      `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -130,12 +127,10 @@ export function validateDescription(description: string): string {
 export function validateAggregationType(type: string): string {
   const normalized = type.trim().toLowerCase();
   if (normalized.length === 0) {
-    throw new Error('Aggregation type must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Aggregation type must not be empty.');
   }
   if (!AGGREGATION_TYPES.has(normalized)) {
-    throw new Error(
-      `Aggregation type must be one of: ${Array.from(AGGREGATION_TYPES).join(', ')} (got ${normalized}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Aggregation type must be one of: ${Array.from(AGGREGATION_TYPES).join(', ')} (got ${normalized}).`);
   }
   return normalized;
 }
@@ -143,7 +138,7 @@ export function validateAggregationType(type: string): string {
 export function validateAggregation(aggregation: MetricAggregation): MetricAggregation {
   const eventName = aggregation.eventName.trim();
   if (eventName.length === 0) {
-    throw new Error('Aggregation eventName must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Aggregation eventName must not be empty.');
   }
 
   const aggregationType = validateAggregationType(aggregation.aggregationType);
@@ -153,11 +148,11 @@ export function validateAggregation(aggregation: MetricAggregation): MetricAggre
     PROPERTY_REQUIRED_AGGREGATION_TYPES.has(aggregationType) &&
     (propertyName === undefined || propertyName.length === 0)
   ) {
-    throw new Error(`aggregation.propertyName is required for aggregationType ${aggregationType}.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `aggregation.propertyName is required for aggregationType ${aggregationType}.`);
   }
 
   if (propertyName !== undefined && propertyName.length === 0) {
-    throw new Error('Aggregation propertyName must not be empty when provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Aggregation propertyName must not be empty when provided.');
   }
 
   return {
@@ -176,9 +171,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -201,10 +196,8 @@ class CreateMetricExecutor implements MetricActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateMetricExecutor: not yet implemented. ' +
-        'Metric creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateMetricExecutor: not yet implemented. ' +
+      'Metric creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -218,10 +211,8 @@ class EditMetricExecutor implements MetricActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EditMetricExecutor: not yet implemented. ' +
-        'Metric editing is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EditMetricExecutor: not yet implemented. ' +
+      'Metric editing is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -235,10 +226,8 @@ class DeleteMetricExecutor implements MetricActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteMetricExecutor: not yet implemented. ' +
-        'Metric deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteMetricExecutor: not yet implemented. ' +
+      'Metric deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -271,11 +260,9 @@ export class BloomreachMetricsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listMetrics: the Bloomreach API does not provide an endpoint for metrics. ' +
-        'Metric data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Metrics in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listMetrics: the Bloomreach API does not provide an endpoint for metrics. ' +
+      'Metric data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Metrics in your project).');
   }
 
   async viewMetricResults(input: ViewMetricResultsInput): Promise<MetricResults> {
@@ -291,11 +278,9 @@ export class BloomreachMetricsService {
       validateDateRange(dateRange);
     }
 
-    throw new Error(
-      'viewMetricResults: the Bloomreach API does not provide an endpoint for metric results. ' +
-        'Metric results must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Metrics and open the metric).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewMetricResults: the Bloomreach API does not provide an endpoint for metric results. ' +
+      'Metric results must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Metrics and open the metric).');
   }
 
   prepareCreateMetric(input: CreateMetricInput): PreparedMetricAction {

--- a/packages/core/src/bloomreachPerformance.ts
+++ b/packages/core/src/bloomreachPerformance.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const PERFORMANCE_DASHBOARD_TYPES = [
@@ -22,15 +23,15 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function assertValidCalendarDate(label: string, value: string): void {
   if (!ISO_DATE_RE.test(value)) {
-    throw new Error(`${label} must be a valid ISO-8601 date (YYYY-MM-DD), got "${value}".`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${label} must be a valid ISO-8601 date (YYYY-MM-DD), got "${value}".`);
   }
   const parsed = new Date(value + 'T00:00:00Z');
   if (Number.isNaN(parsed.getTime())) {
-    throw new Error(`${label} is not a valid calendar date: "${value}".`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${label} is not a valid calendar date: "${value}".`);
   }
   const roundtrip = parsed.toISOString().slice(0, 10);
   if (roundtrip !== value) {
-    throw new Error(`${label} is not a valid calendar date: "${value}".`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${label} is not a valid calendar date: "${value}".`);
   }
 }
 
@@ -53,9 +54,7 @@ export function validateDateRange(dateRange?: DateRangeFilter): DateRangeFilter 
     dateRange.endDate !== undefined &&
     dateRange.startDate > dateRange.endDate
   ) {
-    throw new Error(
-      `startDate "${dateRange.startDate}" must not be after endDate "${dateRange.endDate}".`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `startDate "${dateRange.startDate}" must not be after endDate "${dateRange.endDate}".`);
   }
 
   return dateRange;
@@ -75,7 +74,7 @@ export type ChannelType = (typeof CHANNEL_TYPES)[number];
 /** @throws {Error} If `channel` is not a recognised channel type. */
 export function validateChannel(channel: string): ChannelType {
   if (!CHANNEL_TYPES.includes(channel as ChannelType)) {
-    throw new Error(`channel must be one of: ${CHANNEL_TYPES.join(', ')} (got "${channel}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `channel must be one of: ${CHANNEL_TYPES.join(', ')} (got "${channel}").`);
   }
   return channel as ChannelType;
 }
@@ -200,9 +199,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -251,11 +250,9 @@ export class BloomreachPerformanceService {
     validateDateRange(input.dateRange);
     void this.apiConfig;
 
-    throw new Error(
-      'viewProjectPerformance: the Bloomreach API does not provide an endpoint for project performance dashboards. ' +
-        'Performance data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Overview > Performance Dashboards > Project in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewProjectPerformance: the Bloomreach API does not provide an endpoint for project performance dashboards. ' +
+      'Performance data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Overview > Performance Dashboards > Project in your project).');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -269,11 +266,9 @@ export class BloomreachPerformanceService {
       validateChannel(input.channel);
     }
 
-    throw new Error(
-      'viewChannelPerformance: the Bloomreach API does not provide an endpoint for channel performance dashboards. ' +
-        'Channel performance data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Overview > Performance Dashboards > Channel in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewChannelPerformance: the Bloomreach API does not provide an endpoint for channel performance dashboards. ' +
+      'Channel performance data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Overview > Performance Dashboards > Channel in your project).');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -283,11 +278,9 @@ export class BloomreachPerformanceService {
     validateProject(input.project);
     void this.apiConfig;
 
-    throw new Error(
-      'viewBloomreachUsage: the Bloomreach API does not provide an endpoint for usage dashboards. ' +
-        'Usage data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Overview > Pricing Dashboard in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewBloomreachUsage: the Bloomreach API does not provide an endpoint for usage dashboards. ' +
+      'Usage data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Overview > Pricing Dashboard in your project).');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -297,11 +290,9 @@ export class BloomreachPerformanceService {
     validateProject(input.project);
     void this.apiConfig;
 
-    throw new Error(
-      'viewProjectOverview: the Bloomreach API does not provide an endpoint for project overview dashboards. ' +
-        'Overview data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Overview > Project in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewProjectOverview: the Bloomreach API does not provide an endpoint for project overview dashboards. ' +
+      'Overview data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Overview > Project in your project).');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -311,10 +302,8 @@ export class BloomreachPerformanceService {
     validateProject(input.project);
     void this.apiConfig;
 
-    throw new Error(
-      'viewProjectHealth: the Bloomreach API does not provide an endpoint for health dashboards. ' +
-        'Health data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Overview > Health Dashboard in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewProjectHealth: the Bloomreach API does not provide an endpoint for health dashboards. ' +
+      'Health data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Overview > Health Dashboard in your project).');
   }
 }

--- a/packages/core/src/bloomreachProfileManager.ts
+++ b/packages/core/src/bloomreachProfileManager.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import lockfile from 'proper-lockfile';
 import { chromium } from 'playwright-core';
 import type { BrowserContext, LaunchOptions } from 'playwright-core';
-import { BloomreachBuddyError } from './bloomreachApiClient.js';
+import { BloomreachBuddyError } from './errors.js';
 
 export interface ProfileManagerConfig {
   /** Base directory for browser profiles. Default: ~/.bloomreach-buddy/profiles */

--- a/packages/core/src/bloomreachProjectSettings.ts
+++ b/packages/core/src/bloomreachProjectSettings.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Action type constants
@@ -207,12 +208,10 @@ const MIN_CUSTOM_URL_LENGTH = 1;
 export function validateProjectName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_PROJECT_NAME_LENGTH) {
-    throw new Error('Project name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Project name must not be empty.');
   }
   if (trimmed.length > MAX_PROJECT_NAME_LENGTH) {
-    throw new Error(
-      `Project name must not exceed ${MAX_PROJECT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Project name must not exceed ${MAX_PROJECT_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -221,12 +220,10 @@ export function validateProjectName(name: string): string {
 export function validateCustomTagName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_TAG_NAME_LENGTH) {
-    throw new Error('Tag name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag name must not be empty.');
   }
   if (trimmed.length > MAX_TAG_NAME_LENGTH) {
-    throw new Error(
-      `Tag name must not exceed ${MAX_TAG_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Tag name must not exceed ${MAX_TAG_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -235,7 +232,7 @@ export function validateCustomTagName(name: string): string {
 export function validateCustomTagId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Tag ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag ID must not be empty.');
   }
   return trimmed;
 }
@@ -244,9 +241,7 @@ export function validateCustomTagId(id: string): string {
 export function validateTagColor(color: string): string {
   const trimmed = color.trim();
   if (!/^#[0-9a-fA-F]{6}$/.test(trimmed)) {
-    throw new Error(
-      `Tag color must be a valid hex color code (e.g. "#FF5733"), got "${trimmed}".`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Tag color must be a valid hex color code (e.g. "#FF5733"), got "${trimmed}".`);
   }
   return trimmed;
 }
@@ -255,12 +250,10 @@ export function validateTagColor(color: string): string {
 export function validateVariableName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_VARIABLE_NAME_LENGTH) {
-    throw new Error('Variable name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Variable name must not be empty.');
   }
   if (trimmed.length > MAX_VARIABLE_NAME_LENGTH) {
-    throw new Error(
-      `Variable name must not exceed ${MAX_VARIABLE_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Variable name must not exceed ${MAX_VARIABLE_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -268,9 +261,7 @@ export function validateVariableName(name: string): string {
 /** @throws {Error} If variable value exceeds 5000 characters. */
 export function validateVariableValue(value: string): string {
   if (value.length > MAX_VARIABLE_VALUE_LENGTH) {
-    throw new Error(
-      `Variable value must not exceed ${MAX_VARIABLE_VALUE_LENGTH} characters (got ${value.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Variable value must not exceed ${MAX_VARIABLE_VALUE_LENGTH} characters (got ${value.length}).`);
   }
   return value;
 }
@@ -279,12 +270,10 @@ export function validateVariableValue(value: string): string {
 export function validateCustomUrl(url: string): string {
   const trimmed = url.trim();
   if (trimmed.length < MIN_CUSTOM_URL_LENGTH) {
-    throw new Error('Custom URL must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Custom URL must not be empty.');
   }
   if (trimmed.length > MAX_CUSTOM_URL_LENGTH) {
-    throw new Error(
-      `Custom URL must not exceed ${MAX_CUSTOM_URL_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Custom URL must not exceed ${MAX_CUSTOM_URL_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -338,10 +327,8 @@ class UpdateProjectNameExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = UPDATE_PROJECT_NAME_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UpdateProjectNameExecutor: not yet implemented. ' +
-        'Project name updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateProjectNameExecutor: not yet implemented. ' +
+      'Project name updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -349,10 +336,8 @@ class UpdateCustomUrlExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = UPDATE_CUSTOM_URL_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UpdateCustomUrlExecutor: not yet implemented. ' +
-        'Custom URL updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateCustomUrlExecutor: not yet implemented. ' +
+      'Custom URL updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -360,10 +345,8 @@ class UpdateTermsAndConditionsExecutor implements ProjectSettingsActionExecutor 
   readonly actionType = UPDATE_TERMS_AND_CONDITIONS_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UpdateTermsAndConditionsExecutor: not yet implemented. ' +
-        'Terms and conditions updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateTermsAndConditionsExecutor: not yet implemented. ' +
+      'Terms and conditions updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -371,10 +354,8 @@ class CreateCustomTagExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = CREATE_CUSTOM_TAG_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateCustomTagExecutor: not yet implemented. ' +
-        'Tag creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateCustomTagExecutor: not yet implemented. ' +
+      'Tag creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -382,10 +363,8 @@ class UpdateCustomTagExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = UPDATE_CUSTOM_TAG_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UpdateCustomTagExecutor: not yet implemented. ' +
-        'Tag updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateCustomTagExecutor: not yet implemented. ' +
+      'Tag updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -393,10 +372,8 @@ class DeleteCustomTagExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = DELETE_CUSTOM_TAG_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'DeleteCustomTagExecutor: not yet implemented. ' +
-        'Tag deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteCustomTagExecutor: not yet implemented. ' +
+      'Tag deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -404,10 +381,8 @@ class CreateProjectVariableExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = CREATE_PROJECT_VARIABLE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateProjectVariableExecutor: not yet implemented. ' +
-        'Variable creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateProjectVariableExecutor: not yet implemented. ' +
+      'Variable creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -415,10 +390,8 @@ class UpdateProjectVariableExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = UPDATE_PROJECT_VARIABLE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'UpdateProjectVariableExecutor: not yet implemented. ' +
-        'Variable updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateProjectVariableExecutor: not yet implemented. ' +
+      'Variable updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -426,10 +399,8 @@ class DeleteProjectVariableExecutor implements ProjectSettingsActionExecutor {
   readonly actionType = DELETE_PROJECT_VARIABLE_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'DeleteProjectVariableExecutor: not yet implemented. ' +
-        'Variable deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteProjectVariableExecutor: not yet implemented. ' +
+      'Variable deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -501,10 +472,8 @@ export class BloomreachProjectSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewProjectSettings: not yet implemented. ' +
-        'Project settings must be viewed through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewProjectSettings: not yet implemented. ' +
+      'Project settings must be viewed through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -512,10 +481,8 @@ export class BloomreachProjectSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewProjectToken: not yet implemented. ' +
-        'Project token must be viewed through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewProjectToken: not yet implemented. ' +
+      'Project token must be viewed through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -525,10 +492,8 @@ export class BloomreachProjectSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewTermsAndConditions: not yet implemented. ' +
-        'Terms and conditions must be viewed through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewTermsAndConditions: not yet implemented. ' +
+      'Terms and conditions must be viewed through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -536,10 +501,8 @@ export class BloomreachProjectSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listCustomTags: not yet implemented. ' +
-        'Custom tags must be viewed through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listCustomTags: not yet implemented. ' +
+      'Custom tags must be viewed through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -549,10 +512,8 @@ export class BloomreachProjectSettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listProjectVariables: not yet implemented. ' +
-        'Project variables must be viewed through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listProjectVariables: not yet implemented. ' +
+      'Project variables must be viewed through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 
   // -------------------------------------------------------------------------
@@ -650,7 +611,7 @@ export class BloomreachProjectSettingsService {
     const color = input.color !== undefined ? validateTagColor(input.color) : undefined;
 
     if (name === undefined && color === undefined) {
-      throw new Error('At least one of name or color must be provided for tag update.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of name or color must be provided for tag update.');
     }
 
     const preview = {
@@ -725,9 +686,7 @@ export class BloomreachProjectSettingsService {
       input.value !== undefined ? validateVariableValue(input.value) : undefined;
 
     if (value === undefined && input.description === undefined) {
-      throw new Error(
-        'At least one of value or description must be provided for variable update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of value or description must be provided for variable update.');
     }
 
     const preview = {

--- a/packages/core/src/bloomreachRecommendations.ts
+++ b/packages/core/src/bloomreachRecommendations.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 
 export const CREATE_RECOMMENDATION_MODEL_ACTION_TYPE = 'recommendations.create_model';
 export const CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE = 'recommendations.configure_model';
@@ -118,12 +119,10 @@ const MAX_MAX_ITEMS = 100;
 export function validateModelName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_MODEL_NAME_LENGTH) {
-    throw new Error('Model name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Model name must not be empty.');
   }
   if (trimmed.length > MAX_MODEL_NAME_LENGTH) {
-    throw new Error(
-      `Model name must not exceed ${MAX_MODEL_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Model name must not exceed ${MAX_MODEL_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -131,25 +130,21 @@ export function validateModelName(name: string): string {
 export function validateModelId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Model ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Model ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateRecommendationModelStatus(status: string): RecommendationModelStatus {
   if (!RECOMMENDATION_MODEL_STATUSES.includes(status as RecommendationModelStatus)) {
-    throw new Error(
-      `status must be one of: ${RECOMMENDATION_MODEL_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${RECOMMENDATION_MODEL_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as RecommendationModelStatus;
 }
 
 export function validateAlgorithmType(algorithm: string): RecommendationAlgorithmType {
   if (!RECOMMENDATION_ALGORITHM_TYPES.includes(algorithm as RecommendationAlgorithmType)) {
-    throw new Error(
-      `algorithm must be one of: ${RECOMMENDATION_ALGORITHM_TYPES.join(', ')} (got "${algorithm}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `algorithm must be one of: ${RECOMMENDATION_ALGORITHM_TYPES.join(', ')} (got "${algorithm}").`);
   }
   return algorithm as RecommendationAlgorithmType;
 }
@@ -158,9 +153,7 @@ export function validateFilterRules(
   filters: RecommendationFilterRule[],
 ): RecommendationFilterRule[] {
   if (filters.length > MAX_FILTER_RULES) {
-    throw new Error(
-      `filters must contain at most ${MAX_FILTER_RULES} rules (got ${filters.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `filters must contain at most ${MAX_FILTER_RULES} rules (got ${filters.length}).`);
   }
 
   return filters.map((filter, index) => {
@@ -169,13 +162,13 @@ export function validateFilterRules(
     const value = filter.value.trim();
 
     if (field.length === 0) {
-      throw new Error(`filters[${index}].field must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `filters[${index}].field must not be empty.`);
     }
     if (operator.length === 0) {
-      throw new Error(`filters[${index}].operator must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `filters[${index}].operator must not be empty.`);
     }
     if (value.length === 0) {
-      throw new Error(`filters[${index}].value must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `filters[${index}].value must not be empty.`);
     }
 
     return {
@@ -190,21 +183,17 @@ export function validateBoostRules(
   boostRules: RecommendationBoostRule[],
 ): RecommendationBoostRule[] {
   if (boostRules.length > MAX_BOOST_RULES) {
-    throw new Error(
-      `boostRules must contain at most ${MAX_BOOST_RULES} rules (got ${boostRules.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `boostRules must contain at most ${MAX_BOOST_RULES} rules (got ${boostRules.length}).`);
   }
 
   return boostRules.map((boostRule, index) => {
     const field = boostRule.field.trim();
     if (field.length === 0) {
-      throw new Error(`boostRules[${index}].field must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `boostRules[${index}].field must not be empty.`);
     }
 
     if (boostRule.weight < MIN_BOOST_WEIGHT || boostRule.weight > MAX_BOOST_WEIGHT) {
-      throw new Error(
-        `boostRules[${index}].weight must be between ${MIN_BOOST_WEIGHT} and ${MAX_BOOST_WEIGHT} (got ${boostRule.weight}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `boostRules[${index}].weight must be between ${MIN_BOOST_WEIGHT} and ${MAX_BOOST_WEIGHT} (got ${boostRule.weight}).`);
     }
 
     return {
@@ -216,9 +205,7 @@ export function validateBoostRules(
 
 export function validateMaxItems(maxItems: number): number {
   if (!Number.isInteger(maxItems) || maxItems < MIN_MAX_ITEMS || maxItems > MAX_MAX_ITEMS) {
-    throw new Error(
-      `maxItems must be an integer between ${MIN_MAX_ITEMS} and ${MAX_MAX_ITEMS} (got ${maxItems}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `maxItems must be an integer between ${MIN_MAX_ITEMS} and ${MAX_MAX_ITEMS} (got ${maxItems}).`);
   }
 
   return maxItems;
@@ -237,9 +224,7 @@ class CreateRecommendationModelExecutor implements RecommendationActionExecutor 
   readonly actionType = CREATE_RECOMMENDATION_MODEL_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'CreateRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -247,9 +232,7 @@ class ConfigureRecommendationModelExecutor implements RecommendationActionExecut
   readonly actionType = CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'ConfigureRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ConfigureRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -257,9 +240,7 @@ class DeleteRecommendationModelExecutor implements RecommendationActionExecutor 
   readonly actionType = DELETE_RECOMMENDATION_MODEL_ACTION_TYPE;
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'DeleteRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteRecommendationModelExecutor: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 }
 
@@ -295,9 +276,7 @@ export class BloomreachRecommendationsService {
       }
     }
 
-    throw new Error(
-      'listRecommendationModels: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listRecommendationModels: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   async viewModelPerformance(
@@ -306,9 +285,7 @@ export class BloomreachRecommendationsService {
     validateProject(input.project);
     validateModelId(input.modelId);
 
-    throw new Error(
-      'viewModelPerformance: not yet implemented. Requires browser automation infrastructure.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewModelPerformance: not yet implemented. Requires browser automation infrastructure.', { not_implemented: true });
   }
 
   prepareCreateRecommendationModel(
@@ -318,7 +295,7 @@ export class BloomreachRecommendationsService {
     const name = validateModelName(input.name);
     const modelType = input.modelType.trim();
     if (modelType.length === 0) {
-      throw new Error('Model type must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Model type must not be empty.');
     }
     const algorithm =
       input.algorithm !== undefined ? validateAlgorithmType(input.algorithm) : undefined;

--- a/packages/core/src/bloomreachReports.ts
+++ b/packages/core/src/bloomreachReports.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -141,12 +142,10 @@ const MIN_REPORT_LIMIT = 1;
 export function validateReportName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_REPORT_NAME_LENGTH) {
-    throw new Error('Report name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report name must not be empty.');
   }
   if (trimmed.length > MAX_REPORT_NAME_LENGTH) {
-    throw new Error(
-      `Report name must not exceed ${MAX_REPORT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Report name must not exceed ${MAX_REPORT_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -155,7 +154,7 @@ export function validateReportName(name: string): string {
 export function validateReportId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Report ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report ID must not be empty.');
   }
   return trimmed;
 }
@@ -163,12 +162,12 @@ export function validateReportId(id: string): string {
 /** @throws {Error} If metrics array is empty. */
 export function validateMetrics(metrics: string[]): string[] {
   if (metrics.length === 0) {
-    throw new Error('At least one metric is required.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one metric is required.');
   }
   const trimmed = metrics.map((m) => m.trim());
   for (const metric of trimmed) {
     if (metric.length === 0) {
-      throw new Error('Metric names must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Metric names must not be empty.');
     }
   }
   return trimmed;
@@ -176,9 +175,7 @@ export function validateMetrics(metrics: string[]): string[] {
 
 export function validateReportExportFormat(format: string): ReportExportFormat {
   if (!REPORT_EXPORT_FORMATS.includes(format as ReportExportFormat)) {
-    throw new Error(
-      `Export format must be one of: ${REPORT_EXPORT_FORMATS.join(', ')} (got "${format}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export format must be one of: ${REPORT_EXPORT_FORMATS.join(', ')} (got "${format}").`);
   }
   return format as ReportExportFormat;
 }
@@ -186,9 +183,7 @@ export function validateReportExportFormat(format: string): ReportExportFormat {
 /** @throws {Error} If sort order is not asc or desc. */
 export function validateSortOrder(order: string): ReportSortOrder {
   if (!REPORT_SORT_ORDERS.includes(order as ReportSortOrder)) {
-    throw new Error(
-      `Sort order must be one of: ${REPORT_SORT_ORDERS.join(', ')} (got "${order}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Sort order must be one of: ${REPORT_SORT_ORDERS.join(', ')} (got "${order}").`);
   }
   return order as ReportSortOrder;
 }
@@ -200,9 +195,7 @@ export function validateLimit(limit: number): number {
     limit < MIN_REPORT_LIMIT ||
     limit > MAX_REPORT_LIMIT
   ) {
-    throw new Error(
-      `Limit must be an integer between ${MIN_REPORT_LIMIT} and ${MAX_REPORT_LIMIT} (got ${limit}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Limit must be an integer between ${MIN_REPORT_LIMIT} and ${MAX_REPORT_LIMIT} (got ${limit}).`);
   }
   return limit;
 }
@@ -216,9 +209,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -245,10 +238,8 @@ class CreateReportExecutor implements ReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateReportExecutor: not yet implemented. ' +
-        'Report creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateReportExecutor: not yet implemented. ' +
+      'Report creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -264,10 +255,8 @@ class CloneReportExecutor implements ReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneReportExecutor: not yet implemented. ' +
-        'Report cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneReportExecutor: not yet implemented. ' +
+      'Report cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -283,10 +272,8 @@ class ArchiveReportExecutor implements ReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveReportExecutor: not yet implemented. ' +
-        'Report archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveReportExecutor: not yet implemented. ' +
+      'Report archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -302,10 +289,8 @@ class ExportReportExecutor implements ReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ExportReportExecutor: not yet implemented. ' +
-        'Report export is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ExportReportExecutor: not yet implemented. ' +
+      'Report export is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -348,11 +333,9 @@ export class BloomreachReportsService {
       validateProject(_input.project);
     }
 
-    throw new Error(
-      'listReports: the Bloomreach API does not provide a list endpoint for reports. ' +
-        'Report IDs must be obtained from the Bloomreach Engagement UI ' +
-        '(found in the URL when viewing a report, e.g. "606488856f8cf6f848b20af8").',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listReports: the Bloomreach API does not provide a list endpoint for reports. ' +
+      'Report IDs must be obtained from the Bloomreach Engagement UI ' +
+      '(found in the URL when viewing a report, e.g. "606488856f8cf6f848b20af8").');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -385,7 +368,7 @@ export class BloomreachReportsService {
       name?: string;
     };
     if (!data.success || !Array.isArray(data.rows)) {
-      throw new Error('viewReportResults: unexpected API response format.');
+      throw new BloomreachBuddyError('API_ERROR', 'viewReportResults: unexpected API response format.');
     }
 
     const columns = Array.isArray(data.header) ? data.header : [];

--- a/packages/core/src/bloomreachRetentions.ts
+++ b/packages/core/src/bloomreachRetentions.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -103,12 +104,10 @@ const MIN_RETENTION_NAME_LENGTH = 1;
 export function validateRetentionName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_RETENTION_NAME_LENGTH) {
-    throw new Error('Retention name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Retention name must not be empty.');
   }
   if (trimmed.length > MAX_RETENTION_NAME_LENGTH) {
-    throw new Error(
-      `Retention name must not exceed ${MAX_RETENTION_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Retention name must not exceed ${MAX_RETENTION_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -119,9 +118,7 @@ export function validateRetentionGranularity(
   if (
     !RETENTION_GRANULARITIES.includes(granularity as RetentionGranularity)
   ) {
-    throw new Error(
-      `granularity must be one of: ${RETENTION_GRANULARITIES.join(', ')} (got "${granularity}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `granularity must be one of: ${RETENTION_GRANULARITIES.join(', ')} (got "${granularity}").`);
   }
   return granularity as RetentionGranularity;
 }
@@ -129,7 +126,7 @@ export function validateRetentionGranularity(
 export function validateRetentionAnalysisId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Retention analysis ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Retention analysis ID must not be empty.');
   }
   return trimmed;
 }
@@ -137,7 +134,7 @@ export function validateRetentionAnalysisId(id: string): string {
 export function validateEventName(label: string, eventName: string): string {
   const trimmed = eventName.trim();
   if (trimmed.length === 0) {
-    throw new Error(`${label} must not be empty.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${label} must not be empty.`);
   }
   return trimmed;
 }
@@ -151,9 +148,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -176,10 +173,8 @@ class CreateRetentionExecutor implements RetentionActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateRetentionExecutor: not yet implemented. ' +
-        'Retention creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateRetentionExecutor: not yet implemented. ' +
+      'Retention creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -195,10 +190,8 @@ class CloneRetentionExecutor implements RetentionActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneRetentionExecutor: not yet implemented. ' +
-        'Retention cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneRetentionExecutor: not yet implemented. ' +
+      'Retention cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -214,10 +207,8 @@ class ArchiveRetentionExecutor implements RetentionActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveRetentionExecutor: not yet implemented. ' +
-        'Retention archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveRetentionExecutor: not yet implemented. ' +
+      'Retention archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -251,11 +242,9 @@ export class BloomreachRetentionsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listRetentionAnalyses: the Bloomreach API does not provide a list endpoint for retentions. ' +
-        'Retention analysis IDs must be obtained from the Bloomreach Engagement UI ' +
-        '(found in the URL when viewing a retention analysis, e.g. "606488856f8cf6f848b20af8").',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listRetentionAnalyses: the Bloomreach API does not provide a list endpoint for retentions. ' +
+      'Retention analysis IDs must be obtained from the Bloomreach Engagement UI ' +
+      '(found in the URL when viewing a retention analysis, e.g. "606488856f8cf6f848b20af8").');
   }
 
   async viewRetentionResults(
@@ -293,7 +282,7 @@ export class BloomreachRetentionsService {
       name?: string;
     };
     if (!data.success || !Array.isArray(data.rows)) {
-      throw new Error('viewRetentionResults: unexpected API response format.');
+      throw new BloomreachBuddyError('API_ERROR', 'viewRetentionResults: unexpected API response format.');
     }
 
     const header = Array.isArray(data.header) ? data.header : [];

--- a/packages/core/src/bloomreachScenarios.ts
+++ b/packages/core/src/bloomreachScenarios.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SCENARIO_ACTION_TYPE = 'scenarios.create_scenario';
@@ -101,19 +102,17 @@ const MIN_SCENARIO_NAME_LENGTH = 1;
 export function validateScenarioName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_SCENARIO_NAME_LENGTH) {
-    throw new Error('Scenario name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Scenario name must not be empty.');
   }
   if (trimmed.length > MAX_SCENARIO_NAME_LENGTH) {
-    throw new Error(
-      `Scenario name must not exceed ${MAX_SCENARIO_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Scenario name must not exceed ${MAX_SCENARIO_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateScenarioStatus(status: string): ScenarioStatus {
   if (!SCENARIO_STATUSES.includes(status as ScenarioStatus)) {
-    throw new Error(`status must be one of: ${SCENARIO_STATUSES.join(', ')} (got "${status}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${SCENARIO_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as ScenarioStatus;
 }
@@ -121,7 +120,7 @@ export function validateScenarioStatus(status: string): ScenarioStatus {
 export function validateScenarioId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Scenario ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Scenario ID must not be empty.');
   }
   return trimmed;
 }
@@ -135,9 +134,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -160,10 +159,8 @@ class CreateScenarioExecutor implements ScenarioActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateScenarioExecutor: not yet implemented. ' +
-        'Scenario creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateScenarioExecutor: not yet implemented. ' +
+      'Scenario creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -177,10 +174,8 @@ class StartScenarioExecutor implements ScenarioActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'StartScenarioExecutor: not yet implemented. ' +
-        'Starting scenarios is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'StartScenarioExecutor: not yet implemented. ' +
+      'Starting scenarios is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -194,10 +189,8 @@ class StopScenarioExecutor implements ScenarioActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'StopScenarioExecutor: not yet implemented. ' +
-        'Stopping scenarios is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'StopScenarioExecutor: not yet implemented. ' +
+      'Stopping scenarios is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -211,10 +204,8 @@ class CloneScenarioExecutor implements ScenarioActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneScenarioExecutor: not yet implemented. ' +
-        'Scenario cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneScenarioExecutor: not yet implemented. ' +
+      'Scenario cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -228,10 +219,8 @@ class ArchiveScenarioExecutor implements ScenarioActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveScenarioExecutor: not yet implemented. ' +
-        'Scenario archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveScenarioExecutor: not yet implemented. ' +
+      'Scenario archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -269,11 +258,9 @@ export class BloomreachScenariosService {
       }
     }
 
-    throw new Error(
-      'listScenarios: the Bloomreach API does not provide an endpoint for scenarios. ' +
-        'Scenario data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Campaigns > Scenarios in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listScenarios: the Bloomreach API does not provide an endpoint for scenarios. ' +
+      'Scenario data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Campaigns > Scenarios in your project).');
   }
 
   async viewScenario(input: ViewScenarioInput): Promise<ScenarioDetails> {
@@ -281,11 +268,9 @@ export class BloomreachScenariosService {
     validateProject(input.project);
     validateScenarioId(input.scenarioId);
 
-    throw new Error(
-      'viewScenario: the Bloomreach API does not provide an endpoint for scenario details. ' +
-        'Scenario details must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Campaigns > Scenarios and open the scenario).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewScenario: the Bloomreach API does not provide an endpoint for scenario details. ' +
+      'Scenario details must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Campaigns > Scenarios and open the scenario).');
   }
 
   prepareCreateScenario(input: CreateScenarioInput): PreparedScenarioAction {

--- a/packages/core/src/bloomreachSecuritySettings.ts
+++ b/packages/core/src/bloomreachSecuritySettings.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -122,12 +123,10 @@ const MAX_USERNAME_LENGTH = 200;
 export function validateTunnelName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length === 0) {
-    throw new Error('Tunnel name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tunnel name must not be empty.');
   }
   if (trimmed.length > MAX_TUNNEL_NAME_LENGTH) {
-    throw new Error(
-      `Tunnel name must not exceed ${MAX_TUNNEL_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Tunnel name must not exceed ${MAX_TUNNEL_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -135,20 +134,20 @@ export function validateTunnelName(name: string): string {
 export function validateHost(host: string): string {
   const trimmed = host.trim();
   if (trimmed.length === 0) {
-    throw new Error('Host must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Host must not be empty.');
   }
   if (trimmed.length > MAX_HOST_LENGTH) {
-    throw new Error(`Host must not exceed ${MAX_HOST_LENGTH} characters (got ${trimmed.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Host must not exceed ${MAX_HOST_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validatePort(port: number): number {
   if (!Number.isInteger(port) || port <= 0) {
-    throw new Error('Port must be a positive integer.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Port must be a positive integer.');
   }
   if (port < 1 || port > 65535) {
-    throw new Error(`Port must be between 1 and 65535 (got ${port}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Port must be between 1 and 65535 (got ${port}).`);
   }
   return port;
 }
@@ -156,12 +155,10 @@ export function validatePort(port: number): number {
 export function validateUsername(username: string): string {
   const trimmed = username.trim();
   if (trimmed.length === 0) {
-    throw new Error('Username must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Username must not be empty.');
   }
   if (trimmed.length > MAX_USERNAME_LENGTH) {
-    throw new Error(
-      `Username must not exceed ${MAX_USERNAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Username must not exceed ${MAX_USERNAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -169,7 +166,7 @@ export function validateUsername(username: string): string {
 export function validateTunnelId(tunnelId: string): string {
   const trimmed = tunnelId.trim();
   if (trimmed.length === 0) {
-    throw new Error('Tunnel ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tunnel ID must not be empty.');
   }
   return trimmed;
 }
@@ -191,9 +188,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -220,10 +217,8 @@ class CreateSshTunnelExecutor implements SecuritySettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateSshTunnelExecutor: not yet implemented. ' +
-        'SSH tunnel creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateSshTunnelExecutor: not yet implemented. ' +
+      'SSH tunnel creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -237,10 +232,8 @@ class UpdateSshTunnelExecutor implements SecuritySettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateSshTunnelExecutor: not yet implemented. ' +
-        'SSH tunnel updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateSshTunnelExecutor: not yet implemented. ' +
+      'SSH tunnel updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -254,10 +247,8 @@ class DeleteSshTunnelExecutor implements SecuritySettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteSshTunnelExecutor: not yet implemented. ' +
-        'SSH tunnel deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteSshTunnelExecutor: not yet implemented. ' +
+      'SSH tunnel deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -271,10 +262,8 @@ class EnableTwoStepExecutor implements SecuritySettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EnableTwoStepExecutor: not yet implemented. ' +
-        'Two-step verification enabling is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EnableTwoStepExecutor: not yet implemented. ' +
+      'Two-step verification enabling is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -288,10 +277,8 @@ class DisableTwoStepExecutor implements SecuritySettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DisableTwoStepExecutor: not yet implemented. ' +
-        'Two-step verification disabling is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DisableTwoStepExecutor: not yet implemented. ' +
+      'Two-step verification disabling is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -305,10 +292,8 @@ class UpdateTwoStepExecutor implements SecuritySettingsActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UpdateTwoStepExecutor: not yet implemented. ' +
-        'Two-step verification updates are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UpdateTwoStepExecutor: not yet implemented. ' +
+      'Two-step verification updates are only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -355,10 +340,8 @@ export class BloomreachSecuritySettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'listSshTunnels: not yet implemented. the Bloomreach API does not provide an endpoint for SSH tunnels. ' +
-        'SSH tunnels must be managed through the Bloomreach Engagement UI (navigate to Project Settings > SSH Tunnels).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listSshTunnels: not yet implemented. the Bloomreach API does not provide an endpoint for SSH tunnels. ' +
+      'SSH tunnels must be managed through the Bloomreach Engagement UI (navigate to Project Settings > SSH Tunnels).', { not_implemented: true });
   }
 
   async viewSshTunnel(input?: ViewSshTunnelInput): Promise<BloomreachSshTunnel> {
@@ -366,10 +349,8 @@ export class BloomreachSecuritySettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewSshTunnel: not yet implemented. the Bloomreach API does not provide an endpoint for SSH tunnels. ' +
-        'SSH tunnels must be managed through the Bloomreach Engagement UI (navigate to Project Settings > SSH Tunnels).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewSshTunnel: not yet implemented. the Bloomreach API does not provide an endpoint for SSH tunnels. ' +
+      'SSH tunnels must be managed through the Bloomreach Engagement UI (navigate to Project Settings > SSH Tunnels).', { not_implemented: true });
   }
 
   async viewTwoStepVerification(
@@ -379,10 +360,8 @@ export class BloomreachSecuritySettingsService {
     if (input !== undefined) {
       validateProject(input.project);
     }
-    throw new Error(
-      'viewTwoStepVerification: not yet implemented. the Bloomreach API does not provide an endpoint for two-step verification. ' +
-        'Two-step verification must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Two-Step Verification).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewTwoStepVerification: not yet implemented. the Bloomreach API does not provide an endpoint for two-step verification. ' +
+      'Two-step verification must be managed through the Bloomreach Engagement UI (navigate to Project Settings > Two-Step Verification).', { not_implemented: true });
   }
 
   prepareCreateSshTunnel(input: CreateSshTunnelInput): PreparedSecuritySettingsAction {
@@ -434,9 +413,7 @@ export class BloomreachSecuritySettingsService {
       password === undefined &&
       hostKey === undefined
     ) {
-      throw new Error(
-        'At least one of name, host, port, username, password, or hostKey must be provided for tunnel update.',
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one of name, host, port, username, password, or hostKey must be provided for tunnel update.');
     }
 
     const preview = {

--- a/packages/core/src/bloomreachSegmentations.ts
+++ b/packages/core/src/bloomreachSegmentations.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -130,12 +131,10 @@ const MIN_SEGMENTATION_NAME_LENGTH = 1;
 export function validateSegmentationName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_SEGMENTATION_NAME_LENGTH) {
-    throw new Error('Segmentation name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Segmentation name must not be empty.');
   }
   if (trimmed.length > MAX_SEGMENTATION_NAME_LENGTH) {
-    throw new Error(
-      `Segmentation name must not exceed ${MAX_SEGMENTATION_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Segmentation name must not exceed ${MAX_SEGMENTATION_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -143,41 +142,35 @@ export function validateSegmentationName(name: string): string {
 export function validateSegmentationId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Segmentation ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Segmentation ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateSegmentConditionType(type: string): SegmentConditionType {
   if (!(SEGMENT_CONDITION_TYPES as readonly string[]).includes(type)) {
-    throw new Error(
-      `Invalid condition type "${type}". Must be one of: ${SEGMENT_CONDITION_TYPES.join(', ')}.`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid condition type "${type}". Must be one of: ${SEGMENT_CONDITION_TYPES.join(', ')}.`);
   }
   return type as SegmentConditionType;
 }
 
 export function validateSegmentConditionOperator(operator: string): SegmentConditionOperator {
   if (!(SEGMENT_CONDITION_OPERATORS as readonly string[]).includes(operator)) {
-    throw new Error(
-      `Invalid condition operator "${operator}". Must be one of: ${SEGMENT_CONDITION_OPERATORS.join(', ')}.`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid condition operator "${operator}". Must be one of: ${SEGMENT_CONDITION_OPERATORS.join(', ')}.`);
   }
   return operator as SegmentConditionOperator;
 }
 
 export function validateLogicalOperator(operator: string): SegmentLogicalOperator {
   if (!(SEGMENT_LOGICAL_OPERATORS as readonly string[]).includes(operator)) {
-    throw new Error(
-      `Invalid logical operator "${operator}". Must be one of: ${SEGMENT_LOGICAL_OPERATORS.join(', ')}.`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid logical operator "${operator}". Must be one of: ${SEGMENT_LOGICAL_OPERATORS.join(', ')}.`);
   }
   return operator as SegmentLogicalOperator;
 }
 
 export function validateSegmentConditions(conditions: SegmentCondition[]): SegmentCondition[] {
   if (conditions.length === 0) {
-    throw new Error('conditions must contain at least one segment condition.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'conditions must contain at least one segment condition.');
   }
 
   return conditions.map((condition, index) => {
@@ -186,7 +179,7 @@ export function validateSegmentConditions(conditions: SegmentCondition[]): Segme
 
     const attribute = condition.attribute.trim();
     if (attribute.length === 0) {
-      throw new Error(`conditions[${index}].attribute must not be empty.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `conditions[${index}].attribute must not be empty.`);
     }
 
     return {
@@ -204,7 +197,7 @@ export function validateCustomerListLimit(limit: number | undefined): number | u
   }
 
   if (!Number.isInteger(limit) || limit <= 0) {
-    throw new Error(`limit must be a positive integer when provided (got ${limit}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `limit must be a positive integer when provided (got ${limit}).`);
   }
 
   return limit;
@@ -216,7 +209,7 @@ export function validateCustomerListOffset(offset: number | undefined): number |
   }
 
   if (!Number.isInteger(offset) || offset < 0) {
-    throw new Error(`offset must be a non-negative integer when provided (got ${offset}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `offset must be a non-negative integer when provided (got ${offset}).`);
   }
 
   return offset;
@@ -236,9 +229,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -254,10 +247,8 @@ class CreateSegmentationExecutor implements SegmentationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateSegmentationExecutor: not yet implemented. ' +
-        'Segmentation creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateSegmentationExecutor: not yet implemented. ' +
+      'Segmentation creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -271,10 +262,8 @@ class CloneSegmentationExecutor implements SegmentationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneSegmentationExecutor: not yet implemented. ' +
-        'Segmentation cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneSegmentationExecutor: not yet implemented. ' +
+      'Segmentation cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -288,10 +277,8 @@ class ArchiveSegmentationExecutor implements SegmentationActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveSegmentationExecutor: not yet implemented. ' +
-        'Segmentation archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveSegmentationExecutor: not yet implemented. ' +
+      'Segmentation archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -323,11 +310,9 @@ export class BloomreachSegmentationsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listSegmentations: the Bloomreach API does not provide a list endpoint for segmentations. ' +
-        'Segmentation IDs must be obtained from the Bloomreach Engagement UI ' +
-        '(found in the URL when editing a segmentation, e.g. "606488856f8cf6f848b20af8").',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listSegmentations: the Bloomreach API does not provide a list endpoint for segmentations. ' +
+      'Segmentation IDs must be obtained from the Bloomreach Engagement UI ' +
+      '(found in the URL when editing a segmentation, e.g. "606488856f8cf6f848b20af8").');
   }
 
   async viewSegmentSize(input: ViewSegmentSizeInput): Promise<SegmentSize> {
@@ -346,7 +331,7 @@ export class BloomreachSegmentationsService {
 
     const data = response as { header?: string[]; rows?: unknown[][]; success?: boolean };
     if (!data.success || !Array.isArray(data.rows)) {
-      throw new Error('viewSegmentSize: unexpected API response format.');
+      throw new BloomreachBuddyError('API_ERROR', 'viewSegmentSize: unexpected API response format.');
     }
 
     const hashIndex = Array.isArray(data.header) ? data.header.indexOf('#') : -1;

--- a/packages/core/src/bloomreachSetup.ts
+++ b/packages/core/src/bloomreachSetup.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { BloomreachBuddyError } from './errors.js';
 import { exec } from 'node:child_process';
 import { join } from 'node:path';
 
@@ -7,7 +8,6 @@ import {
   bloomreachApiFetch,
   buildTrackingPath,
   BloomreachApiError,
-  BloomreachBuddyError,
 } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/bloomreachSqlReports.ts
+++ b/packages/core/src/bloomreachSqlReports.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SQL_REPORT_ACTION_TYPE = 'sql_reports.create_report';
@@ -106,12 +107,10 @@ export interface PreparedSqlReportAction {
 export function validateSqlReportName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < 1) {
-    throw new Error('Report name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report name must not be empty.');
   }
   if (trimmed.length > 200) {
-    throw new Error(
-      `Report name must not exceed 200 characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Report name must not exceed 200 characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -119,7 +118,7 @@ export function validateSqlReportName(name: string): string {
 export function validateSqlReportId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Report ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report ID must not be empty.');
   }
   return trimmed;
 }
@@ -127,30 +126,24 @@ export function validateSqlReportId(id: string): string {
 export function validateSqlQuery(query: string): string {
   const trimmed = query.trim();
   if (trimmed.length < 1) {
-    throw new Error('SQL query must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SQL query must not be empty.');
   }
   if (trimmed.length > 10000) {
-    throw new Error(
-      `SQL query must not exceed 10000 characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `SQL query must not exceed 10000 characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateSqlReportExportFormat(format: string): SqlReportExportFormat {
   if (!SQL_REPORT_EXPORT_FORMATS.includes(format as SqlReportExportFormat)) {
-    throw new Error(
-      `format must be one of: ${SQL_REPORT_EXPORT_FORMATS.join(', ')} (got "${format}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `format must be one of: ${SQL_REPORT_EXPORT_FORMATS.join(', ')} (got "${format}").`);
   }
   return format as SqlReportExportFormat;
 }
 
 export function validateSqlReportStatus(status: string): SqlReportStatus {
   if (!SQL_REPORT_STATUSES.includes(status as SqlReportStatus)) {
-    throw new Error(
-      `status must be one of: ${SQL_REPORT_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${SQL_REPORT_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as SqlReportStatus;
 }
@@ -164,9 +157,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -191,10 +184,8 @@ class CreateSqlReportExecutor implements SqlReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateSqlReportExecutor: not yet implemented. ' +
-        'SQL report creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateSqlReportExecutor: not yet implemented. ' +
+      'SQL report creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -210,10 +201,8 @@ class ExecuteSqlReportExecutor implements SqlReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ExecuteSqlReportExecutor: not yet implemented. ' +
-        'SQL report execution is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ExecuteSqlReportExecutor: not yet implemented. ' +
+      'SQL report execution is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -229,10 +218,8 @@ class ExportSqlReportResultsExecutor implements SqlReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ExportSqlReportResultsExecutor: not yet implemented. ' +
-        'SQL report results export is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ExportSqlReportResultsExecutor: not yet implemented. ' +
+      'SQL report results export is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -248,10 +235,8 @@ class CloneSqlReportExecutor implements SqlReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneSqlReportExecutor: not yet implemented. ' +
-        'SQL report cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneSqlReportExecutor: not yet implemented. ' +
+      'SQL report cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -267,10 +252,8 @@ class ArchiveSqlReportExecutor implements SqlReportActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveSqlReportExecutor: not yet implemented. ' +
-        'SQL report archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveSqlReportExecutor: not yet implemented. ' +
+      'SQL report archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -311,11 +294,9 @@ export class BloomreachSqlReportsService {
       }
     }
 
-    throw new Error(
-      'listSqlReports: the Bloomreach API does not provide an endpoint for SQL reports. ' +
-        'SQL report data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > SQL Reports in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listSqlReports: the Bloomreach API does not provide an endpoint for SQL reports. ' +
+      'SQL report data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > SQL Reports in your project).');
   }
 
   async viewSqlReport(input: ViewSqlReportInput): Promise<BloomreachSqlReport> {
@@ -323,11 +304,9 @@ export class BloomreachSqlReportsService {
     validateProject(input.project);
     validateSqlReportId(input.reportId);
 
-    throw new Error(
-      'viewSqlReport: the Bloomreach API does not provide an endpoint for SQL report details. ' +
-        'SQL report details must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > SQL Reports and open the report).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewSqlReport: the Bloomreach API does not provide an endpoint for SQL report details. ' +
+      'SQL report details must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > SQL Reports and open the report).');
   }
 
   prepareCreateSqlReport(input: CreateSqlReportInput): PreparedSqlReportAction {

--- a/packages/core/src/bloomreachSurveys.ts
+++ b/packages/core/src/bloomreachSurveys.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SURVEY_ACTION_TYPE = 'surveys.create_survey';
@@ -114,19 +115,17 @@ const MAX_QUESTION_OPTIONS = 20;
 export function validateSurveyName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_SURVEY_NAME_LENGTH) {
-    throw new Error('Survey name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Survey name must not be empty.');
   }
   if (trimmed.length > MAX_SURVEY_NAME_LENGTH) {
-    throw new Error(
-      `Survey name must not exceed ${MAX_SURVEY_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Survey name must not exceed ${MAX_SURVEY_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateSurveyStatus(status: string): SurveyStatus {
   if (!SURVEY_STATUSES.includes(status as SurveyStatus)) {
-    throw new Error(`status must be one of: ${SURVEY_STATUSES.join(', ')} (got "${status}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${SURVEY_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as SurveyStatus;
 }
@@ -134,16 +133,14 @@ export function validateSurveyStatus(status: string): SurveyStatus {
 export function validateSurveyId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Survey ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Survey ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateQuestionType(type: string): SurveyQuestionType {
   if (!SURVEY_QUESTION_TYPES.includes(type as SurveyQuestionType)) {
-    throw new Error(
-      `question type must be one of: ${SURVEY_QUESTION_TYPES.join(', ')} (got "${type}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `question type must be one of: ${SURVEY_QUESTION_TYPES.join(', ')} (got "${type}").`);
   }
   return type as SurveyQuestionType;
 }
@@ -151,22 +148,20 @@ export function validateQuestionType(type: string): SurveyQuestionType {
 export function validateQuestionText(text: string): string {
   const trimmed = text.trim();
   if (trimmed.length < MIN_QUESTION_TEXT_LENGTH) {
-    throw new Error('Question text must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Question text must not be empty.');
   }
   if (trimmed.length > MAX_QUESTION_TEXT_LENGTH) {
-    throw new Error(
-      `Question text must not exceed ${MAX_QUESTION_TEXT_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Question text must not exceed ${MAX_QUESTION_TEXT_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateQuestions(questions: SurveyQuestion[]): SurveyQuestion[] {
   if (questions.length < MIN_QUESTIONS) {
-    throw new Error(`Survey must include at least ${MIN_QUESTIONS} question.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Survey must include at least ${MIN_QUESTIONS} question.`);
   }
   if (questions.length > MAX_QUESTIONS) {
-    throw new Error(`Survey must not exceed ${MAX_QUESTIONS} questions (got ${questions.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Survey must not exceed ${MAX_QUESTIONS} questions (got ${questions.length}).`);
   }
 
   return questions.map((question) => {
@@ -174,9 +169,7 @@ export function validateQuestions(questions: SurveyQuestion[]): SurveyQuestion[]
     const text = validateQuestionText(question.text);
 
     if (question.options !== undefined && question.options.length > MAX_QUESTION_OPTIONS) {
-      throw new Error(
-        `Question options must not exceed ${MAX_QUESTION_OPTIONS} entries (got ${question.options.length}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Question options must not exceed ${MAX_QUESTION_OPTIONS} entries (got ${question.options.length}).`);
     }
 
     return {
@@ -196,9 +189,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -221,10 +214,8 @@ class CreateSurveyExecutor implements SurveyActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateSurveyExecutor: not yet implemented. ' +
-        'Survey creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateSurveyExecutor: not yet implemented. ' +
+      'Survey creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -238,10 +229,8 @@ class StartSurveyExecutor implements SurveyActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'StartSurveyExecutor: not yet implemented. ' +
-        'Starting surveys is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'StartSurveyExecutor: not yet implemented. ' +
+      'Starting surveys is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -255,10 +244,8 @@ class StopSurveyExecutor implements SurveyActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'StopSurveyExecutor: not yet implemented. ' +
-        'Stopping surveys is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'StopSurveyExecutor: not yet implemented. ' +
+      'Stopping surveys is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -272,10 +259,8 @@ class ArchiveSurveyExecutor implements SurveyActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveSurveyExecutor: not yet implemented. ' +
-        'Survey archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveSurveyExecutor: not yet implemented. ' +
+      'Survey archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -322,10 +307,8 @@ export class BloomreachSurveysService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listSurveys: the Bloomreach API does not provide a list endpoint for surveys. ' +
-        'Survey management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listSurveys: the Bloomreach API does not provide a list endpoint for surveys. ' +
+      'Survey management is only available through the Bloomreach Engagement UI.');
   }
 
   async viewSurveyResults(input: ViewSurveyResultsInput): Promise<SurveyResults> {
@@ -333,10 +316,8 @@ export class BloomreachSurveysService {
     validateSurveyId(input.surveyId);
 
     void this.apiConfig;
-    throw new Error(
-      'viewSurveyResults: the Bloomreach API does not provide a survey results endpoint. ' +
-        'Survey analytics are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewSurveyResults: the Bloomreach API does not provide a survey results endpoint. ' +
+      'Survey analytics are only available through the Bloomreach Engagement UI.');
   }
 
   prepareCreateSurvey(input: CreateSurveyInput): PreparedSurveyAction {

--- a/packages/core/src/bloomreachTagManager.ts
+++ b/packages/core/src/bloomreachTagManager.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 /** Action type for creating a managed tag. */
@@ -133,12 +134,10 @@ const MAX_PRIORITY = 1000;
 export function validateTagName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_TAG_NAME_LENGTH) {
-    throw new Error('Tag name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag name must not be empty.');
   }
   if (trimmed.length > MAX_TAG_NAME_LENGTH) {
-    throw new Error(
-      `Tag name must not exceed ${MAX_TAG_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Tag name must not exceed ${MAX_TAG_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -147,12 +146,10 @@ export function validateTagName(name: string): string {
 export function validateTagId(tagId: string): string {
   const trimmed = tagId.trim();
   if (trimmed.length === 0) {
-    throw new Error('Tag ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag ID must not be empty.');
   }
   if (trimmed.length > MAX_TAG_ID_LENGTH) {
-    throw new Error(
-      `Tag ID must not exceed ${MAX_TAG_ID_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Tag ID must not exceed ${MAX_TAG_ID_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -160,12 +157,10 @@ export function validateTagId(tagId: string): string {
 /** @throws {Error} If JS code is empty or exceeds 100000 characters. */
 export function validateJsCode(code: string): string {
   if (code.trim().length === 0) {
-    throw new Error('JS code must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'JS code must not be empty.');
   }
   if (code.length > MAX_JS_CODE_LENGTH) {
-    throw new Error(
-      `JS code must not exceed ${MAX_JS_CODE_LENGTH} characters (got ${code.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `JS code must not exceed ${MAX_JS_CODE_LENGTH} characters (got ${code.length}).`);
   }
   return code;
 }
@@ -174,7 +169,7 @@ export function validateJsCode(code: string): string {
 export function validateTagStatus(status: string): TagStatus {
   const trimmed = status.trim();
   if (!TAG_STATUSES.includes(trimmed as TagStatus)) {
-    throw new Error(`status must be one of: ${TAG_STATUSES.join(', ')} (got "${status}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${TAG_STATUSES.join(', ')} (got "${status}").`);
   }
   return trimmed as TagStatus;
 }
@@ -183,12 +178,10 @@ export function validateTagStatus(status: string): TagStatus {
 export function validatePageUrl(url: string): string {
   const trimmed = url.trim();
   if (trimmed.length === 0) {
-    throw new Error('Page URL must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page URL must not be empty.');
   }
   if (trimmed.length > MAX_PAGE_URL_LENGTH) {
-    throw new Error(
-      `Page URL must not exceed ${MAX_PAGE_URL_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Page URL must not exceed ${MAX_PAGE_URL_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -196,29 +189,27 @@ export function validatePageUrl(url: string): string {
 /** @throws {Error} If events are empty, too many, invalid, or not unique. */
 export function validateEvents(events: string[]): string[] {
   if (events.length === 0) {
-    throw new Error('Events must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Events must not be empty.');
   }
   if (events.length > MAX_EVENTS_COUNT) {
-    throw new Error(`Events must not exceed ${MAX_EVENTS_COUNT} items (got ${events.length}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Events must not exceed ${MAX_EVENTS_COUNT} items (got ${events.length}).`);
   }
 
   const validated: string[] = [];
   for (const eventName of events) {
     const trimmed = eventName.trim();
     if (trimmed.length === 0) {
-      throw new Error('Event name must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event name must not be empty.');
     }
     if (trimmed.length > MAX_EVENT_NAME_LENGTH) {
-      throw new Error(
-        `Event name must not exceed ${MAX_EVENT_NAME_LENGTH} characters (got ${trimmed.length}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event name must not exceed ${MAX_EVENT_NAME_LENGTH} characters (got ${trimmed.length}).`);
     }
     validated.push(trimmed);
   }
 
   const unique = new Set(validated);
   if (unique.size !== validated.length) {
-    throw new Error('Event names must be unique.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event names must be unique.');
   }
 
   return validated;
@@ -230,34 +221,28 @@ export function validateCustomerAttributes(
 ): Record<string, string> {
   const entries = Object.entries(attrs);
   if (entries.length === 0) {
-    throw new Error('Customer attributes must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer attributes must not be empty.');
   }
   if (entries.length > MAX_CUSTOMER_ATTRIBUTES_COUNT) {
-    throw new Error(
-      `Customer attributes must not exceed ${MAX_CUSTOMER_ATTRIBUTES_COUNT} entries (got ${entries.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Customer attributes must not exceed ${MAX_CUSTOMER_ATTRIBUTES_COUNT} entries (got ${entries.length}).`);
   }
 
   const validated: Record<string, string> = {};
   for (const [key, value] of entries) {
     const trimmedKey = key.trim();
     if (trimmedKey.length === 0) {
-      throw new Error('Customer attribute key must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer attribute key must not be empty.');
     }
     if (trimmedKey.length > MAX_ATTRIBUTE_KEY_LENGTH) {
-      throw new Error(
-        `Customer attribute key must not exceed ${MAX_ATTRIBUTE_KEY_LENGTH} characters (got ${trimmedKey.length}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Customer attribute key must not exceed ${MAX_ATTRIBUTE_KEY_LENGTH} characters (got ${trimmedKey.length}).`);
     }
 
     const trimmedValue = value.trim();
     if (trimmedValue.length === 0) {
-      throw new Error('Customer attribute value must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer attribute value must not be empty.');
     }
     if (trimmedValue.length > MAX_ATTRIBUTE_VALUE_LENGTH) {
-      throw new Error(
-        `Customer attribute value must not exceed ${MAX_ATTRIBUTE_VALUE_LENGTH} characters (got ${trimmedValue.length}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Customer attribute value must not exceed ${MAX_ATTRIBUTE_VALUE_LENGTH} characters (got ${trimmedValue.length}).`);
     }
 
     validated[trimmedKey] = trimmedValue;
@@ -292,10 +277,10 @@ export function validateTriggerConditions(
 /** @throws {Error} If priority is not a positive integer or exceeds 1000. */
 export function validatePriority(priority: number): number {
   if (!Number.isInteger(priority) || priority < 1) {
-    throw new Error('Priority must be a positive integer.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Priority must be a positive integer.');
   }
   if (priority > MAX_PRIORITY) {
-    throw new Error(`Priority must not exceed ${MAX_PRIORITY} (got ${priority}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Priority must not exceed ${MAX_PRIORITY} (got ${priority}).`);
   }
   return priority;
 }
@@ -310,9 +295,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -339,10 +324,8 @@ class CreateTagExecutor implements TagManagerActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateTagExecutor: not yet implemented. ' +
-        'Tag creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateTagExecutor: not yet implemented. ' +
+      'Tag creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -356,10 +339,8 @@ class EnableTagExecutor implements TagManagerActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EnableTagExecutor: not yet implemented. ' +
-        'Tag enabling is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EnableTagExecutor: not yet implemented. ' +
+      'Tag enabling is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -373,10 +354,8 @@ class DisableTagExecutor implements TagManagerActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DisableTagExecutor: not yet implemented. ' +
-        'Tag disabling is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DisableTagExecutor: not yet implemented. ' +
+      'Tag disabling is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -390,10 +369,8 @@ class EditTagExecutor implements TagManagerActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'EditTagExecutor: not yet implemented. ' +
-        'Tag editing is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'EditTagExecutor: not yet implemented. ' +
+      'Tag editing is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -407,10 +384,8 @@ class DeleteTagExecutor implements TagManagerActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteTagExecutor: not yet implemented. ' +
-        'Tag deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteTagExecutor: not yet implemented. ' +
+      'Tag deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -456,11 +431,9 @@ export class BloomreachTagManagerService {
       }
     }
 
-    throw new Error(
-      'listTags: the Bloomreach API does not provide an endpoint for managed tags. ' +
-        'Managed tag data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Managed Tags in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listTags: the Bloomreach API does not provide an endpoint for managed tags. ' +
+      'Managed tag data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Managed Tags in your project).');
   }
 
   /** @throws {Error} Bloomreach API does not expose managed tag details. */
@@ -469,11 +442,9 @@ export class BloomreachTagManagerService {
     validateProject(input.project);
     validateTagId(input.tagId);
 
-    throw new Error(
-      'viewTag: the Bloomreach API does not provide an endpoint for managed tag details. ' +
-        'Managed tag details must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Data & Assets > Managed Tags and open the tag).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewTag: the Bloomreach API does not provide an endpoint for managed tag details. ' +
+      'Managed tag details must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Data & Assets > Managed Tags and open the tag).');
   }
 
   /** @throws {Error} If input validation fails. */

--- a/packages/core/src/bloomreachTracking.ts
+++ b/packages/core/src/bloomreachTracking.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildTrackingPath } from './bloomreachApiClient.js';
 
@@ -97,7 +98,7 @@ export function validateTrackingCustomerIds(ids: TrackingCustomerIds): TrackingC
     (value) => typeof value === 'string' && value.trim().length > 0,
   );
   if (!hasAtLeastOne) {
-    throw new Error('At least one customer identifier must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one customer identifier must be provided.');
   }
 
   const validated: TrackingCustomerIds = {};
@@ -110,9 +111,7 @@ export function validateTrackingCustomerIds(ids: TrackingCustomerIds): TrackingC
       continue;
     }
     if (trimmed.length > MAX_FIELD_LENGTH) {
-      throw new Error(
-        `Customer identifier '${key}' must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Customer identifier '${key}' must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`);
     }
     validated[key] = trimmed;
   }
@@ -123,26 +122,22 @@ export function validateTrackingCustomerIds(ids: TrackingCustomerIds): TrackingC
 export function validateEventType(eventType: string): string {
   const trimmed = eventType.trim();
   if (trimmed.length === 0) {
-    throw new Error('Event type must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event type must not be empty.');
   }
   if (trimmed.length > MAX_FIELD_LENGTH) {
-    throw new Error(
-      `Event type must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event type must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateBatchCommands(commands: BatchCommand[]): BatchCommand[] {
   if (!Array.isArray(commands) || commands.length === 0) {
-    throw new Error('At least one batch command must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one batch command must be provided.');
   }
 
   return commands.map((command, index) => {
     if (command.name !== 'customers' && command.name !== 'customers/events') {
-      throw new Error(
-        `Batch command at index ${index} has invalid name '${String(command.name)}'. Expected 'customers' or 'customers/events'.`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Batch command at index ${index} has invalid name '${String(command.name)}'. Expected 'customers' or 'customers/events'.`);
     }
 
     if (
@@ -150,19 +145,17 @@ export function validateBatchCommands(commands: BatchCommand[]): BatchCommand[] 
       command.data === null ||
       Array.isArray(command.data)
     ) {
-      throw new Error(`Batch command at index ${index} must include a non-null data object.`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Batch command at index ${index} must include a non-null data object.`);
     }
 
     let commandId: string | undefined;
     if (command.commandId !== undefined) {
       const trimmedCommandId = command.commandId.trim();
       if (trimmedCommandId.length === 0) {
-        throw new Error(`Batch command at index ${index} has an empty commandId.`);
+        throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Batch command at index ${index} has an empty commandId.`);
       }
       if (trimmedCommandId.length > MAX_FIELD_LENGTH) {
-        throw new Error(
-          `Batch command commandId at index ${index} must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmedCommandId.length}).`,
-        );
+        throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Batch command commandId at index ${index} must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmedCommandId.length}).`);
       }
       commandId = trimmedCommandId;
     }
@@ -178,12 +171,10 @@ export function validateBatchCommands(commands: BatchCommand[]): BatchCommand[] 
 export function validateTrackingConsentCategory(category: string): string {
   const trimmed = category.trim();
   if (trimmed.length === 0) {
-    throw new Error('Consent category must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Consent category must not be empty.');
   }
   if (trimmed.length > MAX_FIELD_LENGTH) {
-    throw new Error(
-      `Consent category must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Consent category must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -191,7 +182,7 @@ export function validateTrackingConsentCategory(category: string): string {
 export function validateConsentAction(action: string): 'accept' | 'reject' {
   const normalized = action.trim().toLowerCase();
   if (normalized !== 'accept' && normalized !== 'reject') {
-    throw new Error(`Consent action must be 'accept' or 'reject' (got '${action}').`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Consent action must be 'accept' or 'reject' (got '${action}').`);
   }
   return normalized;
 }
@@ -199,12 +190,10 @@ export function validateConsentAction(action: string): 'accept' | 'reject' {
 export function validateCampaignType(campaignType: string): string {
   const trimmed = campaignType.trim();
   if (trimmed.length === 0) {
-    throw new Error('Campaign type must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign type must not be empty.');
   }
   if (trimmed.length > MAX_FIELD_LENGTH) {
-    throw new Error(
-      `Campaign type must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign type must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -212,12 +201,10 @@ export function validateCampaignType(campaignType: string): string {
 export function validateCampaignAction(action: string): string {
   const trimmed = action.trim();
   if (trimmed.length === 0) {
-    throw new Error('Campaign action must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign action must not be empty.');
   }
   if (trimmed.length > MAX_FIELD_LENGTH) {
-    throw new Error(
-      `Campaign action must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign action must not exceed ${MAX_FIELD_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -227,7 +214,7 @@ export function validateTimestamp(timestamp?: number): number | undefined {
     return undefined;
   }
   if (!Number.isFinite(timestamp) || timestamp <= 0) {
-    throw new Error('Timestamp must be a positive number when provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Timestamp must be a positive number when provided.');
   }
   return timestamp;
 }
@@ -237,7 +224,7 @@ function validateProperties(properties?: Record<string, unknown>): Record<string
     return undefined;
   }
   if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
-    throw new Error('Properties must be a non-null object.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Properties must be a non-null object.');
   }
   return properties;
 }
@@ -246,10 +233,10 @@ function validateRequiredProperties(
   properties: Record<string, unknown>,
 ): Record<string, unknown> {
   if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
-    throw new Error('Properties must be a non-null object.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Properties must be a non-null object.');
   }
   if (Object.keys(properties).length === 0) {
-    throw new Error('At least one property must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one property must be provided.');
   }
   return properties;
 }
@@ -393,9 +380,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;

--- a/packages/core/src/bloomreachTrends.ts
+++ b/packages/core/src/bloomreachTrends.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
@@ -91,21 +92,17 @@ const MIN_TREND_NAME_LENGTH = 1;
 export function validateTrendName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_TREND_NAME_LENGTH) {
-    throw new Error('Trend name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Trend name must not be empty.');
   }
   if (trimmed.length > MAX_TREND_NAME_LENGTH) {
-    throw new Error(
-      `Trend name must not exceed ${MAX_TREND_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Trend name must not exceed ${MAX_TREND_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateTrendGranularity(granularity: string): TrendGranularity {
   if (!TREND_GRANULARITIES.includes(granularity as TrendGranularity)) {
-    throw new Error(
-      `granularity must be one of: ${TREND_GRANULARITIES.join(', ')} (got "${granularity}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `granularity must be one of: ${TREND_GRANULARITIES.join(', ')} (got "${granularity}").`);
   }
   return granularity as TrendGranularity;
 }
@@ -113,7 +110,7 @@ export function validateTrendGranularity(granularity: string): TrendGranularity 
 export function validateTrendAnalysisId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Trend analysis ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Trend analysis ID must not be empty.');
   }
   return trimmed;
 }
@@ -127,9 +124,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -152,10 +149,8 @@ class CreateTrendExecutor implements TrendActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateTrendExecutor: not yet implemented. ' +
-        'Trend creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateTrendExecutor: not yet implemented. ' +
+      'Trend creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -169,10 +164,8 @@ class CloneTrendExecutor implements TrendActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneTrendExecutor: not yet implemented. ' +
-        'Trend cloning is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneTrendExecutor: not yet implemented. ' +
+      'Trend cloning is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -186,10 +179,8 @@ class ArchiveTrendExecutor implements TrendActionExecutor {
 
   async execute(_payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveTrendExecutor: not yet implemented. ' +
-        'Trend archiving is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveTrendExecutor: not yet implemented. ' +
+      'Trend archiving is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -222,11 +213,9 @@ export class BloomreachTrendsService {
       validateProject(input.project);
     }
 
-    throw new Error(
-      'listTrendAnalyses: the Bloomreach API does not provide an endpoint for trend analyses. ' +
-        'Trend data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > Trends in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listTrendAnalyses: the Bloomreach API does not provide an endpoint for trend analyses. ' +
+      'Trend data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > Trends in your project).');
   }
 
   async viewTrendResults(input: ViewTrendResultsInput): Promise<TrendResults> {
@@ -246,11 +235,9 @@ export class BloomreachTrendsService {
       validateDateRange(dateRange);
     }
 
-    throw new Error(
-      'viewTrendResults: the Bloomreach API does not provide an endpoint for trend analysis results. ' +
-        'Trend results must be viewed in the Bloomreach Engagement UI ' +
-        '(navigate to Analytics > Trends and open the analysis).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewTrendResults: the Bloomreach API does not provide an endpoint for trend analysis results. ' +
+      'Trend results must be viewed in the Bloomreach Engagement UI ' +
+      '(navigate to Analytics > Trends and open the analysis).');
   }
 
   prepareCreateTrendAnalysis(input: CreateTrendAnalysisInput): PreparedTrendAction {
@@ -261,7 +248,7 @@ export class BloomreachTrendsService {
 
     const events = input.events.map((event) => event.trim()).filter(Boolean);
     if (events.length === 0) {
-      throw new Error('events must contain at least one event name.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'events must contain at least one event name.');
     }
 
     const preview = {

--- a/packages/core/src/bloomreachUseCases.ts
+++ b/packages/core/src/bloomreachUseCases.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const DEPLOY_USE_CASE_ACTION_TYPE = 'use_cases.deploy';
@@ -92,7 +93,7 @@ export interface PreparedUseCaseAction {
 export function validateUseCaseId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Use case ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Use case ID must not be empty.');
   }
   return trimmed;
 }
@@ -100,23 +101,21 @@ export function validateUseCaseId(id: string): string {
 export function validateUseCaseSearchQuery(query: string): string {
   const trimmed = query.trim();
   if (trimmed.length === 0) {
-    throw new Error('Search query must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Search query must not be empty.');
   }
   return trimmed;
 }
 
 export function validateGoalCategory(category: string): UseCaseGoalCategory {
   if (!USE_CASE_GOAL_CATEGORIES.includes(category as UseCaseGoalCategory)) {
-    throw new Error(
-      `category must be one of: ${USE_CASE_GOAL_CATEGORIES.join(', ')} (got "${category}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `category must be one of: ${USE_CASE_GOAL_CATEGORIES.join(', ')} (got "${category}").`);
   }
   return category as UseCaseGoalCategory;
 }
 
 export function validateUseCaseTag(tag: string): UseCaseTag {
   if (!USE_CASE_TAGS.includes(tag as UseCaseTag)) {
-    throw new Error(`tag must be one of: ${USE_CASE_TAGS.join(', ')} (got "${tag}").`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `tag must be one of: ${USE_CASE_TAGS.join(', ')} (got "${tag}").`);
   }
   return tag as UseCaseTag;
 }
@@ -130,9 +129,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -157,10 +156,8 @@ class DeployUseCaseExecutor implements UseCaseActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeployUseCaseExecutor: not yet implemented. ' +
-        'Use case deployment is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeployUseCaseExecutor: not yet implemented. ' +
+      'Use case deployment is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -176,10 +173,8 @@ class FavoriteUseCaseExecutor implements UseCaseActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'FavoriteUseCaseExecutor: not yet implemented. ' +
-        'Use case favoriting is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'FavoriteUseCaseExecutor: not yet implemented. ' +
+      'Use case favoriting is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -195,10 +190,8 @@ class UnfavoriteUseCaseExecutor implements UseCaseActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'UnfavoriteUseCaseExecutor: not yet implemented. ' +
-        'Use case unfavoriting is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'UnfavoriteUseCaseExecutor: not yet implemented. ' +
+      'Use case unfavoriting is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -245,11 +238,9 @@ export class BloomreachUseCasesService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listUseCases: the Bloomreach API does not provide a use case listing endpoint. ' +
-        'Use case data must be obtained from the Bloomreach Engagement UI ' +
-        '(navigate to Use Case Center in your project).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listUseCases: the Bloomreach API does not provide a use case listing endpoint. ' +
+      'Use case data must be obtained from the Bloomreach Engagement UI ' +
+      '(navigate to Use Case Center in your project).');
   }
 
   async searchUseCases(input: SearchUseCasesInput): Promise<BloomreachUseCase[]> {
@@ -263,10 +254,8 @@ export class BloomreachUseCasesService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'searchUseCases: the Bloomreach API does not provide a use case search endpoint. ' +
-        'Use case search is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'searchUseCases: the Bloomreach API does not provide a use case search endpoint. ' +
+      'Use case search is only available through the Bloomreach Engagement UI.');
   }
 
   async viewUseCase(input: ViewUseCaseInput): Promise<UseCaseDetails> {
@@ -274,10 +263,8 @@ export class BloomreachUseCasesService {
     validateUseCaseId(input.useCaseId);
 
     void this.apiConfig;
-    throw new Error(
-      'viewUseCase: the Bloomreach API does not provide a use case detail endpoint. ' +
-        'Use case details are only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewUseCase: the Bloomreach API does not provide a use case detail endpoint. ' +
+      'Use case details are only available through the Bloomreach Engagement UI.');
   }
 
   async listProjectUseCases(
@@ -288,10 +275,8 @@ export class BloomreachUseCasesService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listProjectUseCases: the Bloomreach API does not provide a project use case listing endpoint. ' +
-        'Project use case data is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listProjectUseCases: the Bloomreach API does not provide a project use case listing endpoint. ' +
+      'Project use case data is only available through the Bloomreach Engagement UI.');
   }
 
   prepareDeployUseCase(input: DeployUseCaseInput): PreparedUseCaseAction {

--- a/packages/core/src/bloomreachVouchers.ts
+++ b/packages/core/src/bloomreachVouchers.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import {
   validateListLimit as validateVoucherListLimit,
@@ -109,12 +110,10 @@ const MAX_REDEMPTIONS_LIMIT = 1_000_000;
 export function validatePoolName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_POOL_NAME_LENGTH) {
-    throw new Error('Pool name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Pool name must not be empty.');
   }
   if (trimmed.length > MAX_POOL_NAME_LENGTH) {
-    throw new Error(
-      `Pool name must not exceed ${MAX_POOL_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Pool name must not exceed ${MAX_POOL_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -123,12 +122,10 @@ export function validatePoolName(name: string): string {
 export function validatePoolId(poolId: string): string {
   const trimmed = poolId.trim();
   if (trimmed.length === 0) {
-    throw new Error('Pool ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Pool ID must not be empty.');
   }
   if (trimmed.length > MAX_POOL_ID_LENGTH) {
-    throw new Error(
-      `Pool ID must not exceed ${MAX_POOL_ID_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Pool ID must not exceed ${MAX_POOL_ID_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
@@ -136,29 +133,25 @@ export function validatePoolId(poolId: string): string {
 /** @throws {Error} If any voucher code is empty, exceeds 200 chars, or batch exceeds 10,000. */
 export function validateVoucherCodes(codes: string[]): string[] {
   if (codes.length === 0) {
-    throw new Error('At least one voucher code must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one voucher code must be provided.');
   }
   if (codes.length > MAX_VOUCHER_CODES_PER_BATCH) {
-    throw new Error(
-      `Voucher code batch must not exceed ${MAX_VOUCHER_CODES_PER_BATCH} codes (got ${codes.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Voucher code batch must not exceed ${MAX_VOUCHER_CODES_PER_BATCH} codes (got ${codes.length}).`);
   }
   const validated: string[] = [];
   for (const code of codes) {
     const trimmed = code.trim();
     if (trimmed.length === 0) {
-      throw new Error('Voucher code must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Voucher code must not be empty.');
     }
     if (trimmed.length > MAX_VOUCHER_CODE_LENGTH) {
-      throw new Error(
-        `Voucher code must not exceed ${MAX_VOUCHER_CODE_LENGTH} characters (got ${trimmed.length}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Voucher code must not exceed ${MAX_VOUCHER_CODE_LENGTH} characters (got ${trimmed.length}).`);
     }
     validated.push(trimmed);
   }
   const unique = new Set(validated);
   if (unique.size !== validated.length) {
-    throw new Error('Voucher codes must be unique within a batch.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Voucher codes must be unique within a batch.');
   }
   return validated;
 }
@@ -166,12 +159,10 @@ export function validateVoucherCodes(codes: string[]): string[] {
 /** @throws {Error} If count is not a positive integer or exceeds 100,000. */
 export function validateAutoGenerateCount(count: number): number {
   if (!Number.isInteger(count) || count < 1) {
-    throw new Error('Auto-generate count must be a positive integer.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Auto-generate count must be a positive integer.');
   }
   if (count > MAX_AUTO_GENERATE_COUNT) {
-    throw new Error(
-      `Auto-generate count must not exceed ${MAX_AUTO_GENERATE_COUNT} (got ${count}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Auto-generate count must not exceed ${MAX_AUTO_GENERATE_COUNT} (got ${count}).`);
   }
   return count;
 }
@@ -180,22 +171,20 @@ export function validateAutoGenerateCount(count: number): number {
 export function validateRedemptionRules(rules: RedemptionRules): RedemptionRules {
   if (rules.maxRedemptions !== undefined) {
     if (!Number.isInteger(rules.maxRedemptions) || rules.maxRedemptions < 1) {
-      throw new Error('Max redemptions must be a positive integer.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Max redemptions must be a positive integer.');
     }
     if (rules.maxRedemptions > MAX_REDEMPTIONS_LIMIT) {
-      throw new Error(
-        `Max redemptions must not exceed ${MAX_REDEMPTIONS_LIMIT} (got ${rules.maxRedemptions}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Max redemptions must not exceed ${MAX_REDEMPTIONS_LIMIT} (got ${rules.maxRedemptions}).`);
     }
   }
   if (rules.expiresAt !== undefined) {
     const trimmed = rules.expiresAt.trim();
     if (trimmed.length === 0) {
-      throw new Error('Expiration date must not be empty.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Expiration date must not be empty.');
     }
     const parsed = Date.parse(trimmed);
     if (isNaN(parsed)) {
-      throw new Error('Expiration date must be a valid ISO-8601 date string.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Expiration date must be a valid ISO-8601 date string.');
     }
   }
   return rules;
@@ -210,18 +199,14 @@ export function validateVoucherSource(
     (voucherCodes === undefined || voucherCodes.length === 0) &&
     autoGenerateCount === undefined
   ) {
-    throw new Error(
-      'Either voucher codes or auto-generate count must be provided.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Either voucher codes or auto-generate count must be provided.');
   }
   if (
     voucherCodes !== undefined &&
     voucherCodes.length > 0 &&
     autoGenerateCount !== undefined
   ) {
-    throw new Error(
-      'Provide either voucher codes or auto-generate count, not both.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Provide either voucher codes or auto-generate count, not both.');
   }
 }
 
@@ -234,9 +219,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -265,10 +250,8 @@ class CreateVoucherPoolExecutor implements VoucherActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateVoucherPoolExecutor: not yet implemented. ' +
-        'Voucher pool creation is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateVoucherPoolExecutor: not yet implemented. ' +
+      'Voucher pool creation is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -284,10 +267,8 @@ class AddVouchersExecutor implements VoucherActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'AddVouchersExecutor: not yet implemented. ' +
-        'Adding vouchers to a pool is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'AddVouchersExecutor: not yet implemented. ' +
+      'Adding vouchers to a pool is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -303,10 +284,8 @@ class DeleteVoucherPoolExecutor implements VoucherActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'DeleteVoucherPoolExecutor: not yet implemented. ' +
-        'Voucher pool deletion is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'DeleteVoucherPoolExecutor: not yet implemented. ' +
+      'Voucher pool deletion is only available through the Bloomreach Engagement UI.', { not_implemented: true });
   }
 }
 
@@ -350,10 +329,8 @@ export class BloomreachVouchersService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listVoucherPools: the Bloomreach API does not provide a voucher pool listing endpoint. ' +
-        'Voucher pool management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listVoucherPools: the Bloomreach API does not provide a voucher pool listing endpoint. ' +
+      'Voucher pool management is only available through the Bloomreach Engagement UI.');
   }
 
   /** @throws {Error} Browser automation not yet available. */
@@ -362,10 +339,8 @@ export class BloomreachVouchersService {
     validatePoolId(input.poolId);
 
     void this.apiConfig;
-    throw new Error(
-      'viewVoucherStatus: the Bloomreach API does not provide a voucher status endpoint. ' +
-        'Voucher pool management is only available through the Bloomreach Engagement UI.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewVoucherStatus: the Bloomreach API does not provide a voucher status endpoint. ' +
+      'Voucher pool management is only available through the Bloomreach Engagement UI.');
   }
 
   /** @throws {Error} If input validation fails. */

--- a/packages/core/src/bloomreachWeblayers.ts
+++ b/packages/core/src/bloomreachWeblayers.ts
@@ -1,4 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
+import { BloomreachBuddyError } from './errors.js';
 import {
   bloomreachApiFetch,
   buildWebxpPath,
@@ -151,21 +152,17 @@ const MAX_AB_TEST_VARIANTS = 10;
 export function validateWeblayerName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < MIN_WEBLAYER_NAME_LENGTH) {
-    throw new Error('Weblayer name must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Weblayer name must not be empty.');
   }
   if (trimmed.length > MAX_WEBLAYER_NAME_LENGTH) {
-    throw new Error(
-      `Weblayer name must not exceed ${MAX_WEBLAYER_NAME_LENGTH} characters (got ${trimmed.length}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Weblayer name must not exceed ${MAX_WEBLAYER_NAME_LENGTH} characters (got ${trimmed.length}).`);
   }
   return trimmed;
 }
 
 export function validateWeblayerStatus(status: string): WeblayerStatus {
   if (!WEBLAYER_STATUSES.includes(status as WeblayerStatus)) {
-    throw new Error(
-      `status must be one of: ${WEBLAYER_STATUSES.join(', ')} (got "${status}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${WEBLAYER_STATUSES.join(', ')} (got "${status}").`);
   }
   return status as WeblayerStatus;
 }
@@ -173,7 +170,7 @@ export function validateWeblayerStatus(status: string): WeblayerStatus {
 export function validateWeblayerId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Weblayer ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Weblayer ID must not be empty.');
   }
   return trimmed;
 }
@@ -181,18 +178,18 @@ export function validateWeblayerId(id: string): string {
 export function validateBanditId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Bandit ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Bandit ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateVariants(variants: WeblayerVariant[]): WeblayerVariant[] {
   if (!Array.isArray(variants) || variants.length === 0) {
-    throw new Error('At least one variant must be provided.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one variant must be provided.');
   }
   for (const v of variants) {
     if (typeof v.id !== 'string' || v.id.trim().length === 0) {
-      throw new Error('Each variant must have a non-empty id.');
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Each variant must have a non-empty id.');
     }
   }
   return variants;
@@ -201,16 +198,14 @@ export function validateVariants(variants: WeblayerVariant[]): WeblayerVariant[]
 export function validateVariantId(id: string): string {
   const trimmed = id.trim();
   if (trimmed.length === 0) {
-    throw new Error('Variant ID must not be empty.');
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Variant ID must not be empty.');
   }
   return trimmed;
 }
 
 export function validateWeblayerDisplayType(displayType: string): WeblayerDisplayType {
   if (!WEBLAYER_DISPLAY_TYPES.includes(displayType as WeblayerDisplayType)) {
-    throw new Error(
-      `displayType must be one of: ${WEBLAYER_DISPLAY_TYPES.join(', ')} (got "${displayType}").`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `displayType must be one of: ${WEBLAYER_DISPLAY_TYPES.join(', ')} (got "${displayType}").`);
   }
   return displayType as WeblayerDisplayType;
 }
@@ -221,15 +216,11 @@ export function validateWeblayerABTestConfig(config: WeblayerABTestConfig): Webl
     config.variants < MIN_AB_TEST_VARIANTS ||
     config.variants > MAX_AB_TEST_VARIANTS
   ) {
-    throw new Error(
-      `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${config.variants}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${config.variants}).`);
   }
   if (config.splitPercentage !== undefined) {
     if (config.splitPercentage < 0 || config.splitPercentage > 100) {
-      throw new Error(
-        `A/B test split percentage must be between 0 and 100 (got ${config.splitPercentage}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test split percentage must be between 0 and 100 (got ${config.splitPercentage}).`);
     }
   }
   return config;
@@ -239,19 +230,15 @@ export function validateDisplayConditions(
   conditions: WeblayerDisplayConditions,
 ): WeblayerDisplayConditions {
   if (conditions.delayMs !== undefined && conditions.delayMs < 0) {
-    throw new Error(`delayMs must be greater than or equal to 0 (got ${conditions.delayMs}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `delayMs must be greater than or equal to 0 (got ${conditions.delayMs}).`);
   }
   if (conditions.scrollPercentage !== undefined) {
     if (conditions.scrollPercentage < 0 || conditions.scrollPercentage > 100) {
-      throw new Error(
-        `scrollPercentage must be between 0 and 100 (got ${conditions.scrollPercentage}).`,
-      );
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `scrollPercentage must be between 0 and 100 (got ${conditions.scrollPercentage}).`);
     }
   }
   if (conditions.frequencyCap !== undefined && conditions.frequencyCap < 1) {
-    throw new Error(
-      `frequencyCap must be greater than or equal to 1 (got ${conditions.frequencyCap}).`,
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `frequencyCap must be greater than or equal to 1 (got ${conditions.frequencyCap}).`);
   }
   return conditions;
 }
@@ -265,9 +252,9 @@ function requireApiConfig(
   operation: string,
 ): BloomreachApiConfig {
   if (!config) {
-    throw new Error(
-      `${operation} requires API credentials. ` +
-        'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+    throw new BloomreachBuddyError('CONFIG_MISSING', `${operation} requires API credentials. ` +
+      'Set BLOOMREACH_PROJECT_TOKEN, BLOOMREACH_API_KEY_ID, and BLOOMREACH_API_SECRET environment variables.',
+      { missing: ['BLOOMREACH_PROJECT_TOKEN', 'BLOOMREACH_API_KEY_ID', 'BLOOMREACH_API_SECRET'] },
     );
   }
   return config;
@@ -290,11 +277,9 @@ class CreateWeblayerExecutor implements WeblayerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CreateWeblayerExecutor: not yet implemented. ' +
-        'Weblayer creation is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
-        'For real-time personalization, use getBestVariant and reportReward methods.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CreateWeblayerExecutor: not yet implemented. ' +
+      'Weblayer creation is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
+      'For real-time personalization, use getBestVariant and reportReward methods.', { not_implemented: true });
   }
 }
 
@@ -310,11 +295,9 @@ class StartWeblayerExecutor implements WeblayerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'StartWeblayerExecutor: not yet implemented. ' +
-        'Weblayer activation is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
-        'For real-time personalization, use getBestVariant and reportReward methods.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'StartWeblayerExecutor: not yet implemented. ' +
+      'Weblayer activation is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
+      'For real-time personalization, use getBestVariant and reportReward methods.', { not_implemented: true });
   }
 }
 
@@ -330,11 +313,9 @@ class StopWeblayerExecutor implements WeblayerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'StopWeblayerExecutor: not yet implemented. ' +
-        'Weblayer deactivation is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
-        'For real-time personalization, use getBestVariant and reportReward methods.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'StopWeblayerExecutor: not yet implemented. ' +
+      'Weblayer deactivation is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
+      'For real-time personalization, use getBestVariant and reportReward methods.', { not_implemented: true });
   }
 }
 
@@ -350,11 +331,9 @@ class CloneWeblayerExecutor implements WeblayerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'CloneWeblayerExecutor: not yet implemented. ' +
-        'Weblayer cloning is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
-        'For real-time personalization, use getBestVariant and reportReward methods.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'CloneWeblayerExecutor: not yet implemented. ' +
+      'Weblayer cloning is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
+      'For real-time personalization, use getBestVariant and reportReward methods.', { not_implemented: true });
   }
 }
 
@@ -370,11 +349,9 @@ class ArchiveWeblayerExecutor implements WeblayerActionExecutor {
     _payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     void this.apiConfig;
-    throw new Error(
-      'ArchiveWeblayerExecutor: not yet implemented. ' +
-        'Weblayer archiving is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
-        'For real-time personalization, use getBestVariant and reportReward methods.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'ArchiveWeblayerExecutor: not yet implemented. ' +
+      'Weblayer archiving is only available through the Bloomreach Engagement UI: Campaigns > Web layers. ' +
+      'For real-time personalization, use getBestVariant and reportReward methods.', { not_implemented: true });
   }
 }
 
@@ -412,11 +389,9 @@ export class BloomreachWeblayersService {
     }
 
     void this.apiConfig;
-    throw new Error(
-      'listWeblayers: the Bloomreach API does not provide a weblayer listing endpoint. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Web layers. ' +
-        'For personalization, use getBestVariant and reportReward methods (API-backed).',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'listWeblayers: the Bloomreach API does not provide a weblayer listing endpoint. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Web layers. ' +
+      'For personalization, use getBestVariant and reportReward methods (API-backed).');
   }
 
   async viewWeblayerPerformance(
@@ -426,10 +401,8 @@ export class BloomreachWeblayersService {
     validateWeblayerId(input.weblayerId);
 
     void this.apiConfig;
-    throw new Error(
-      'viewWeblayerPerformance: the Bloomreach API does not provide a weblayer performance endpoint. ' +
-        'Use the Bloomreach Engagement UI: Campaigns > Web layers > [weblayer] > Results.',
-    );
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'viewWeblayerPerformance: the Bloomreach API does not provide a weblayer performance endpoint. ' +
+      'Use the Bloomreach Engagement UI: Campaigns > Web layers > [weblayer] > Results.');
   }
 
   prepareCreateWeblayer(input: CreateWeblayerInput): PreparedWeblayerAction {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+export const ERROR_CODES = [
+  'CONFIG_MISSING', // Missing API credentials or configuration
+  'AUTH_REQUIRED', // Dashboard session expired or missing
+  'CAPTCHA_OR_CHALLENGE', // Bot detection challenge encountered
+  'RATE_LIMITED', // Rate limit exceeded
+  'SESSION_EXPIRED', // Stored browser session expired
+  'PROFILE_LOCKED', // Browser profile locked by another process
+  'UI_CHANGED_SELECTOR_FAILED', // Dashboard UI changed, selectors broken
+  'NETWORK_ERROR', // Network connectivity issue
+  'TIMEOUT', // Operation timed out
+  'API_ERROR', // Non-2xx API response
+  'TARGET_NOT_FOUND', // Requested resource not found
+  'ACTION_PRECONDITION_FAILED', // Invalid input or state
+  'UNKNOWN', // Unclassified error
+] as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[number];
+
+/**
+ * Backward-compatible alias for {@link ErrorCode}.
+ * Prefer `ErrorCode` in new code.
+ */
+export type BloomreachErrorCode = ErrorCode;
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+/**
+ * Base error class for all Bloomreach Buddy errors.
+ * Every error carries a machine-readable `code` and an optional `details`
+ * bag for structured context (missing fields, UI URLs, etc.).
+ */
+export class BloomreachBuddyError extends Error {
+  readonly code: ErrorCode;
+  readonly details: Record<string, unknown>;
+
+  constructor(
+    code: ErrorCode,
+    message: string,
+    details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'BloomreachBuddyError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/**
+ * Thrown on non-2xx API responses. Carries the HTTP status code and the
+ * parsed (or raw) response body for inspection.
+ */
+export class BloomreachApiError extends BloomreachBuddyError {
+  readonly statusCode: number;
+  readonly responseBody: unknown;
+
+  constructor(message: string, statusCode: number, responseBody: unknown) {
+    super('API_ERROR', message, { statusCode, responseBody });
+    this.name = 'BloomreachApiError';
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error serialization
+// ---------------------------------------------------------------------------
+
+export interface ErrorPayload {
+  code: ErrorCode | 'UNKNOWN';
+  message: string;
+  details: Record<string, unknown>;
+}
+
+/**
+ * Convert any caught value into a structured, serializable error payload.
+ * Preserves full fidelity for {@link BloomreachBuddyError} instances and
+ * falls back gracefully for plain `Error` or unknown values.
+ */
+export function toErrorPayload(error: unknown): ErrorPayload {
+  if (error instanceof BloomreachBuddyError) {
+    return {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      code: 'UNKNOWN',
+      message: error.message,
+      details: { cause_name: error.name },
+    };
+  }
+  return { code: 'UNKNOWN', message: String(error), details: {} };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateCredentials } from './bloomreachSetup.js';
 
+export * from './errors.js';
 export * from "./db/database.js";
 export * from "./twoPhaseCommit.js";
 export * from './bloomreachCampaignCalendar.js';

--- a/packages/core/src/twoPhaseCommit.ts
+++ b/packages/core/src/twoPhaseCommit.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import type { BloomreachDatabase, PreparedActionRow } from './db/database.js';
-import { BloomreachBuddyError } from './bloomreachApiClient.js';
+import { BloomreachBuddyError } from './errors.js';
 
 export const DEFAULT_TOKEN_TTL_MS = 30 * 60 * 1000;
 

--- a/packages/mcp/src/__tests__/toolResults.test.ts
+++ b/packages/mcp/src/__tests__/toolResults.test.ts
@@ -45,7 +45,7 @@ describe('toErrorResult', () => {
     const result = toErrorResult('string error');
     const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
     expect(payload.code).toBe('UNKNOWN');
-    expect(payload.message).toBe('Unknown error occurred.');
+    expect(payload.message).toBe('string error');
   });
 });
 

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import * as core from '@bloomreach-buddy/core';
 import {
+  BloomreachBuddyError,
   BloomreachDatabase,
   TwoPhaseCommitService,
   type ActionExecutor,
@@ -113,7 +114,7 @@ function getProject(args: Record<string, unknown>): string {
   const projectFromArgs = typeof args.project === 'string' ? args.project.trim() : '';
   const project = projectFromArgs || projectId.trim();
   if (!project) {
-    throw new Error('Missing project. Provide `project` argument or BLOOMREACH_PROJECT env var.');
+    throw new BloomreachBuddyError('CONFIG_MISSING', 'Missing project. Provide `project` argument or BLOOMREACH_PROJECT env var.', { missing: ['BLOOMREACH_PROJECT'] });
   }
   return project;
 }
@@ -122,7 +123,7 @@ function getServiceConstructor(serviceClass: string): ServiceConstructor {
   const coreExports = core as unknown as Record<string, unknown>;
   const candidate = coreExports[serviceClass];
   if (typeof candidate !== 'function') {
-    throw new Error(`Missing service constructor: ${serviceClass}`);
+    throw new BloomreachBuddyError('TARGET_NOT_FOUND', `Missing service constructor: ${serviceClass}`);
   }
   return candidate as ServiceConstructor;
 }
@@ -6209,7 +6210,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const service = new ServiceCtor(project, apiConfig);
     const methodCandidate = service[route.methodName];
     if (typeof methodCandidate !== 'function') {
-      throw new Error(`Service method not found: ${route.serviceClass}.${route.methodName}`);
+      throw new BloomreachBuddyError('TARGET_NOT_FOUND', `Service method not found: ${route.serviceClass}.${route.methodName}`);
     }
 
     const result = await Promise.resolve(

--- a/packages/mcp/src/toolArgs.ts
+++ b/packages/mcp/src/toolArgs.ts
@@ -1,3 +1,5 @@
+import { BloomreachBuddyError } from "@bloomreach-buddy/core";
+
 export type ToolArgs = Record<string, unknown>;
 
 export function readString(args: ToolArgs, key: string, fallback: string): string {
@@ -19,7 +21,7 @@ export function readRequiredString(args: ToolArgs, key: string): string {
   if (typeof value === 'string' && value.trim().length > 0) {
     return value.trim();
   }
-  throw new Error(`${key} is required.`);
+  throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} is required.`);
 }
 
 export function readBoundedString(
@@ -32,7 +34,7 @@ export function readBoundedString(
     typeof fallback === 'string' ? readString(args, key, fallback) : readRequiredString(args, key);
 
   if (value.length > maxLength) {
-    throw new Error(`${key} must be ${maxLength} characters or fewer.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} must be ${maxLength} characters or fewer.`);
   }
 
   return value;
@@ -44,7 +46,7 @@ export function readValidatedUrl(args: ToolArgs, key: string): string {
   try {
     return new URL(value).toString();
   } catch (error) {
-    throw new Error(
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED',
       `${key} must be a valid URL. ${error instanceof Error ? error.message : String(error)}`,
     );
   }
@@ -57,7 +59,7 @@ export function readPositiveNumber(args: ToolArgs, key: string, fallback: number
   }
 
   if (!Number.isFinite(value) || value <= 0) {
-    throw new Error(`${key} must be a positive number.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} must be a positive number.`);
   }
 
   return value;
@@ -70,7 +72,7 @@ export function readNonNegativeNumber(args: ToolArgs, key: string, fallback: num
   }
 
   if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`${key} must be zero or a positive number.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} must be zero or a positive number.`);
   }
 
   return value;
@@ -87,7 +89,7 @@ export function readRequiredBoolean(args: ToolArgs, key: string): boolean {
     return value;
   }
 
-  throw new Error(`${key} is required.`);
+  throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} is required.`);
 }
 
 export function readOptionalPositiveNumber(args: ToolArgs, key: string): number | undefined {
@@ -110,7 +112,7 @@ export function readOptionalNonNegativeNumber(args: ToolArgs, key: string): numb
     !Number.isInteger(value) ||
     value < 0
   ) {
-    throw new Error(`${key} must be a non-negative integer.`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} must be a non-negative integer.`);
   }
 
   return value;
@@ -134,7 +136,7 @@ export function readStringArray(args: ToolArgs, key: string): string[] | undefin
     return items.length > 0 ? items : undefined;
   }
 
-  throw new Error(`${key} must be a string or array of strings.`);
+  throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} must be a string or array of strings.`);
 }
 
 export function readRequiredStringArray(args: ToolArgs, key: string): string[] {
@@ -143,7 +145,7 @@ export function readRequiredStringArray(args: ToolArgs, key: string): string[] {
     return values;
   }
 
-  throw new Error(`${key} is required.`);
+  throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} is required.`);
 }
 
 export function readObject(args: ToolArgs, key: string): Record<string, unknown> | undefined {
@@ -156,5 +158,5 @@ export function readObject(args: ToolArgs, key: string): Record<string, unknown>
     return value as Record<string, unknown>;
   }
 
-  throw new Error(`${key} must be an object.`);
+  throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${key} must be an object.`);
 }

--- a/packages/mcp/src/toolResults.ts
+++ b/packages/mcp/src/toolResults.ts
@@ -1,4 +1,4 @@
-import { BloomreachBuddyError } from '@bloomreach-buddy/core';
+import { BloomreachBuddyError, toErrorPayload } from '@bloomreach-buddy/core';
 import type { ToolArgs } from './toolArgs.js';
 
 export type ToolResult = { content: Array<{ type: 'text'; text: string }> };
@@ -39,8 +39,12 @@ export function buildRecoveryHint(error: unknown): string {
       return 'Bloomreach rate limit reached. Wait for the rate-limit window to reset before retrying.';
     case 'API_ERROR':
       return 'Bloomreach API returned an error response. Check input parameters and project permissions, then retry.';
-    case 'ACTION_PRECONDITION_FAILED':
-      return 'Action precondition not met. The confirm token may be expired, already used, or invalid. Prepare a new action and retry.';
+    case 'ACTION_PRECONDITION_FAILED': {
+      if (error.details.not_implemented) {
+        return 'This feature is not yet available through the API. Visit the Bloomreach Engagement UI to perform this action manually.';
+      }
+      return 'Action precondition not met. Verify input parameters and retry with corrected values.';
+    }
     case 'TARGET_NOT_FOUND':
       return 'The requested resource was not found. Verify the identifier and retry.';
     case 'NETWORK_ERROR':
@@ -59,12 +63,10 @@ export function buildRecoveryHint(error: unknown): string {
 }
 
 export function toErrorResult(error: unknown): ToolErrorResult {
-  const code = isBloomreachError(error) ? error.code : 'UNKNOWN';
-  const message = error instanceof Error ? error.message : 'Unknown error occurred.';
+  const payload = toErrorPayload(error);
 
-  const errorPayload = {
-    code,
-    message,
+  const errorResponse = {
+    ...payload,
     recovery_hint: buildRecoveryHint(error),
   };
 
@@ -73,7 +75,7 @@ export function toErrorResult(error: unknown): ToolErrorResult {
     content: [
       {
         type: 'text',
-        text: JSON.stringify(errorPayload, null, 2),
+        text: JSON.stringify(errorResponse, null, 2),
       },
     ],
   };

--- a/packages/mcp/src/toolSchema.ts
+++ b/packages/mcp/src/toolSchema.ts
@@ -1,3 +1,5 @@
+import { BloomreachBuddyError } from "@bloomreach-buddy/core";
+
 export type BloomreachMcpSchemaPrimitiveType =
   | 'array'
   | 'boolean'
@@ -85,7 +87,7 @@ export function throwToolSchemaValidationError(
   details: Record<string, unknown> = {},
 ): never {
   void details;
-  throw new Error(`${formatToolSchemaPath(path)} ${message}`);
+  throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${formatToolSchemaPath(path)} ${message}`);
 }
 
 export function validateToolArgEnum(


### PR DESCRIPTION
## Summary

Fixes #180 — Standardizes error handling across the entire codebase to use `BloomreachBuddyError` with structured error codes, details, and recovery hints.

## Changes

### New: `packages/core/src/errors.ts`
- Canonical error class location per ARCHITECTURE.md spec
- `ERROR_CODES` const array with 13 error codes
- `BloomreachBuddyError` with `details: Record<string, unknown>` field
- `BloomreachApiError` subclass
- `toErrorPayload()` serialization function

### Converted: 692 `throw new Error()` → `BloomreachBuddyError`
- **39 service files** in `packages/core/src/` — zero plain `Error` throws remaining
- **4 MCP files** (`toolArgs.ts`, `toolSchema.ts`, `toolResults.ts`, `bloomreach-mcp.ts`)
- **1 CLI file** (`bloomreach.ts`)

### Error code mapping
| Error pattern | Error code | Details |
|---|---|---|
| Input validation failures | `ACTION_PRECONDITION_FAILED` | — |
| Missing API credentials | `CONFIG_MISSING` | `{ missing: ['BLOOMREACH_PROJECT_TOKEN', ...] }` |
| Not-yet-implemented features | `ACTION_PRECONDITION_FAILED` | `{ not_implemented: true }` |
| Unexpected API response format | `API_ERROR` | — |
| Missing service/method | `TARGET_NOT_FOUND` | — |

### MCP structured error payloads
Every error now returns:
```json
{
  "code": "CONFIG_MISSING",
  "message": "...",
  "details": { "missing": ["BLOOMREACH_PROJECT_TOKEN", ...] },
  "recovery_hint": "Missing API credentials. Set BLOOMREACH_PROJECT_TOKEN, ..."
}
```

Recovery hints are context-aware — `not_implemented` errors suggest visiting the Bloomreach Engagement UI.

## Test results
- ✅ 9738/9738 tests pass (9644 core + 94 MCP)
- ✅ TypeScript typecheck clean
- ✅ ESLint clean
- ✅ Build succeeds

## Backward compatibility
- `BloomreachBuddyError` and `BloomreachApiError` are re-exported from `bloomreachApiClient.ts` for import compatibility
- `BloomreachErrorCode` type alias preserved
- All error messages unchanged — existing `.toThrow('substring')` test assertions continue to pass

Closes #180
