### PR TITLE
feat: add MCP tools for Bloomreach Recommendations (#182)

### DIFF
--- a/packages/mcp/src/__tests__/toolConstants.test.ts
+++ b/packages/mcp/src/__tests__/toolConstants.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { BLOOMREACH_MCP_TOOL_NAMES } from '../index.js';
 
 describe('tool constants', () => {
-  it('exports 262 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
-    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(262);
+  it('exports 267 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(267);
   });
 
   it('all tool names follow bloomreach.<domain>.<action> dot-notation', () => {
@@ -46,7 +46,7 @@ describe('tool constants', () => {
     }
   });
 
-  it('covers all 34 expected service domains', () => {
+  it('covers all 35 expected service domains', () => {
     const domains = new Set(BLOOMREACH_MCP_TOOL_NAMES.map((name) => name.split('.')[1]));
     const expectedDomains = [
       'actions',
@@ -70,6 +70,7 @@ describe('tool constants', () => {
       'metrics',
       'performance',
       'project_settings',
+      'recommendations',
       'reports',
       'retentions',
       'scenarios',

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -6118,6 +6118,174 @@ const tools: ToolRoute[] = [
     serviceClass: 'BloomreachTrackingService',
     methodName: 'prepareTrackCampaign',
   },
+  {
+    name: toolNames.BLOOMREACH_RECOMMENDATIONS_LIST_TOOL,
+    description:
+      'List recommendation models in the project, optionally filtered by status. Returns model metadata including name, status, algorithm, and URL. ⚠️ Not yet available — coming in a future release.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description:
+            'Bloomreach project identifier. Defaults to BLOOMREACH_PROJECT when omitted.',
+        },
+        status: {
+          type: 'string',
+          description:
+            'Filter by model status: active, inactive, training, or draft.',
+        },
+      },
+      required: ['project'],
+      additionalProperties: true,
+    },
+    serviceClass: 'BloomreachRecommendationsService',
+    methodName: 'listRecommendationModels',
+  },
+  {
+    name: toolNames.BLOOMREACH_RECOMMENDATIONS_VIEW_PERFORMANCE_TOOL,
+    description:
+      'View performance metrics of a recommendation model including impressions, clicks, CTR, conversions, revenue, and average order value. ⚠️ Not yet available — coming in a future release.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description:
+            'Bloomreach project identifier. Defaults to BLOOMREACH_PROJECT when omitted.',
+        },
+        modelId: {
+          type: 'string',
+          description:
+            'ID of the recommendation model. Use bloomreach.recommendations.list to find available IDs.',
+        },
+      },
+      required: ['project', 'modelId'],
+      additionalProperties: true,
+    },
+    serviceClass: 'BloomreachRecommendationsService',
+    methodName: 'viewModelPerformance',
+  },
+  {
+    name: toolNames.BLOOMREACH_RECOMMENDATIONS_PREPARE_CREATE_TOOL,
+    description:
+      'Create a new recommendation model. Returns a confirmToken — call bloomreach.actions.confirm to execute.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description:
+            'Bloomreach project identifier. Defaults to BLOOMREACH_PROJECT when omitted.',
+        },
+        name: {
+          type: 'string',
+          description: 'Display name for the recommendation model (1–200 characters).',
+        },
+        modelType: {
+          type: 'string',
+          description:
+            'Type of recommendation model (e.g. product_recommendations, category_recommendations).',
+        },
+        algorithm: {
+          type: 'string',
+          description:
+            'Recommendation algorithm: collaborative_filtering, content_based, hybrid, trending, or personalized.',
+        },
+        catalogId: {
+          type: 'string',
+          description: 'Catalog ID to use for recommendations.',
+        },
+        operatorNote: {
+          type: 'string',
+          description: 'Optional note describing the reason for this action.',
+        },
+      },
+      required: ['project', 'name', 'modelType'],
+      additionalProperties: true,
+    },
+    serviceClass: 'BloomreachRecommendationsService',
+    methodName: 'prepareCreateRecommendationModel',
+  },
+  {
+    name: toolNames.BLOOMREACH_RECOMMENDATIONS_PREPARE_CONFIGURE_TOOL,
+    description:
+      'Configure parameters of an existing recommendation model (algorithm, filters, boost rules, max items). Returns a confirmToken — call bloomreach.actions.confirm to execute.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description:
+            'Bloomreach project identifier. Defaults to BLOOMREACH_PROJECT when omitted.',
+        },
+        modelId: {
+          type: 'string',
+          description:
+            'ID of the recommendation model. Use bloomreach.recommendations.list to find available IDs.',
+        },
+        algorithm: {
+          type: 'string',
+          description:
+            'Recommendation algorithm: collaborative_filtering, content_based, hybrid, trending, or personalized.',
+        },
+        catalogId: {
+          type: 'string',
+          description: 'Catalog ID to use for recommendations.',
+        },
+        filters: {
+          type: 'array',
+          description:
+            'Filter rules to restrict recommended items. Each rule has field, operator, and value.',
+        },
+        boostRules: {
+          type: 'array',
+          description:
+            'Boost rules to prioritize certain items. Each rule has field and weight (0–100).',
+        },
+        maxItems: {
+          type: 'number',
+          description: 'Maximum number of items to recommend (1–100).',
+        },
+        operatorNote: {
+          type: 'string',
+          description: 'Optional note describing the reason for this action.',
+        },
+      },
+      required: ['project', 'modelId'],
+      additionalProperties: true,
+    },
+    serviceClass: 'BloomreachRecommendationsService',
+    methodName: 'prepareConfigureRecommendationModel',
+  },
+  {
+    name: toolNames.BLOOMREACH_RECOMMENDATIONS_PREPARE_DELETE_TOOL,
+    description:
+      'Delete a recommendation model. Returns a confirmToken — call bloomreach.actions.confirm to execute.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description:
+            'Bloomreach project identifier. Defaults to BLOOMREACH_PROJECT when omitted.',
+        },
+        modelId: {
+          type: 'string',
+          description:
+            'ID of the recommendation model. Use bloomreach.recommendations.list to find available IDs.',
+        },
+        operatorNote: {
+          type: 'string',
+          description: 'Optional note describing the reason for this action.',
+        },
+      },
+      required: ['project', 'modelId'],
+      additionalProperties: true,
+    },
+    serviceClass: 'BloomreachRecommendationsService',
+    methodName: 'prepareDeleteRecommendationModel',
+  },
 ];
 
 const toolByName = new Map<string, ToolRoute>(tools.map((tool) => [tool.name, tool]));

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -360,6 +360,17 @@ export const BLOOMREACH_ACCESS_PREPARE_DELETE_API_KEY_TOOL =
 export const BLOOMREACH_ACTIONS_CONFIRM_TOOL = 'bloomreach.actions.confirm';
 export const BLOOMREACH_ACTIONS_LIST_TOOL = 'bloomreach.actions.list';
 
+// --- Recommendations tools (issue #182) ---
+export const BLOOMREACH_RECOMMENDATIONS_LIST_TOOL = 'bloomreach.recommendations.list';
+export const BLOOMREACH_RECOMMENDATIONS_VIEW_PERFORMANCE_TOOL =
+  'bloomreach.recommendations.view_performance';
+export const BLOOMREACH_RECOMMENDATIONS_PREPARE_CREATE_TOOL =
+  'bloomreach.recommendations.prepare_create';
+export const BLOOMREACH_RECOMMENDATIONS_PREPARE_CONFIGURE_TOOL =
+  'bloomreach.recommendations.prepare_configure';
+export const BLOOMREACH_RECOMMENDATIONS_PREPARE_DELETE_TOOL =
+  'bloomreach.recommendations.prepare_delete';
+
 
 // --- Tracking tools (issue #177) ---
 export const BLOOMREACH_TRACKING_TRACK_EVENT_TOOL = 'bloomreach.tracking.track_event';
@@ -623,6 +634,11 @@ export const BLOOMREACH_MCP_TOOL_NAMES = [
   BLOOMREACH_ACCESS_LIST_API_KEYS_TOOL,
   BLOOMREACH_ACCESS_PREPARE_CREATE_API_KEY_TOOL,
   BLOOMREACH_ACCESS_PREPARE_DELETE_API_KEY_TOOL,
+  BLOOMREACH_RECOMMENDATIONS_LIST_TOOL,
+  BLOOMREACH_RECOMMENDATIONS_VIEW_PERFORMANCE_TOOL,
+  BLOOMREACH_RECOMMENDATIONS_PREPARE_CREATE_TOOL,
+  BLOOMREACH_RECOMMENDATIONS_PREPARE_CONFIGURE_TOOL,
+  BLOOMREACH_RECOMMENDATIONS_PREPARE_DELETE_TOOL,
   BLOOMREACH_TRACKING_TRACK_EVENT_TOOL,
   BLOOMREACH_TRACKING_TRACK_BATCH_TOOL,
   BLOOMREACH_TRACKING_TRACK_CUSTOMER_TOOL,
@@ -633,4 +649,3 @@ export const BLOOMREACH_MCP_TOOL_NAMES = [
 ] as const;
 
 export type BloomreachMcpToolName = (typeof BLOOMREACH_MCP_TOOL_NAMES)[number];
-


### PR DESCRIPTION
## Summary

Closes #182 — Registers 5 new MCP tools for the Bloomreach Recommendations feature, bridging the gap between the existing core service and the MCP server.

## Changes

- **`packages/mcp/src/index.ts`** — Added 5 tool name constants (`BLOOMREACH_RECOMMENDATIONS_*`) and included them in the `BLOOMREACH_MCP_TOOL_NAMES` array
- **`packages/mcp/src/bin/bloomreach-mcp.ts`** — Added 5 tool route definitions mapping MCP tool names → `BloomreachRecommendationsService` methods with full JSON Schema input validation
- **`packages/mcp/src/__tests__/toolConstants.test.ts`** — Updated expected tool count (262→267), domain count (34→35), and added `recommendations` to expected domains

## New MCP Tools

| Tool | Service Method | Type |
|------|---------------|------|
| `bloomreach.recommendations.list` | `listRecommendationModels` | Read |
| `bloomreach.recommendations.view_performance` | `viewModelPerformance` | Read |
| `bloomreach.recommendations.prepare_create` | `prepareCreateRecommendationModel` | Write (two-phase) |
| `bloomreach.recommendations.prepare_configure` | `prepareConfigureRecommendationModel` | Write (two-phase) |
| `bloomreach.recommendations.prepare_delete` | `prepareDeleteRecommendationModel` | Write (two-phase) |

## Quality Gates

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 4916 tests passed
- ✅ `npm run build` — success

Closes #182
