### PR TITLE
fix: add runtime null/undefined guards to all prepare_* methods (#184)

### DIFF
--- a/packages/core/src/__tests__/bloomreachCampaignSettings.test.ts
+++ b/packages/core/src/__tests__/bloomreachCampaignSettings.test.ts
@@ -2624,3 +2624,122 @@ describe('BloomreachCampaignSettingsService', () => {
     });
   });
 });
+
+describe('null/undefined input guards', () => {
+  it('throws when prepareCreateTimezone is called without name', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateTimezone({
+        project: 'test',
+        name: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateTimezone is called without project', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateTimezone({
+        project: undefined as unknown as string,
+        name: 'UTC',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateLanguage is called without name', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateLanguage({
+        project: 'test',
+        code: 'en',
+        name: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateLanguage is called without code', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateLanguage({
+        project: 'test',
+        code: undefined as unknown as string,
+        name: 'English',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateLanguage is called without project', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateLanguage({
+        project: undefined as unknown as string,
+        code: 'en',
+        name: 'English',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateFont is called without name', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateFont({
+        project: 'test',
+        name: undefined as unknown as string,
+        type: 'system',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateFont is called without project', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateFont({
+        project: undefined as unknown as string,
+        name: 'Inter',
+        type: 'system',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateThroughputPolicy is called without name', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateThroughputPolicy({
+        project: 'test',
+        name: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateThroughputPolicy is called without project', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateThroughputPolicy({
+        project: undefined as unknown as string,
+        name: 'Default Throughput',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateUrlList is called without listType', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreateUrlList({
+        project: 'test',
+        name: 'Main URLs',
+        listType: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreatePageVariable is called without value', () => {
+    const service = new BloomreachCampaignSettingsService('test');
+    expect(() =>
+      service.prepareCreatePageVariable({
+        project: 'test',
+        name: 'hero_title',
+        value: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+});

--- a/packages/core/src/__tests__/bloomreachDataManager.test.ts
+++ b/packages/core/src/__tests__/bloomreachDataManager.test.ts
@@ -1752,3 +1752,107 @@ describe('BloomreachDataManagerService - consent categories', () => {
     });
   });
 });
+
+describe('null/undefined input guards', () => {
+  it('throws when prepareAddCustomerProperty is called without name', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareAddCustomerProperty({
+        project: 'test',
+        name: undefined as unknown as string,
+        type: 'string',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareAddCustomerProperty is called without type', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareAddCustomerProperty({
+        project: 'test',
+        name: 'tier',
+        type: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareAddCustomerProperty is called without project', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareAddCustomerProperty({
+        project: undefined as unknown as string,
+        name: 'tier',
+        type: 'string',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareAddEventDefinition is called without name', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareAddEventDefinition({
+        project: 'test',
+        name: undefined as unknown as string,
+        type: 'json',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareAddEventDefinition is called without type', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareAddEventDefinition({
+        project: 'test',
+        name: 'checkout',
+        type: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareAddEventDefinition is called without project', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareAddEventDefinition({
+        project: undefined as unknown as string,
+        name: 'checkout',
+        type: 'json',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareConfigureMapping is called without sourceField', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareConfigureMapping({
+        project: 'test',
+        sourceField: undefined as unknown as string,
+        targetField: 'target',
+        transformationType: 'direct',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareConfigureMapping is called without targetField', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareConfigureMapping({
+        project: 'test',
+        sourceField: 'source',
+        targetField: undefined as unknown as string,
+        transformationType: 'direct',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareConfigureMapping is called without project', () => {
+    const service = new BloomreachDataManagerService('test');
+    expect(() =>
+      service.prepareConfigureMapping({
+        project: undefined as unknown as string,
+        sourceField: 'source',
+        targetField: 'target',
+        transformationType: 'direct',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+});

--- a/packages/core/src/__tests__/bloomreachFunnels.test.ts
+++ b/packages/core/src/__tests__/bloomreachFunnels.test.ts
@@ -14,6 +14,7 @@ import {
   createFunnelActionExecutors,
   BloomreachFunnelsService,
 } from '../index.js';
+import type { FunnelStep } from '../index.js';
 import type { BloomreachApiConfig } from '../bloomreachApiClient.js';
 
 const TEST_API_CONFIG: BloomreachApiConfig = {
@@ -1223,5 +1224,98 @@ describe('BloomreachFunnelsService', () => {
         }),
       );
     });
+  });
+});
+
+describe('null/undefined input guards', () => {
+  it('throws when prepareCreateFunnelAnalysis is called without name', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareCreateFunnelAnalysis({
+        project: 'test',
+        name: undefined as unknown as string,
+        steps: [
+          { order: 1, eventName: 'visit' },
+          { order: 2, eventName: 'purchase' },
+        ],
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateFunnelAnalysis is called without steps', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareCreateFunnelAnalysis({
+        project: 'test',
+        name: 'My Funnel',
+        steps: undefined as unknown as FunnelStep[],
+      }),
+    ).toThrow('is required and must be an array');
+  });
+
+  it('throws when prepareCreateFunnelAnalysis is called without project', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareCreateFunnelAnalysis({
+        project: undefined as unknown as string,
+        name: 'My Funnel',
+        steps: [
+          { order: 1, eventName: 'visit' },
+          { order: 2, eventName: 'purchase' },
+        ],
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCloneFunnelAnalysis is called without analysisId', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareCloneFunnelAnalysis({
+        project: 'test',
+        analysisId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCloneFunnelAnalysis is called without project', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareCloneFunnelAnalysis({
+        project: undefined as unknown as string,
+        analysisId: 'funnel-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareArchiveFunnelAnalysis is called without analysisId', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareArchiveFunnelAnalysis({
+        project: 'test',
+        analysisId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareArchiveFunnelAnalysis is called without project', () => {
+    const service = new BloomreachFunnelsService('test');
+    expect(() =>
+      service.prepareArchiveFunnelAnalysis({
+        project: undefined as unknown as string,
+        analysisId: 'funnel-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when validateFunnelName is called with undefined', () => {
+    expect(() =>
+      validateFunnelName(undefined as unknown as string),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when validateFunnelSteps is called with undefined', () => {
+    expect(() =>
+      validateFunnelSteps(undefined as unknown as FunnelStep[]),
+    ).toThrow('is required and must be an array');
   });
 });

--- a/packages/core/src/__tests__/bloomreachRetentions.test.ts
+++ b/packages/core/src/__tests__/bloomreachRetentions.test.ts
@@ -1283,3 +1283,93 @@ describe('BloomreachRetentionsService', () => {
     });
   });
 });
+
+describe('null/undefined input guards', () => {
+  it('throws when prepareCreateRetentionAnalysis is called without name', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: undefined as unknown as string,
+        cohortEvent: 'sign_up',
+        returnEvent: 'purchase',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateRetentionAnalysis is called without cohortEvent', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Retention Cohort',
+        cohortEvent: undefined as unknown as string,
+        returnEvent: 'purchase',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateRetentionAnalysis is called without returnEvent', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareCreateRetentionAnalysis({
+        project: 'test',
+        name: 'Retention Cohort',
+        cohortEvent: 'sign_up',
+        returnEvent: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateRetentionAnalysis is called without project', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareCreateRetentionAnalysis({
+        project: undefined as unknown as string,
+        name: 'Retention Cohort',
+        cohortEvent: 'sign_up',
+        returnEvent: 'purchase',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCloneRetentionAnalysis is called without analysisId', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareCloneRetentionAnalysis({
+        project: 'test',
+        analysisId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCloneRetentionAnalysis is called without project', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareCloneRetentionAnalysis({
+        project: undefined as unknown as string,
+        analysisId: 'retention-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareArchiveRetentionAnalysis is called without analysisId', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareArchiveRetentionAnalysis({
+        project: 'test',
+        analysisId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareArchiveRetentionAnalysis is called without project', () => {
+    const service = new BloomreachRetentionsService('test');
+    expect(() =>
+      service.prepareArchiveRetentionAnalysis({
+        project: undefined as unknown as string,
+        analysisId: 'retention-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+});

--- a/packages/core/src/__tests__/bloomreachSegmentations.test.ts
+++ b/packages/core/src/__tests__/bloomreachSegmentations.test.ts
@@ -1594,3 +1594,92 @@ describe('BloomreachSegmentationsService', () => {
     });
   });
 });
+
+describe('null/undefined input guards', () => {
+  it('throws when prepareCreateSegmentation is called without name', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareCreateSegmentation({
+        project: 'test',
+        name: undefined as unknown as string,
+        conditions: [
+          {
+            type: 'customer_attribute',
+            attribute: 'country',
+            operator: 'equals',
+            value: 'DK',
+          },
+        ],
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateSegmentation is called without conditions', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareCreateSegmentation({
+        project: 'test',
+        name: 'VIP Segment',
+        conditions: undefined as unknown as SegmentCondition[],
+      }),
+    ).toThrow('is required and must be an array');
+  });
+
+  it('throws when prepareCreateSegmentation is called without project', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareCreateSegmentation({
+        project: undefined as unknown as string,
+        name: 'VIP Segment',
+        conditions: [
+          {
+            type: 'customer_attribute',
+            attribute: 'country',
+            operator: 'equals',
+            value: 'DK',
+          },
+        ],
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCloneSegmentation is called without segmentationId', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareCloneSegmentation({
+        project: 'test',
+        segmentationId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCloneSegmentation is called without project', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareCloneSegmentation({
+        project: undefined as unknown as string,
+        segmentationId: 'seg-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareArchiveSegmentation is called without segmentationId', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareArchiveSegmentation({
+        project: 'test',
+        segmentationId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareArchiveSegmentation is called without project', () => {
+    const service = new BloomreachSegmentationsService('test');
+    expect(() =>
+      service.prepareArchiveSegmentation({
+        project: undefined as unknown as string,
+        segmentationId: 'seg-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+});

--- a/packages/core/src/__tests__/bloomreachTagManager.test.ts
+++ b/packages/core/src/__tests__/bloomreachTagManager.test.ts
@@ -1229,3 +1229,80 @@ describe('BloomreachTagManagerService', () => {
     });
   });
 });
+
+describe('null/undefined input guards', () => {
+  it('throws when prepareCreateTag is called without name', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareCreateTag({
+        project: 'test',
+        name: undefined as unknown as string,
+        jsCode: 'console.log("hello")',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateTag is called without jsCode', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareCreateTag({
+        project: 'test',
+        name: 'Checkout tracker',
+        jsCode: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareCreateTag is called without project', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareCreateTag({
+        project: undefined as unknown as string,
+        name: 'Checkout tracker',
+        jsCode: 'console.log("hello")',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareEditTag is called without tagId', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareEditTag({
+        project: 'test',
+        tagId: undefined as unknown as string,
+        name: 'Updated tag',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareEditTag is called without project', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareEditTag({
+        project: undefined as unknown as string,
+        tagId: 'tag-123',
+        name: 'Updated tag',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareDeleteTag is called without tagId', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareDeleteTag({
+        project: 'test',
+        tagId: undefined as unknown as string,
+      }),
+    ).toThrow('is required and must be a string');
+  });
+
+  it('throws when prepareDeleteTag is called without project', () => {
+    const service = new BloomreachTagManagerService('test');
+    expect(() =>
+      service.prepareDeleteTag({
+        project: undefined as unknown as string,
+        tagId: 'tag-123',
+      }),
+    ).toThrow('is required and must be a string');
+  });
+});

--- a/packages/core/src/bloomreachAccessManagement.ts
+++ b/packages/core/src/bloomreachAccessManagement.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -112,6 +112,7 @@ export interface PreparedAccessAction {
 const MAX_API_KEY_NAME_LENGTH = 200;
 
 export function validateEmail(email: string): string {
+  requireString(email, 'email');
   const trimmed = email.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email must not be empty.');
@@ -126,6 +127,7 @@ export function validateEmail(email: string): string {
 }
 
 export function validateMemberRole(role: string): TeamMemberRole {
+  requireString(role, 'role');
   if (!TEAM_MEMBER_ROLES.includes(role as TeamMemberRole)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `role must be one of: ${TEAM_MEMBER_ROLES.join(', ')} (got "${role}").`);
   }
@@ -133,6 +135,7 @@ export function validateMemberRole(role: string): TeamMemberRole {
 }
 
 export function validateMemberId(id: string): string {
+  requireString(id, 'memberId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Member ID must not be empty.');
@@ -141,6 +144,7 @@ export function validateMemberId(id: string): string {
 }
 
 export function validateApiKeyName(name: string): string {
+  requireString(name, 'api key name');
   const trimmed = name.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'API key name must not be empty.');
@@ -152,6 +156,7 @@ export function validateApiKeyName(name: string): string {
 }
 
 export function validateApiKeyId(id: string): string {
+  requireString(id, 'apiKeyId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'API key ID must not be empty.');

--- a/packages/core/src/bloomreachAssetManager.ts
+++ b/packages/core/src/bloomreachAssetManager.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 
 export const CREATE_EMAIL_TEMPLATE_ACTION_TYPE =
   'asset_manager.create_email_template';
@@ -229,6 +229,7 @@ type CloneableAssetType = (typeof CLONEABLE_ASSET_TYPES)[number];
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validateAssetName(name: string): string {
+  requireString(name, 'name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_ASSET_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Asset name must not be empty.');
@@ -241,6 +242,7 @@ export function validateAssetName(name: string): string {
 
 /** @throws {Error} If `type` is not a recognised asset type. */
 export function validateAssetType(type: string): AssetType {
+  requireString(type, 'type');
   if (!ASSET_TYPES.includes(type as AssetType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `assetType must be one of: ${ASSET_TYPES.join(', ')} (got "${type}").`);
   }
@@ -249,6 +251,7 @@ export function validateAssetType(type: string): AssetType {
 
 /** @throws {Error} If `status` is not a recognised template status. */
 export function validateTemplateStatus(status: string): TemplateStatus {
+  requireString(status, 'status');
   if (!TEMPLATE_STATUSES.includes(status as TemplateStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${TEMPLATE_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -257,6 +260,7 @@ export function validateTemplateStatus(status: string): TemplateStatus {
 
 /** @throws {Error} If `category` is not a recognised file category. */
 export function validateFileCategory(category: string): FileCategory {
+  requireString(category, 'category');
   if (!FILE_CATEGORIES.includes(category as FileCategory)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `category must be one of: ${FILE_CATEGORIES.join(', ')} (got "${category}").`);
   }
@@ -265,6 +269,7 @@ export function validateFileCategory(category: string): FileCategory {
 
 /** @throws {Error} If `language` is not a recognised snippet language. */
 export function validateSnippetLanguage(language: string): SnippetLanguage {
+  requireString(language, 'language');
   if (!SNIPPET_LANGUAGES.includes(language as SnippetLanguage)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `language must be one of: ${SNIPPET_LANGUAGES.join(', ')} (got "${language}").`);
   }
@@ -273,6 +278,7 @@ export function validateSnippetLanguage(language: string): SnippetLanguage {
 
 /** @throws {Error} If `type` is not a recognised builder type. */
 export function validateBuilderType(type: string): TemplateBuilderType {
+  requireString(type, 'type');
   if (!TEMPLATE_BUILDER_TYPES.includes(type as TemplateBuilderType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `builderType must be one of: ${TEMPLATE_BUILDER_TYPES.join(', ')} (got "${type}").`);
   }
@@ -281,6 +287,7 @@ export function validateBuilderType(type: string): TemplateBuilderType {
 
 /** @throws {Error} If snippet content is empty or exceeds 100000 characters. */
 export function validateSnippetContent(content: string): string {
+  requireString(content, 'content');
   if (content.trim().length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Snippet content must not be empty.');
   }
@@ -292,6 +299,7 @@ export function validateSnippetContent(content: string): string {
 
 /** @throws {Error} If mime type is empty or malformed. */
 export function validateMimeType(mimeType: string): string {
+  requireString(mimeType, 'MIME type');
   const trimmed = mimeType.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'MIME type must not be empty.');
@@ -304,6 +312,7 @@ export function validateMimeType(mimeType: string): string {
 
 /** @throws {Error} If asset ID is empty. */
 export function validateAssetId(id: string): string {
+  requireString(id, 'id');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Asset ID must not be empty.');
@@ -312,6 +321,7 @@ export function validateAssetId(id: string): string {
 }
 
 function validateCloneableAssetType(type: string): CloneableAssetType {
+  requireString(type, 'type');
   const assetType = validateAssetType(type);
   if (!CLONEABLE_ASSET_TYPES.includes(assetType as CloneableAssetType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `assetType must be one of cloneable types: ${CLONEABLE_ASSET_TYPES.join(', ')} (got "${type}").`);

--- a/packages/core/src/bloomreachCampaignCalendar.ts
+++ b/packages/core/src/bloomreachCampaignCalendar.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const EXPORT_CALENDAR_ACTION_TYPE = 'campaign_calendar.export';
@@ -108,6 +108,7 @@ const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 /** @throws {Error} If date is not a valid ISO-8601 YYYY-MM-DD string. */
 export function validateDateFormat(date: string): string {
+  requireString(date, 'Date');
   const trimmed = date.trim();
   if (!ISO_DATE_REGEX.test(trimmed)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Date must be in YYYY-MM-DD format (got "${trimmed}").`);
@@ -124,6 +125,8 @@ export function validateDateFormat(date: string): string {
  *   or if startDate is after endDate.
  */
 export function validateCalendarDateRange(startDate: string, endDate: string): CalendarDateRange {
+  requireString(startDate, 'Start date');
+  requireString(endDate, 'End date');
   const validStart = validateDateFormat(startDate);
   const validEnd = validateDateFormat(endDate);
   if (new Date(validStart) > new Date(validEnd)) {
@@ -134,6 +137,7 @@ export function validateCalendarDateRange(startDate: string, endDate: string): C
 
 /** @throws {Error} If `type` is not a recognised campaign type. */
 export function validateCalendarCampaignType(type: string): CampaignCalendarCampaignType {
+  requireString(type, 'Campaign type');
   if (!CAMPAIGN_CALENDAR_CAMPAIGN_TYPES.includes(type as CampaignCalendarCampaignType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign type must be one of: ${CAMPAIGN_CALENDAR_CAMPAIGN_TYPES.join(', ')} (got "${type}").`);
   }
@@ -142,6 +146,7 @@ export function validateCalendarCampaignType(type: string): CampaignCalendarCamp
 
 /** @throws {Error} If `status` is not a recognised campaign calendar status. */
 export function validateCalendarCampaignStatus(status: string): CampaignCalendarStatus {
+  requireString(status, 'Campaign status');
   if (!CAMPAIGN_CALENDAR_STATUSES.includes(status as CampaignCalendarStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Campaign status must be one of: ${CAMPAIGN_CALENDAR_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -150,6 +155,7 @@ export function validateCalendarCampaignStatus(status: string): CampaignCalendar
 
 /** @throws {Error} If `channel` is not a recognised campaign channel. */
 export function validateCalendarChannel(channel: string): CampaignCalendarChannel {
+  requireString(channel, 'Channel');
   if (!CAMPAIGN_CALENDAR_CHANNELS.includes(channel as CampaignCalendarChannel)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Channel must be one of: ${CAMPAIGN_CALENDAR_CHANNELS.join(', ')} (got "${channel}").`);
   }
@@ -158,6 +164,7 @@ export function validateCalendarChannel(channel: string): CampaignCalendarChanne
 
 /** @throws {Error} If `format` is not a recognised export format. */
 export function validateExportFormat(format: string): CampaignCalendarExportFormat {
+  requireString(format, 'Export format');
   if (!CAMPAIGN_CALENDAR_EXPORT_FORMATS.includes(format as CampaignCalendarExportFormat)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export format must be one of: ${CAMPAIGN_CALENDAR_EXPORT_FORMATS.join(', ')} (got "${format}").`);
   }

--- a/packages/core/src/bloomreachCampaignSettings.ts
+++ b/packages/core/src/bloomreachCampaignSettings.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -449,6 +449,7 @@ const MIN_PAGE_VARIABLE_NAME_LENGTH = 1;
 const MAX_PAGE_VARIABLE_VALUE_LENGTH = 5000;
 
 export function validateTimezoneName(name: string): string {
+  requireString(name, 'Timezone name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_TIMEZONE_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Timezone name must not be empty.');
@@ -460,6 +461,7 @@ export function validateTimezoneName(name: string): string {
 }
 
 export function validateTimezoneId(id: string): string {
+  requireString(id, 'Timezone ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Timezone ID must not be empty.');
@@ -468,6 +470,7 @@ export function validateTimezoneId(id: string): string {
 }
 
 export function validateLanguageCode(code: string): string {
+  requireString(code, 'Language code');
   const trimmed = code.trim();
   if (trimmed.length < MIN_LANGUAGE_CODE_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Language code must not be empty.');
@@ -479,6 +482,7 @@ export function validateLanguageCode(code: string): string {
 }
 
 export function validateLanguageName(name: string): string {
+  requireString(name, 'Language name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_LANGUAGE_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Language name must not be empty.');
@@ -490,6 +494,7 @@ export function validateLanguageName(name: string): string {
 }
 
 export function validateFontName(name: string): string {
+  requireString(name, 'Font name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_FONT_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font name must not be empty.');
@@ -501,6 +506,7 @@ export function validateFontName(name: string): string {
 }
 
 export function validateFontId(id: string): string {
+  requireString(id, 'Font ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font ID must not be empty.');
@@ -509,6 +515,7 @@ export function validateFontId(id: string): string {
 }
 
 export function validatePolicyName(name: string): string {
+  requireString(name, 'Policy name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_POLICY_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Policy name must not be empty.');
@@ -520,6 +527,7 @@ export function validatePolicyName(name: string): string {
 }
 
 export function validatePolicyId(id: string): string {
+  requireString(id, 'Policy ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Policy ID must not be empty.');
@@ -528,6 +536,7 @@ export function validatePolicyId(id: string): string {
 }
 
 export function validateConsentCategory(category: string): string {
+  requireString(category, 'Consent category');
   const trimmed = category.trim();
   if (trimmed.length < MIN_CONSENT_CATEGORY_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Consent category must not be empty.');
@@ -539,6 +548,7 @@ export function validateConsentCategory(category: string): string {
 }
 
 export function validateConsentId(id: string): string {
+  requireString(id, 'Consent ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Consent ID must not be empty.');
@@ -547,6 +557,7 @@ export function validateConsentId(id: string): string {
 }
 
 export function validateUrlListName(name: string): string {
+  requireString(name, 'URL list name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_URL_LIST_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list name must not be empty.');
@@ -558,6 +569,7 @@ export function validateUrlListName(name: string): string {
 }
 
 export function validateUrlListId(id: string): string {
+  requireString(id, 'URL list ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list ID must not be empty.');
@@ -566,6 +578,7 @@ export function validateUrlListId(id: string): string {
 }
 
 export function validatePageVariableName(name: string): string {
+  requireString(name, 'Page variable name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_PAGE_VARIABLE_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page variable name must not be empty.');
@@ -577,6 +590,7 @@ export function validatePageVariableName(name: string): string {
 }
 
 export function validatePageVariableId(id: string): string {
+  requireString(id, 'Page variable ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page variable ID must not be empty.');
@@ -585,6 +599,7 @@ export function validatePageVariableId(id: string): string {
 }
 
 export function validatePageVariableValue(value: string): string {
+  requireString(value, 'Page variable value');
   const trimmed = value.trim();
   if (trimmed.length > MAX_PAGE_VARIABLE_VALUE_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Page variable value must not exceed ${MAX_PAGE_VARIABLE_VALUE_LENGTH} characters (got ${trimmed.length}).`);
@@ -1225,14 +1240,29 @@ export class BloomreachCampaignSettingsService {
       input.defaultSenderName !== undefined
         ? validatePolicyName(input.defaultSenderName)
         : undefined;
+    if (input.defaultSenderEmail !== undefined) {
+      requireString(input.defaultSenderEmail, 'Default sender email');
+    }
     const defaultSenderEmail =
       input.defaultSenderEmail !== undefined ? input.defaultSenderEmail.trim() : undefined;
+    if (input.defaultReplyToEmail !== undefined) {
+      requireString(input.defaultReplyToEmail, 'Default reply-to email');
+    }
     const defaultReplyToEmail =
       input.defaultReplyToEmail !== undefined ? input.defaultReplyToEmail.trim() : undefined;
+    if (input.defaultUtmSource !== undefined) {
+      requireString(input.defaultUtmSource, 'Default UTM source');
+    }
     const defaultUtmSource =
       input.defaultUtmSource !== undefined ? input.defaultUtmSource.trim() : undefined;
+    if (input.defaultUtmMedium !== undefined) {
+      requireString(input.defaultUtmMedium, 'Default UTM medium');
+    }
     const defaultUtmMedium =
       input.defaultUtmMedium !== undefined ? input.defaultUtmMedium.trim() : undefined;
+    if (input.defaultUtmCampaign !== undefined) {
+      requireString(input.defaultUtmCampaign, 'Default UTM campaign');
+    }
     const defaultUtmCampaign =
       input.defaultUtmCampaign !== undefined ? input.defaultUtmCampaign.trim() : undefined;
 
@@ -1406,6 +1436,7 @@ export class BloomreachCampaignSettingsService {
   prepareCreateFont(input: CreateFontInput): PreparedCampaignSettingsAction {
     const project = validateProject(input.project);
     const name = validateFontName(input.name);
+    requireString(input.type, 'Font type');
     const type = input.type.trim();
     if (type.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Font type must not be empty.');
@@ -1432,6 +1463,9 @@ export class BloomreachCampaignSettingsService {
     const project = validateProject(input.project);
     const fontId = validateFontId(input.fontId);
     const name = input.name !== undefined ? validateFontName(input.name) : undefined;
+    if (input.type !== undefined) {
+      requireString(input.type, 'Font type');
+    }
     const type = input.type !== undefined ? input.type.trim() : undefined;
 
     if (type !== undefined && type.length === 0) {
@@ -1720,6 +1754,7 @@ export class BloomreachCampaignSettingsService {
   prepareCreateUrlList(input: CreateUrlListInput): PreparedCampaignSettingsAction {
     const project = validateProject(input.project);
     const name = validateUrlListName(input.name);
+    requireString(input.listType, 'URL list type');
     const listType = input.listType.trim();
     if (listType.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'URL list type must not be empty.');
@@ -1747,6 +1782,9 @@ export class BloomreachCampaignSettingsService {
     const project = validateProject(input.project);
     const urlListId = validateUrlListId(input.urlListId);
     const name = input.name !== undefined ? validateUrlListName(input.name) : undefined;
+    if (input.listType !== undefined) {
+      requireString(input.listType, 'URL list type');
+    }
     const listType = input.listType !== undefined ? input.listType.trim() : undefined;
 
     if (listType !== undefined && listType.length === 0) {

--- a/packages/core/src/bloomreachCatalogs.ts
+++ b/packages/core/src/bloomreachCatalogs.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray, requireObject } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -97,6 +97,7 @@ const MAX_CATALOG_NAME_LENGTH = 200;
 const MIN_CATALOG_NAME_LENGTH = 1;
 
 export function validateCatalogName(name: string): string {
+  requireString(name, 'name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_CATALOG_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog name must not be empty.');
@@ -108,6 +109,7 @@ export function validateCatalogName(name: string): string {
 }
 
 export function validateCatalogId(id: string): string {
+  requireString(id, 'id');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog ID must not be empty.');
@@ -116,6 +118,7 @@ export function validateCatalogId(id: string): string {
 }
 
 export function validateCatalogSchema(schema: Record<string, string>): Record<string, string> {
+  requireObject(schema, 'schema');
   const entries = Object.entries(schema);
   if (entries.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog schema must include at least one field.');
@@ -138,6 +141,7 @@ export function validateCatalogSchema(schema: Record<string, string>): Record<st
 }
 
 export function validateCatalogItems(items: Record<string, unknown>[]): Record<string, unknown>[] {
+  requireArray(items, 'items');
   if (items.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog items must include at least one item.');
   }
@@ -147,11 +151,13 @@ export function validateCatalogItems(items: Record<string, unknown>[]): Record<s
 export function validateCatalogItemUpdates(
   items: { id: string; properties: Record<string, unknown> }[],
 ): { id: string; properties: Record<string, unknown> }[] {
+  requireArray(items, 'items');
   if (items.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog item updates must include at least one item.');
   }
 
   return items.map((item) => {
+    requireString(item.id, 'Catalog item ID');
     const id = item.id.trim();
     if (id.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Catalog item ID must not be empty.');

--- a/packages/core/src/bloomreachChannelSettings.ts
+++ b/packages/core/src/bloomreachChannelSettings.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Action type constants
@@ -156,6 +156,7 @@ const MAX_PROVIDER_NAME_LENGTH = 100;
 const MAX_SENDER_NUMBER_LENGTH = 30;
 
 export function validateDomain(domain: string): string {
+  requireString(domain, 'domain');
   const trimmed = domain.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Domain must not be empty.');
@@ -167,6 +168,7 @@ export function validateDomain(domain: string): string {
 }
 
 export function validateProviderName(provider: string): string {
+  requireString(provider, 'provider');
   const trimmed = provider.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Provider name must not be empty.');
@@ -178,6 +180,7 @@ export function validateProviderName(provider: string): string {
 }
 
 export function validateSenderNumber(number: string): string {
+  requireString(number, 'sender number');
   const trimmed = number.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Sender number must not be empty.');
@@ -189,6 +192,7 @@ export function validateSenderNumber(number: string): string {
 }
 
 export function validatePageId(pageId: string): string {
+  requireString(pageId, 'pageId');
   const trimmed = pageId.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page ID must not be empty.');
@@ -394,10 +398,17 @@ export class BloomreachChannelSettingsService {
   ): PreparedChannelSettingsAction {
     const project = validateProject(input.project);
     const provider = validateProviderName(input.provider);
-    const firebaseCredentials =
-      input.firebaseCredentials !== undefined ? input.firebaseCredentials.trim() : undefined;
-    const apnsCertificate =
-      input.apnsCertificate !== undefined ? input.apnsCertificate.trim() : undefined;
+    let firebaseCredentials: string | undefined;
+    if (input.firebaseCredentials !== undefined) {
+      requireString(input.firebaseCredentials, 'firebase credentials');
+      firebaseCredentials = input.firebaseCredentials.trim();
+    }
+
+    let apnsCertificate: string | undefined;
+    if (input.apnsCertificate !== undefined) {
+      requireString(input.apnsCertificate, 'apns certificate');
+      apnsCertificate = input.apnsCertificate.trim();
+    }
 
     const preview = {
       action: CONFIGURE_PUSH_PROVIDER_ACTION_TYPE,
@@ -488,7 +499,11 @@ export class BloomreachChannelSettingsService {
   ): PreparedChannelSettingsAction {
     const project = validateProject(input.project);
     const pageId = validatePageId(input.pageId);
-    const accessToken = input.accessToken !== undefined ? input.accessToken.trim() : undefined;
+    let accessToken: string | undefined;
+    if (input.accessToken !== undefined) {
+      requireString(input.accessToken, 'access token');
+      accessToken = input.accessToken.trim();
+    }
 
     const preview = {
       action: CONFIGURE_FACEBOOK_MESSAGING_ACTION_TYPE,

--- a/packages/core/src/bloomreachCustomers.ts
+++ b/packages/core/src/bloomreachCustomers.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray, requireObject } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import {
   bloomreachApiFetch,
@@ -155,6 +155,7 @@ const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 1000;
 
 export function validateCustomerId(id: string): string {
+  requireString(id, 'id');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer ID must not be empty.');
@@ -166,6 +167,7 @@ export function validateCustomerId(id: string): string {
 }
 
 export function validateCustomerIds(ids: CustomerIds): CustomerIds {
+  requireObject(ids, 'customerIds');
   const hasAtLeastOne = Object.values(ids).some(
     (v) => typeof v === 'string' && v.trim().length > 0,
   );
@@ -182,6 +184,7 @@ export function validateCustomerIds(ids: CustomerIds): CustomerIds {
 }
 
 export function validateCustomerEventType(eventType: string): string {
+  requireString(eventType, 'Event type');
   const trimmed = eventType.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event type must not be empty.');
@@ -193,6 +196,7 @@ export function validateCustomerEventType(eventType: string): string {
 }
 
 export function validateCustomerBatchCommands(commands: CustomerBatchCommand[]): CustomerBatchCommand[] {
+  requireArray(commands, 'commands');
   if (!Array.isArray(commands) || commands.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one batch command must be provided.');
   }
@@ -215,6 +219,7 @@ export function validateCustomerBatchCommands(commands: CustomerBatchCommand[]):
 }
 
 export function validateSearchQuery(query: string): string {
+  requireString(query, 'query');
   const trimmed = query.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Search query must not be empty.');

--- a/packages/core/src/bloomreachDashboards.ts
+++ b/packages/core/src/bloomreachDashboards.ts
@@ -1,5 +1,5 @@
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireObject, requireString } from './errors.js';
 
 export const CREATE_DASHBOARD_ACTION_TYPE = 'dashboards.create_dashboard';
 export const SET_HOME_DASHBOARD_ACTION_TYPE = 'dashboards.set_home_dashboard';
@@ -73,6 +73,7 @@ const MIN_LAYOUT_COLUMNS = 1;
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validateDashboardName(name: string): string {
+  requireString(name, 'dashboard name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_DASHBOARD_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard name must not be empty.');
@@ -85,6 +86,7 @@ export function validateDashboardName(name: string): string {
 
 /** @throws {Error} If project is empty. */
 export function validateProject(project: string): string {
+  requireString(project, 'project');
   const trimmed = project.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Project identifier must not be empty.');
@@ -94,16 +96,18 @@ export function validateProject(project: string): string {
 
 /** @throws {Error} If column count is not an integer between 1 and 6. */
 export function validateLayoutConfig(layout: DashboardLayoutConfig): DashboardLayoutConfig {
-  if (layout.columns !== undefined) {
+  requireObject(layout, 'layout');
+  const validatedLayout = layout as DashboardLayoutConfig;
+  if (validatedLayout.columns !== undefined) {
     if (
-      !Number.isInteger(layout.columns) ||
-      layout.columns < MIN_LAYOUT_COLUMNS ||
-      layout.columns > MAX_LAYOUT_COLUMNS
+      !Number.isInteger(validatedLayout.columns) ||
+      validatedLayout.columns < MIN_LAYOUT_COLUMNS ||
+      validatedLayout.columns > MAX_LAYOUT_COLUMNS
     ) {
-      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Layout columns must be an integer between ${MIN_LAYOUT_COLUMNS} and ${MAX_LAYOUT_COLUMNS} (got ${layout.columns}).`);
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Layout columns must be an integer between ${MIN_LAYOUT_COLUMNS} and ${MAX_LAYOUT_COLUMNS} (got ${validatedLayout.columns}).`);
     }
   }
-  return layout;
+  return validatedLayout;
 }
 
 export function buildDashboardsUrl(project: string): string {
@@ -245,6 +249,7 @@ export class BloomreachDashboardsService {
   /** @throws {Error} If input validation fails. */
   prepareSetHomeDashboard(input: SetHomeDashboardInput): PreparedDashboardAction {
     const project = validateProject(input.project);
+    requireString(input.dashboardId, 'dashboard ID');
     const dashboardId = input.dashboardId.trim();
     if (dashboardId.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard ID must not be empty.');

--- a/packages/core/src/bloomreachDataManager.ts
+++ b/packages/core/src/bloomreachDataManager.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray } from './errors.js';
 import {
   bloomreachApiFetch,
   buildDataPath,
@@ -219,6 +219,7 @@ const TRANSFORMATION_TYPES = new Set([
 ]);
 
 function validateRequiredTrimmed(value: string, fieldName: string): string {
+  requireString(value, fieldName);
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not be empty.`);
@@ -227,6 +228,7 @@ function validateRequiredTrimmed(value: string, fieldName: string): string {
 }
 
 function validatePropertyName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Property name');
   if (trimmed.length > MAX_PROPERTY_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Property name must not exceed ${MAX_PROPERTY_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -235,6 +237,7 @@ function validatePropertyName(name: string): string {
 }
 
 function validateEventName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Event name');
   if (trimmed.length > MAX_EVENT_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event name must not exceed ${MAX_EVENT_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -243,6 +246,7 @@ function validateEventName(name: string): string {
 }
 
 function validateDefinitionName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Definition name');
   if (trimmed.length > MAX_DEFINITION_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Definition name must not exceed ${MAX_DEFINITION_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -251,6 +255,7 @@ function validateDefinitionName(name: string): string {
 }
 
 function validateDescription(description: string): string {
+  requireString(description, 'description');
   const trimmed = validateRequiredTrimmed(description, 'Description');
   if (trimmed.length > MAX_DESCRIPTION_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Description must not exceed ${MAX_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`);
@@ -259,6 +264,7 @@ function validateDescription(description: string): string {
 }
 
 function validatePropertyType(type: string): string {
+  requireString(type, 'type');
   const normalized = validateRequiredTrimmed(type, 'Property type').toLowerCase();
   if (!PROPERTY_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Property type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`);
@@ -267,6 +273,7 @@ function validatePropertyType(type: string): string {
 }
 
 function validateEventType(type: string): string {
+  requireString(type, 'type');
   const normalized = validateRequiredTrimmed(type, 'Event type').toLowerCase();
   if (!PROPERTY_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Event type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`);
@@ -275,6 +282,7 @@ function validateEventType(type: string): string {
 }
 
 function validateFieldType(type: string): string {
+  requireString(type, 'type');
   const normalized = validateRequiredTrimmed(type, 'Field type').toLowerCase();
   if (!PROPERTY_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Field type must be one of: ${Array.from(PROPERTY_TYPES).join(', ')} (got ${normalized}).`);
@@ -283,6 +291,7 @@ function validateFieldType(type: string): string {
 }
 
 function validateSourceType(sourceType: string): string {
+  requireString(sourceType, 'Source type');
   const normalized = validateRequiredTrimmed(sourceType, 'Source type').toLowerCase();
   if (!SOURCE_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source type must be one of: ${Array.from(SOURCE_TYPES).join(', ')} (got ${normalized}).`);
@@ -291,6 +300,7 @@ function validateSourceType(sourceType: string): string {
 }
 
 function validateSourceUrl(url: string): string {
+  requireString(url, 'url');
   const trimmed = validateRequiredTrimmed(url, 'Source URL');
   if (trimmed.length > MAX_URL_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source URL must not exceed ${MAX_URL_LENGTH} characters (got ${trimmed.length}).`);
@@ -304,6 +314,7 @@ function validateSourceUrl(url: string): string {
 }
 
 function validateSourceName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Source name');
   if (trimmed.length > MAX_SOURCE_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source name must not exceed ${MAX_SOURCE_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -312,6 +323,7 @@ function validateSourceName(name: string): string {
 }
 
 function validateDefinitionId(id: string): string {
+  requireString(id, 'id');
   const trimmed = validateRequiredTrimmed(id, 'Definition ID');
   if (trimmed.length > MAX_FIELD_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Definition ID must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -320,6 +332,7 @@ function validateDefinitionId(id: string): string {
 }
 
 function validateSourceId(id: string): string {
+  requireString(id, 'id');
   const trimmed = validateRequiredTrimmed(id, 'Source ID');
   if (trimmed.length > MAX_FIELD_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source ID must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -331,6 +344,8 @@ function validateMappingFields(
   sourceField: string,
   targetField: string,
 ): { sourceField: string; targetField: string } {
+  requireString(sourceField, 'Source field');
+  requireString(targetField, 'Target field');
   const validatedSourceField = validateRequiredTrimmed(sourceField, 'Source field');
   if (validatedSourceField.length > MAX_FIELD_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source field must not exceed ${MAX_FIELD_NAME_LENGTH} characters (got ${validatedSourceField.length}).`);
@@ -348,6 +363,7 @@ function validateMappingFields(
 }
 
 function validateTransformationType(type: string): string {
+  requireString(type, 'type');
   const normalized = validateRequiredTrimmed(type, 'Transformation type').toLowerCase();
   if (!TRANSFORMATION_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Transformation type must be one of: ${Array.from(TRANSFORMATION_TYPES).join(', ')} (got ${normalized}).`);
@@ -396,6 +412,8 @@ function validateEventProperties(
   if (properties === undefined) {
     return [];
   }
+
+  requireArray(properties, 'Event properties');
 
   return properties.map((property, index) => {
     const name = validatePropertyName(property.name);

--- a/packages/core/src/bloomreachEmailCampaigns.ts
+++ b/packages/core/src/bloomreachEmailCampaigns.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireObject, requireString } from './errors.js';
 import { bloomreachApiFetch, buildEmailPath } from './bloomreachApiClient.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
@@ -168,6 +168,7 @@ const MAX_AB_TEST_VARIANTS = 10;
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validateCampaignName(name: string): string {
+  requireString(name, 'Campaign name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_CAMPAIGN_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign name must not be empty.');
@@ -180,6 +181,7 @@ export function validateCampaignName(name: string): string {
 
 /** @throws {Error} If subject line is empty or exceeds 998 characters (RFC 2822 limit). */
 export function validateSubjectLine(subjectLine: string): string {
+  requireString(subjectLine, 'Subject line');
   const trimmed = subjectLine.trim();
   if (trimmed.length < MIN_SUBJECT_LINE_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Subject line must not be empty.');
@@ -192,6 +194,7 @@ export function validateSubjectLine(subjectLine: string): string {
 
 /** @throws {Error} If `status` is not a recognised email campaign status. */
 export function validateEmailCampaignStatus(status: string): EmailCampaignStatus {
+  requireString(status, 'status');
   if (!EMAIL_CAMPAIGN_STATUSES.includes(status as EmailCampaignStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${EMAIL_CAMPAIGN_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -200,6 +203,7 @@ export function validateEmailCampaignStatus(status: string): EmailCampaignStatus
 
 /** @throws {Error} If `templateType` is not a recognised template type. */
 export function validateTemplateType(templateType: string): EmailTemplateType {
+  requireString(templateType, 'templateType');
   if (!EMAIL_TEMPLATE_TYPES.includes(templateType as EmailTemplateType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `templateType must be one of: ${EMAIL_TEMPLATE_TYPES.join(', ')} (got "${templateType}").`);
   }
@@ -208,6 +212,7 @@ export function validateTemplateType(templateType: string): EmailTemplateType {
 
 /** @throws {Error} If `scheduleType` is not a recognised schedule type. */
 export function validateScheduleType(scheduleType: string): SendScheduleType {
+  requireString(scheduleType, 'schedule type');
   if (!SEND_SCHEDULE_TYPES.includes(scheduleType as SendScheduleType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `schedule type must be one of: ${SEND_SCHEDULE_TYPES.join(', ')} (got "${scheduleType}").`);
   }
@@ -216,6 +221,7 @@ export function validateScheduleType(scheduleType: string): SendScheduleType {
 
 /** @throws {Error} If A/B test config is invalid. */
 export function validateABTestConfig(config: EmailCampaignABTestConfig): EmailCampaignABTestConfig {
+  requireObject(config, 'AB test config');
   if (
     !Number.isInteger(config.variants) ||
     config.variants < MIN_AB_TEST_VARIANTS ||
@@ -233,6 +239,7 @@ export function validateABTestConfig(config: EmailCampaignABTestConfig): EmailCa
 
 /** @throws {Error} If campaign ID is empty. */
 export function validateCampaignId(id: string): string {
+  requireString(id, 'Campaign ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign ID must not be empty.');
@@ -242,6 +249,7 @@ export function validateCampaignId(id: string): string {
 
 /** @throws {Error} If schedule config is invalid. */
 export function validateSchedule(schedule: EmailCampaignSchedule): EmailCampaignSchedule {
+  requireObject(schedule, 'schedule');
   validateScheduleType(schedule.type);
   if (schedule.type === 'scheduled' && schedule.scheduledAt === undefined) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'scheduledAt is required when schedule type is "scheduled".');
@@ -253,6 +261,7 @@ export function validateSchedule(schedule: EmailCampaignSchedule): EmailCampaign
 }
 
 export function validateEmailIntegrationId(id: string): string {
+  requireString(id, 'Integration ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Integration ID must not be empty.');
@@ -261,6 +270,7 @@ export function validateEmailIntegrationId(id: string): string {
 }
 
 export function validateEmailAddress(email: string): string {
+  requireString(email, 'Email address');
   const trimmed = email.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email address must not be empty.');
@@ -274,6 +284,7 @@ export function validateEmailAddress(email: string): string {
 export function validateTransactionalEmailContent(
   content: TransactionalEmailContent,
 ): TransactionalEmailContent {
+  requireObject(content, 'content');
   if (!content.templateId && !content.html) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Email content must include either a templateId or raw html.');
   }

--- a/packages/core/src/bloomreachEvaluationSettings.ts
+++ b/packages/core/src/bloomreachEvaluationSettings.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireObject, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -124,6 +124,7 @@ const MAX_ATTRIBUTION_WINDOW_DAYS = 365;
 const MAX_MAPPING_FIELD_LENGTH = 200;
 
 export function validateAttributionModel(model: string): string {
+  requireString(model, 'attribution model');
   const trimmed = model.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Attribution model must not be empty.');
@@ -145,6 +146,7 @@ export function validateAttributionWindow(window: number): number {
 }
 
 export function validateCurrencyCode(code: string): string {
+  requireString(code, 'currency code');
   const trimmed = code.trim().toUpperCase();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Currency code must not be empty.');
@@ -159,6 +161,7 @@ export function validateCurrencyCode(code: string): string {
 }
 
 export function validateDashboardId(id: string): string {
+  requireString(id, 'dashboardId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Dashboard ID must not be empty.');
@@ -167,6 +170,7 @@ export function validateDashboardId(id: string): string {
 }
 
 export function validateMappingField(field: string): string {
+  requireString(field, 'mapping field');
   const trimmed = field.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Mapping field must not be empty.');
@@ -380,7 +384,14 @@ export class BloomreachEvaluationSettingsService {
       input.attributionWindow !== undefined
         ? validateAttributionWindow(input.attributionWindow)
         : undefined;
-    const channels = input.channels?.map((channel) => channel.trim());
+    let channels: string[] | undefined;
+    if (input.channels !== undefined) {
+      requireArray(input.channels, 'channels');
+      channels = input.channels.map((channel, index) => {
+        requireString(channel, `channels[${index}]`);
+        return channel.trim();
+      });
+    }
 
     const preview = {
       action: CONFIGURE_REVENUE_ATTRIBUTION_ACTION_TYPE,
@@ -402,8 +413,11 @@ export class BloomreachEvaluationSettingsService {
   prepareSetCurrency(input: SetCurrencyInput): PreparedEvaluationSettingsAction {
     const project = validateProject(input.project);
     const currencyCode = validateCurrencyCode(input.currencyCode);
-    const currencySymbol =
-      input.currencySymbol !== undefined ? input.currencySymbol.trim() : undefined;
+    let currencySymbol: string | undefined;
+    if (input.currencySymbol !== undefined) {
+      requireString(input.currencySymbol, 'currency symbol');
+      currencySymbol = input.currencySymbol.trim();
+    }
 
     const preview = {
       action: SET_CURRENCY_ACTION_TYPE,
@@ -425,13 +439,17 @@ export class BloomreachEvaluationSettingsService {
     input: ConfigureEvaluationDashboardsInput,
   ): PreparedEvaluationSettingsAction {
     const project = validateProject(input.project);
+    requireArray(input.dashboards, 'dashboards');
     if (input.dashboards.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one dashboard configuration must be provided.');
     }
-    const dashboards = input.dashboards.map((dashboard) => ({
-      id: validateDashboardId(dashboard.id),
-      enabled: dashboard.enabled,
-    }));
+    const dashboards = input.dashboards.map((dashboard, index) => {
+      requireObject(dashboard, `dashboards[${index}]`);
+      return {
+        id: validateDashboardId(dashboard.id),
+        enabled: dashboard.enabled,
+      };
+    });
 
     const preview = {
       action: CONFIGURE_EVALUATION_DASHBOARDS_ACTION_TYPE,
@@ -453,7 +471,11 @@ export class BloomreachEvaluationSettingsService {
   ): PreparedEvaluationSettingsAction {
     const project = validateProject(input.project);
     const mappingField = validateMappingField(input.mappingField);
-    const mappingType = input.mappingType !== undefined ? input.mappingType.trim() : undefined;
+    let mappingType: string | undefined;
+    if (input.mappingType !== undefined) {
+      requireString(input.mappingType, 'mapping type');
+      mappingType = input.mappingType.trim();
+    }
 
     const preview = {
       action: CONFIGURE_VOUCHER_MAPPING_ACTION_TYPE,

--- a/packages/core/src/bloomreachExports.ts
+++ b/packages/core/src/bloomreachExports.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -135,6 +135,8 @@ const EXPORT_TYPES = new Set(['customers', 'events']);
 const DESTINATION_TYPES = new Set(['sftp', 's3', 'email', 'webhook']);
 const SCHEDULE_FREQUENCIES = new Set(['daily', 'weekly', 'monthly']);
 function validateRequiredTrimmed(value: string, fieldName: string): string {
+  requireString(value, 'value');
+  requireString(fieldName, 'Field name');
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not be empty.`);
@@ -143,6 +145,7 @@ function validateRequiredTrimmed(value: string, fieldName: string): string {
 }
 
 function validateExportName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Export name');
   if (trimmed.length > MAX_EXPORT_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export name must not exceed ${MAX_EXPORT_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -151,6 +154,7 @@ function validateExportName(name: string): string {
 }
 
 function validateExportType(exportType: string): string {
+  requireString(exportType, 'Export type');
   const normalized = validateRequiredTrimmed(exportType, 'Export type').toLowerCase();
   if (!EXPORT_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export type must be one of: ${Array.from(EXPORT_TYPES).join(', ')} (got ${normalized}).`);
@@ -159,6 +163,7 @@ function validateExportType(exportType: string): string {
 }
 
 function validateDestinationType(destinationType: string): string {
+  requireString(destinationType, 'Destination type');
   const normalized = validateRequiredTrimmed(destinationType, 'Destination type').toLowerCase();
   if (!DESTINATION_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Destination type must be one of: ${Array.from(DESTINATION_TYPES).join(', ')} (got ${normalized}).`);
@@ -167,6 +172,7 @@ function validateDestinationType(destinationType: string): string {
 }
 
 function validateExportId(exportId: string): string {
+  requireString(exportId, 'Export ID');
   const trimmed = validateRequiredTrimmed(exportId, 'Export ID');
   if (trimmed.length > MAX_EXPORT_ID_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export ID must not exceed ${MAX_EXPORT_ID_LENGTH} characters (got ${trimmed.length}).`);
@@ -175,6 +181,7 @@ function validateExportId(exportId: string): string {
 }
 
 function validateScheduleFrequency(frequency: string): string {
+  requireString(frequency, 'frequency');
   const normalized = validateRequiredTrimmed(frequency, 'Schedule frequency').toLowerCase();
   if (!SCHEDULE_FREQUENCIES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`);
@@ -200,9 +207,12 @@ function validateOptionalString(
 }
 
 function validateStringArray(values: string[] | undefined, fieldName: string): string[] | undefined {
+  requireString(fieldName, 'Field name');
   if (values === undefined) {
     return undefined;
   }
+
+  requireArray(values, fieldName);
 
   if (!Array.isArray(values)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must be an array.`);
@@ -325,6 +335,7 @@ function validateDestination(destination: ExportDestination): ExportDestination 
 }
 
 function validateTimeFormat(time: string): string {
+  requireString(time, 'time');
   const trimmed = validateRequiredTrimmed(time, 'Schedule time');
   const match = /^(\d{2}):(\d{2})$/.exec(trimmed);
   if (match === null) {

--- a/packages/core/src/bloomreachFlows.ts
+++ b/packages/core/src/bloomreachFlows.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireString } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
@@ -106,6 +106,7 @@ const MIN_JOURNEY_DEPTH = 1;
 const MAX_JOURNEY_DEPTH = 20;
 
 export function validateFlowName(name: string): string {
+  requireString(name, 'Flow name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_FLOW_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Flow name must not be empty.');
@@ -117,6 +118,7 @@ export function validateFlowName(name: string): string {
 }
 
 export function validateFlowAnalysisId(id: string): string {
+  requireString(id, 'Flow analysis ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Flow analysis ID must not be empty.');
@@ -125,6 +127,7 @@ export function validateFlowAnalysisId(id: string): string {
 }
 
 export function validateStartingEvent(eventName: string): string {
+  requireString(eventName, 'Starting event');
   const trimmed = eventName.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Starting event must not be empty.');
@@ -133,6 +136,7 @@ export function validateStartingEvent(eventName: string): string {
 }
 
 export function validateFlowEvents(events: FlowEvent[]): FlowEvent[] {
+  requireArray(events, 'events');
   if (events.length < 1) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'events must contain at least one event to track.');
   }

--- a/packages/core/src/bloomreachFunnels.ts
+++ b/packages/core/src/bloomreachFunnels.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireString } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -99,6 +99,7 @@ const MAX_FUNNEL_NAME_LENGTH = 200;
 const MIN_FUNNEL_NAME_LENGTH = 1;
 
 export function validateFunnelName(name: string): string {
+  requireString(name, 'Funnel name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_FUNNEL_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Funnel name must not be empty.');
@@ -110,6 +111,7 @@ export function validateFunnelName(name: string): string {
 }
 
 export function validateFunnelAnalysisId(id: string): string {
+  requireString(id, 'Funnel analysis ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Funnel analysis ID must not be empty.');
@@ -118,6 +120,7 @@ export function validateFunnelAnalysisId(id: string): string {
 }
 
 export function validateFunnelSteps(steps: FunnelStep[]): FunnelStep[] {
+  requireArray(steps, 'steps');
   if (steps.length < 2) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'steps must contain at least two funnel steps.');
   }

--- a/packages/core/src/bloomreachGeoAnalyses.ts
+++ b/packages/core/src/bloomreachGeoAnalyses.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -92,6 +92,7 @@ const MAX_GEO_ANALYSIS_NAME_LENGTH = 200;
 const MIN_GEO_ANALYSIS_NAME_LENGTH = 1;
 
 export function validateGeoAnalysisName(name: string): string {
+  requireString(name, 'Geo analysis name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_GEO_ANALYSIS_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Geo analysis name must not be empty.');
@@ -103,6 +104,7 @@ export function validateGeoAnalysisName(name: string): string {
 }
 
 export function validateGeoGranularity(granularity: string): GeoGranularity {
+  requireString(granularity, 'granularity');
   if (!GEO_GRANULARITIES.includes(granularity as GeoGranularity)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `granularity must be one of: ${GEO_GRANULARITIES.join(', ')} (got "${granularity}").`);
   }
@@ -110,6 +112,7 @@ export function validateGeoGranularity(granularity: string): GeoGranularity {
 }
 
 export function validateGeoAnalysisId(id: string): string {
+  requireString(id, 'Geo analysis ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Geo analysis ID must not be empty.');
@@ -118,6 +121,7 @@ export function validateGeoAnalysisId(id: string): string {
 }
 
 export function validateAttribute(attribute: string): string {
+  requireString(attribute, 'attribute');
   const trimmed = attribute.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'attribute must not be empty.');

--- a/packages/core/src/bloomreachImports.ts
+++ b/packages/core/src/bloomreachImports.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -142,6 +142,8 @@ const MAPPING_TRANSFORMATION_TYPES = new Set([
 ]);
 
 function validateRequiredTrimmed(value: string, fieldName: string): string {
+  requireString(value, 'value');
+  requireString(fieldName, 'Field name');
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${fieldName} must not be empty.`);
@@ -150,6 +152,7 @@ function validateRequiredTrimmed(value: string, fieldName: string): string {
 }
 
 function validateImportName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Import name');
   if (trimmed.length > MAX_IMPORT_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import name must not exceed ${MAX_IMPORT_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -158,6 +161,7 @@ function validateImportName(name: string): string {
 }
 
 function validateImportType(type: string): string {
+  requireString(type, 'type');
   const normalized = validateRequiredTrimmed(type, 'Import type').toLowerCase();
   if (!IMPORT_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import type must be one of: ${Array.from(IMPORT_TYPES).join(', ')} (got ${normalized}).`);
@@ -166,6 +170,7 @@ function validateImportType(type: string): string {
 }
 
 function validateImportStatus(status: string): string {
+  requireString(status, 'status');
   const normalized = validateRequiredTrimmed(status, 'Import status').toLowerCase();
   if (!IMPORT_STATUSES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import status must be one of: ${Array.from(IMPORT_STATUSES).join(', ')} (got ${normalized}).`);
@@ -174,6 +179,7 @@ function validateImportStatus(status: string): string {
 }
 
 function validateImportSource(source: string): string {
+  requireString(source, 'source');
   const trimmed = validateRequiredTrimmed(source, 'Import source');
   if (trimmed.length > MAX_SOURCE_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import source must not exceed ${MAX_SOURCE_LENGTH} characters (got ${trimmed.length}).`);
@@ -187,6 +193,7 @@ function validateImportSource(source: string): string {
 }
 
 function validateImportId(id: string): string {
+  requireString(id, 'id');
   const trimmed = validateRequiredTrimmed(id, 'Import ID');
   if (trimmed.length > MAX_IMPORT_ID_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Import ID must not exceed ${MAX_IMPORT_ID_LENGTH} characters (got ${trimmed.length}).`);
@@ -195,6 +202,7 @@ function validateImportId(id: string): string {
 }
 
 function validateColumnName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Source column');
   if (trimmed.length > MAX_COLUMN_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Source column must not exceed ${MAX_COLUMN_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -203,6 +211,7 @@ function validateColumnName(name: string): string {
 }
 
 function validatePropertyName(name: string): string {
+  requireString(name, 'name');
   const trimmed = validateRequiredTrimmed(name, 'Target property');
   if (trimmed.length > MAX_PROPERTY_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Target property must not exceed ${MAX_PROPERTY_NAME_LENGTH} characters (got ${trimmed.length}).`);
@@ -211,6 +220,7 @@ function validatePropertyName(name: string): string {
 }
 
 function validateMappingTransformationType(type: string): string {
+  requireString(type, 'type');
   const normalized = validateRequiredTrimmed(type, 'Transformation type').toLowerCase();
   if (!MAPPING_TRANSFORMATION_TYPES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Transformation type must be one of: ${Array.from(MAPPING_TRANSFORMATION_TYPES).join(', ')} (got ${normalized}).`);
@@ -219,6 +229,7 @@ function validateMappingTransformationType(type: string): string {
 }
 
 function validateMapping(mapping: ImportMapping[]): ImportMapping[] {
+  requireArray(mapping, 'mapping');
   if (!Array.isArray(mapping)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Mapping must be an array.');
   }
@@ -244,6 +255,7 @@ function validateMapping(mapping: ImportMapping[]): ImportMapping[] {
 }
 
 function validateScheduleFrequency(frequency: string): string {
+  requireString(frequency, 'frequency');
   const normalized = validateRequiredTrimmed(frequency, 'Schedule frequency').toLowerCase();
   if (!SCHEDULE_FREQUENCIES.has(normalized)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Schedule frequency must be one of: ${Array.from(SCHEDULE_FREQUENCIES).join(', ')} (got ${normalized}).`);
@@ -252,6 +264,7 @@ function validateScheduleFrequency(frequency: string): string {
 }
 
 function validateCronExpression(cron: string): string {
+  requireString(cron, 'cron');
   const trimmed = validateRequiredTrimmed(cron, 'Cron expression');
   if (trimmed.length > MAX_CRON_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Cron expression must not exceed ${MAX_CRON_LENGTH} characters (got ${trimmed.length}).`);

--- a/packages/core/src/bloomreachInitiatives.ts
+++ b/packages/core/src/bloomreachInitiatives.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray, requireObject } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_INITIATIVE_ACTION_TYPE = 'initiatives.create_initiative';
@@ -101,6 +101,7 @@ const MAX_INITIATIVE_DESCRIPTION_LENGTH = 2000;
 const MAX_ITEMS_PER_ADD = 100;
 
 export function validateInitiativeName(name: string): string {
+  requireString(name, 'name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_INITIATIVE_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Initiative name must not be empty.');
@@ -112,6 +113,7 @@ export function validateInitiativeName(name: string): string {
 }
 
 export function validateInitiativeDescription(description: string): string {
+  requireString(description, 'description');
   const trimmed = description.trim();
   if (trimmed.length > MAX_INITIATIVE_DESCRIPTION_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Initiative description must not exceed ${MAX_INITIATIVE_DESCRIPTION_LENGTH} characters (got ${trimmed.length}).`);
@@ -120,6 +122,7 @@ export function validateInitiativeDescription(description: string): string {
 }
 
 export function validateInitiativeStatus(status: string): InitiativeStatus {
+  requireString(status, 'status');
   if (!INITIATIVE_STATUSES.includes(status as InitiativeStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${INITIATIVE_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -127,6 +130,7 @@ export function validateInitiativeStatus(status: string): InitiativeStatus {
 }
 
 export function validateInitiativeId(id: string): string {
+  requireString(id, 'id');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Initiative ID must not be empty.');
@@ -135,6 +139,7 @@ export function validateInitiativeId(id: string): string {
 }
 
 export function validateInitiativeItemType(type: string): InitiativeItemType {
+  requireString(type, 'type');
   if (!INITIATIVE_ITEM_TYPES.includes(type as InitiativeItemType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Item type must be one of: ${INITIATIVE_ITEM_TYPES.join(', ')} (got "${type}").`);
   }
@@ -144,6 +149,7 @@ export function validateInitiativeItemType(type: string): InitiativeItemType {
 export function validateInitiativeItems(
   items: InitiativeItemReference[],
 ): InitiativeItemReference[] {
+  requireArray(items, 'items');
   if (items.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Items array must not be empty.');
   }
@@ -151,6 +157,7 @@ export function validateInitiativeItems(
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Cannot add more than ${MAX_ITEMS_PER_ADD} items at once (got ${items.length}).`);
   }
   for (const item of items) {
+    requireString(item.id, 'Item ID');
     if (!item.id || item.id.trim().length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Each item must have a non-empty ID.');
     }
@@ -162,6 +169,7 @@ export function validateInitiativeItems(
 export function validateImportConfiguration(
   configuration: Record<string, unknown>,
 ): Record<string, unknown> {
+  requireObject(configuration, 'Import configuration');
   if (Object.keys(configuration).length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Import configuration must not be empty.');
   }

--- a/packages/core/src/bloomreachIntegrations.ts
+++ b/packages/core/src/bloomreachIntegrations.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -156,6 +156,7 @@ const MIN_INTEGRATION_NAME_LENGTH = 1;
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validateIntegrationName(name: string): string {
+  requireString(name, 'name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_INTEGRATION_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Integration name must not be empty.');
@@ -168,6 +169,7 @@ export function validateIntegrationName(name: string): string {
 
 /** @throws {Error} If project is empty. */
 export function validateIntegrationProject(project: string): string {
+  requireString(project, 'project');
   const trimmed = project.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Project identifier must not be empty.');
@@ -177,6 +179,7 @@ export function validateIntegrationProject(project: string): string {
 
 /** @throws {Error} If integrationId is empty. */
 export function validateIntegrationId(integrationId: string): string {
+  requireString(integrationId, 'Integration ID');
   const trimmed = integrationId.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Integration ID must not be empty.');
@@ -186,6 +189,7 @@ export function validateIntegrationId(integrationId: string): string {
 
 /** @throws {Error} If type is not a valid integration type. */
 export function validateIntegrationType(type: string): IntegrationType {
+  requireString(type, 'type');
   if (!INTEGRATION_TYPES.includes(type as IntegrationType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid integration type '${type}'. Must be one of: ${INTEGRATION_TYPES.join(', ')}.`);
   }
@@ -194,6 +198,7 @@ export function validateIntegrationType(type: string): IntegrationType {
 
 /** @throws {Error} If status is not a valid integration status. */
 export function validateIntegrationStatus(status: string): IntegrationStatus {
+  requireString(status, 'status');
   if (!INTEGRATION_STATUSES.includes(status as IntegrationStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid integration status '${status}'. Must be one of: ${INTEGRATION_STATUSES.join(', ')}.`);
   }
@@ -202,6 +207,7 @@ export function validateIntegrationStatus(status: string): IntegrationStatus {
 
 /** @throws {Error} If provider is empty. */
 export function validateProvider(provider: string): string {
+  requireString(provider, 'provider');
   const trimmed = provider.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Provider must not be empty.');

--- a/packages/core/src/bloomreachMetrics.ts
+++ b/packages/core/src/bloomreachMetrics.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireObject, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
@@ -95,6 +95,7 @@ const AGGREGATION_TYPES = new Set(['sum', 'count', 'average', 'min', 'max', 'uni
 const PROPERTY_REQUIRED_AGGREGATION_TYPES = new Set(['sum', 'average', 'min', 'max']);
 
 export function validateMetricName(name: string): string {
+  requireString(name, 'Metric name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_METRIC_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Metric name must not be empty.');
@@ -106,6 +107,7 @@ export function validateMetricName(name: string): string {
 }
 
 export function validateMetricId(id: string): string {
+  requireString(id, 'Metric ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Metric ID must not be empty.');
@@ -114,6 +116,7 @@ export function validateMetricId(id: string): string {
 }
 
 export function validateDescription(description: string): string {
+  requireString(description, 'Description');
   const trimmed = description.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Description must not be empty.');
@@ -125,6 +128,7 @@ export function validateDescription(description: string): string {
 }
 
 export function validateAggregationType(type: string): string {
+  requireString(type, 'Aggregation type');
   const normalized = type.trim().toLowerCase();
   if (normalized.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Aggregation type must not be empty.');
@@ -136,12 +140,17 @@ export function validateAggregationType(type: string): string {
 }
 
 export function validateAggregation(aggregation: MetricAggregation): MetricAggregation {
+  requireObject(aggregation, 'aggregation');
+  requireString(aggregation.eventName, 'Aggregation eventName');
   const eventName = aggregation.eventName.trim();
   if (eventName.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Aggregation eventName must not be empty.');
   }
 
   const aggregationType = validateAggregationType(aggregation.aggregationType);
+  if (aggregation.propertyName !== undefined) {
+    requireString(aggregation.propertyName, 'Aggregation propertyName');
+  }
   const propertyName = aggregation.propertyName?.trim();
 
   if (

--- a/packages/core/src/bloomreachPerformance.ts
+++ b/packages/core/src/bloomreachPerformance.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const PERFORMANCE_DASHBOARD_TYPES = [
@@ -73,6 +73,7 @@ export type ChannelType = (typeof CHANNEL_TYPES)[number];
 
 /** @throws {Error} If `channel` is not a recognised channel type. */
 export function validateChannel(channel: string): ChannelType {
+  requireString(channel, 'channel');
   if (!CHANNEL_TYPES.includes(channel as ChannelType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `channel must be one of: ${CHANNEL_TYPES.join(', ')} (got "${channel}").`);
   }

--- a/packages/core/src/bloomreachProjectSettings.ts
+++ b/packages/core/src/bloomreachProjectSettings.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Action type constants
@@ -206,6 +206,7 @@ const MIN_CUSTOM_URL_LENGTH = 1;
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validateProjectName(name: string): string {
+  requireString(name, 'project name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_PROJECT_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Project name must not be empty.');
@@ -218,6 +219,7 @@ export function validateProjectName(name: string): string {
 
 /** @throws {Error} If tag name is empty or exceeds 100 characters. */
 export function validateCustomTagName(name: string): string {
+  requireString(name, 'tag name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_TAG_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag name must not be empty.');
@@ -230,6 +232,7 @@ export function validateCustomTagName(name: string): string {
 
 /** @throws {Error} If tag ID is empty. */
 export function validateCustomTagId(id: string): string {
+  requireString(id, 'tagId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag ID must not be empty.');
@@ -239,6 +242,7 @@ export function validateCustomTagId(id: string): string {
 
 /** @throws {Error} If colour is not a valid hex colour code. */
 export function validateTagColor(color: string): string {
+  requireString(color, 'color');
   const trimmed = color.trim();
   if (!/^#[0-9a-fA-F]{6}$/.test(trimmed)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Tag color must be a valid hex color code (e.g. "#FF5733"), got "${trimmed}".`);
@@ -248,6 +252,7 @@ export function validateTagColor(color: string): string {
 
 /** @throws {Error} If variable name is empty or exceeds 200 characters. */
 export function validateVariableName(name: string): string {
+  requireString(name, 'variable name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_VARIABLE_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Variable name must not be empty.');
@@ -260,6 +265,7 @@ export function validateVariableName(name: string): string {
 
 /** @throws {Error} If variable value exceeds 5000 characters. */
 export function validateVariableValue(value: string): string {
+  requireString(value, 'value');
   if (value.length > MAX_VARIABLE_VALUE_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Variable value must not exceed ${MAX_VARIABLE_VALUE_LENGTH} characters (got ${value.length}).`);
   }
@@ -268,6 +274,7 @@ export function validateVariableValue(value: string): string {
 
 /** @throws {Error} If custom URL is empty or exceeds 500 characters. */
 export function validateCustomUrl(url: string): string {
+  requireString(url, 'customUrl');
   const trimmed = url.trim();
   if (trimmed.length < MIN_CUSTOM_URL_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Custom URL must not be empty.');

--- a/packages/core/src/bloomreachRecommendations.ts
+++ b/packages/core/src/bloomreachRecommendations.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireObject, requireString } from './errors.js';
 
 export const CREATE_RECOMMENDATION_MODEL_ACTION_TYPE = 'recommendations.create_model';
 export const CONFIGURE_RECOMMENDATION_MODEL_ACTION_TYPE = 'recommendations.configure_model';
@@ -117,6 +117,7 @@ const MIN_MAX_ITEMS = 1;
 const MAX_MAX_ITEMS = 100;
 
 export function validateModelName(name: string): string {
+  requireString(name, 'model name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_MODEL_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Model name must not be empty.');
@@ -128,6 +129,7 @@ export function validateModelName(name: string): string {
 }
 
 export function validateModelId(id: string): string {
+  requireString(id, 'modelId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Model ID must not be empty.');
@@ -136,6 +138,7 @@ export function validateModelId(id: string): string {
 }
 
 export function validateRecommendationModelStatus(status: string): RecommendationModelStatus {
+  requireString(status, 'status');
   if (!RECOMMENDATION_MODEL_STATUSES.includes(status as RecommendationModelStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${RECOMMENDATION_MODEL_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -143,6 +146,7 @@ export function validateRecommendationModelStatus(status: string): Recommendatio
 }
 
 export function validateAlgorithmType(algorithm: string): RecommendationAlgorithmType {
+  requireString(algorithm, 'algorithm');
   if (!RECOMMENDATION_ALGORITHM_TYPES.includes(algorithm as RecommendationAlgorithmType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `algorithm must be one of: ${RECOMMENDATION_ALGORITHM_TYPES.join(', ')} (got "${algorithm}").`);
   }
@@ -152,11 +156,16 @@ export function validateAlgorithmType(algorithm: string): RecommendationAlgorith
 export function validateFilterRules(
   filters: RecommendationFilterRule[],
 ): RecommendationFilterRule[] {
+  requireArray(filters, 'filters');
   if (filters.length > MAX_FILTER_RULES) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `filters must contain at most ${MAX_FILTER_RULES} rules (got ${filters.length}).`);
   }
 
   return filters.map((filter, index) => {
+    requireObject(filter, `filters[${index}]`);
+    requireString(filter.field, `filters[${index}].field`);
+    requireString(filter.operator, `filters[${index}].operator`);
+    requireString(filter.value, `filters[${index}].value`);
     const field = filter.field.trim();
     const operator = filter.operator.trim();
     const value = filter.value.trim();
@@ -182,11 +191,14 @@ export function validateFilterRules(
 export function validateBoostRules(
   boostRules: RecommendationBoostRule[],
 ): RecommendationBoostRule[] {
+  requireArray(boostRules, 'boostRules');
   if (boostRules.length > MAX_BOOST_RULES) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `boostRules must contain at most ${MAX_BOOST_RULES} rules (got ${boostRules.length}).`);
   }
 
   return boostRules.map((boostRule, index) => {
+    requireObject(boostRule, `boostRules[${index}]`);
+    requireString(boostRule.field, `boostRules[${index}].field`);
     const field = boostRule.field.trim();
     if (field.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `boostRules[${index}].field must not be empty.`);
@@ -293,6 +305,7 @@ export class BloomreachRecommendationsService {
   ): PreparedRecommendationAction {
     const project = validateProject(input.project);
     const name = validateModelName(input.name);
+    requireString(input.modelType, 'model type');
     const modelType = input.modelType.trim();
     if (modelType.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Model type must not be empty.');

--- a/packages/core/src/bloomreachReports.ts
+++ b/packages/core/src/bloomreachReports.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildDataPath } from './bloomreachApiClient.js';
 
@@ -140,6 +140,7 @@ const MIN_REPORT_LIMIT = 1;
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validateReportName(name: string): string {
+  requireString(name, 'report name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_REPORT_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report name must not be empty.');
@@ -152,6 +153,7 @@ export function validateReportName(name: string): string {
 
 /** @throws {Error} If report ID is empty. */
 export function validateReportId(id: string): string {
+  requireString(id, 'reportId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report ID must not be empty.');
@@ -161,6 +163,7 @@ export function validateReportId(id: string): string {
 
 /** @throws {Error} If metrics array is empty. */
 export function validateMetrics(metrics: string[]): string[] {
+  requireArray(metrics, 'metrics');
   if (metrics.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one metric is required.');
   }
@@ -174,6 +177,7 @@ export function validateMetrics(metrics: string[]): string[] {
 }
 
 export function validateReportExportFormat(format: string): ReportExportFormat {
+  requireString(format, 'format');
   if (!REPORT_EXPORT_FORMATS.includes(format as ReportExportFormat)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Export format must be one of: ${REPORT_EXPORT_FORMATS.join(', ')} (got "${format}").`);
   }
@@ -182,6 +186,7 @@ export function validateReportExportFormat(format: string): ReportExportFormat {
 
 /** @throws {Error} If sort order is not asc or desc. */
 export function validateSortOrder(order: string): ReportSortOrder {
+  requireString(order, 'order');
   if (!REPORT_SORT_ORDERS.includes(order as ReportSortOrder)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Sort order must be one of: ${REPORT_SORT_ORDERS.join(', ')} (got "${order}").`);
   }

--- a/packages/core/src/bloomreachRetentions.ts
+++ b/packages/core/src/bloomreachRetentions.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -102,6 +102,7 @@ const MAX_RETENTION_NAME_LENGTH = 200;
 const MIN_RETENTION_NAME_LENGTH = 1;
 
 export function validateRetentionName(name: string): string {
+  requireString(name, 'Retention name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_RETENTION_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Retention name must not be empty.');
@@ -115,6 +116,7 @@ export function validateRetentionName(name: string): string {
 export function validateRetentionGranularity(
   granularity: string,
 ): RetentionGranularity {
+  requireString(granularity, 'granularity');
   if (
     !RETENTION_GRANULARITIES.includes(granularity as RetentionGranularity)
   ) {
@@ -124,6 +126,7 @@ export function validateRetentionGranularity(
 }
 
 export function validateRetentionAnalysisId(id: string): string {
+  requireString(id, 'Retention analysis ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Retention analysis ID must not be empty.');
@@ -132,6 +135,7 @@ export function validateRetentionAnalysisId(id: string): string {
 }
 
 export function validateEventName(label: string, eventName: string): string {
+  requireString(eventName, label);
   const trimmed = eventName.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `${label} must not be empty.`);

--- a/packages/core/src/bloomreachScenarios.ts
+++ b/packages/core/src/bloomreachScenarios.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SCENARIO_ACTION_TYPE = 'scenarios.create_scenario';
@@ -100,6 +100,7 @@ const MAX_SCENARIO_NAME_LENGTH = 200;
 const MIN_SCENARIO_NAME_LENGTH = 1;
 
 export function validateScenarioName(name: string): string {
+  requireString(name, 'scenario name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_SCENARIO_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Scenario name must not be empty.');
@@ -111,6 +112,7 @@ export function validateScenarioName(name: string): string {
 }
 
 export function validateScenarioStatus(status: string): ScenarioStatus {
+  requireString(status, 'status');
   if (!SCENARIO_STATUSES.includes(status as ScenarioStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${SCENARIO_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -118,6 +120,7 @@ export function validateScenarioStatus(status: string): ScenarioStatus {
 }
 
 export function validateScenarioId(id: string): string {
+  requireString(id, 'scenarioId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Scenario ID must not be empty.');

--- a/packages/core/src/bloomreachSecuritySettings.ts
+++ b/packages/core/src/bloomreachSecuritySettings.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -121,6 +121,7 @@ const MAX_HOST_LENGTH = 253;
 const MAX_USERNAME_LENGTH = 200;
 
 export function validateTunnelName(name: string): string {
+  requireString(name, 'tunnel name');
   const trimmed = name.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tunnel name must not be empty.');
@@ -132,6 +133,7 @@ export function validateTunnelName(name: string): string {
 }
 
 export function validateHost(host: string): string {
+  requireString(host, 'host');
   const trimmed = host.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Host must not be empty.');
@@ -153,6 +155,7 @@ export function validatePort(port: number): number {
 }
 
 export function validateUsername(username: string): string {
+  requireString(username, 'username');
   const trimmed = username.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Username must not be empty.');
@@ -164,6 +167,7 @@ export function validateUsername(username: string): string {
 }
 
 export function validateTunnelId(tunnelId: string): string {
+  requireString(tunnelId, 'tunnelId');
   const trimmed = tunnelId.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tunnel ID must not be empty.');
@@ -370,9 +374,23 @@ export class BloomreachSecuritySettingsService {
     const host = validateHost(input.host);
     const port = validatePort(input.port);
     const username = validateUsername(input.username);
-    const password = input.password !== undefined ? input.password.trim() : undefined;
-    const hostKey = input.hostKey !== undefined ? input.hostKey.trim() : undefined;
-    const databaseType = input.databaseType !== undefined ? input.databaseType.trim() : undefined;
+    let password: string | undefined;
+    if (input.password !== undefined) {
+      requireString(input.password, 'password');
+      password = input.password.trim();
+    }
+
+    let hostKey: string | undefined;
+    if (input.hostKey !== undefined) {
+      requireString(input.hostKey, 'host key');
+      hostKey = input.hostKey.trim();
+    }
+
+    let databaseType: string | undefined;
+    if (input.databaseType !== undefined) {
+      requireString(input.databaseType, 'database type');
+      databaseType = input.databaseType.trim();
+    }
 
     const preview = {
       action: CREATE_SSH_TUNNEL_ACTION_TYPE,
@@ -402,8 +420,17 @@ export class BloomreachSecuritySettingsService {
     const host = input.host !== undefined ? validateHost(input.host) : undefined;
     const port = input.port !== undefined ? validatePort(input.port) : undefined;
     const username = input.username !== undefined ? validateUsername(input.username) : undefined;
-    const password = input.password !== undefined ? input.password.trim() : undefined;
-    const hostKey = input.hostKey !== undefined ? input.hostKey.trim() : undefined;
+    let password: string | undefined;
+    if (input.password !== undefined) {
+      requireString(input.password, 'password');
+      password = input.password.trim();
+    }
+
+    let hostKey: string | undefined;
+    if (input.hostKey !== undefined) {
+      requireString(input.hostKey, 'host key');
+      hostKey = input.hostKey.trim();
+    }
 
     if (
       name === undefined &&

--- a/packages/core/src/bloomreachSegmentations.ts
+++ b/packages/core/src/bloomreachSegmentations.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireString } from './errors.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
@@ -129,6 +129,7 @@ const MAX_SEGMENTATION_NAME_LENGTH = 200;
 const MIN_SEGMENTATION_NAME_LENGTH = 1;
 
 export function validateSegmentationName(name: string): string {
+  requireString(name, 'Segmentation name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_SEGMENTATION_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Segmentation name must not be empty.');
@@ -140,6 +141,7 @@ export function validateSegmentationName(name: string): string {
 }
 
 export function validateSegmentationId(id: string): string {
+  requireString(id, 'Segmentation ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Segmentation ID must not be empty.');
@@ -148,6 +150,7 @@ export function validateSegmentationId(id: string): string {
 }
 
 export function validateSegmentConditionType(type: string): SegmentConditionType {
+  requireString(type, 'condition type');
   if (!(SEGMENT_CONDITION_TYPES as readonly string[]).includes(type)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid condition type "${type}". Must be one of: ${SEGMENT_CONDITION_TYPES.join(', ')}.`);
   }
@@ -155,6 +158,7 @@ export function validateSegmentConditionType(type: string): SegmentConditionType
 }
 
 export function validateSegmentConditionOperator(operator: string): SegmentConditionOperator {
+  requireString(operator, 'condition operator');
   if (!(SEGMENT_CONDITION_OPERATORS as readonly string[]).includes(operator)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid condition operator "${operator}". Must be one of: ${SEGMENT_CONDITION_OPERATORS.join(', ')}.`);
   }
@@ -162,6 +166,7 @@ export function validateSegmentConditionOperator(operator: string): SegmentCondi
 }
 
 export function validateLogicalOperator(operator: string): SegmentLogicalOperator {
+  requireString(operator, 'logical operator');
   if (!(SEGMENT_LOGICAL_OPERATORS as readonly string[]).includes(operator)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Invalid logical operator "${operator}". Must be one of: ${SEGMENT_LOGICAL_OPERATORS.join(', ')}.`);
   }
@@ -169,6 +174,7 @@ export function validateLogicalOperator(operator: string): SegmentLogicalOperato
 }
 
 export function validateSegmentConditions(conditions: SegmentCondition[]): SegmentCondition[] {
+  requireArray(conditions, 'conditions');
   if (conditions.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'conditions must contain at least one segment condition.');
   }

--- a/packages/core/src/bloomreachSqlReports.ts
+++ b/packages/core/src/bloomreachSqlReports.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SQL_REPORT_ACTION_TYPE = 'sql_reports.create_report';
@@ -105,6 +105,7 @@ export interface PreparedSqlReportAction {
 }
 
 export function validateSqlReportName(name: string): string {
+  requireString(name, 'report name');
   const trimmed = name.trim();
   if (trimmed.length < 1) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report name must not be empty.');
@@ -116,6 +117,7 @@ export function validateSqlReportName(name: string): string {
 }
 
 export function validateSqlReportId(id: string): string {
+  requireString(id, 'reportId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Report ID must not be empty.');
@@ -124,6 +126,7 @@ export function validateSqlReportId(id: string): string {
 }
 
 export function validateSqlQuery(query: string): string {
+  requireString(query, 'query');
   const trimmed = query.trim();
   if (trimmed.length < 1) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'SQL query must not be empty.');
@@ -135,6 +138,7 @@ export function validateSqlQuery(query: string): string {
 }
 
 export function validateSqlReportExportFormat(format: string): SqlReportExportFormat {
+  requireString(format, 'format');
   if (!SQL_REPORT_EXPORT_FORMATS.includes(format as SqlReportExportFormat)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `format must be one of: ${SQL_REPORT_EXPORT_FORMATS.join(', ')} (got "${format}").`);
   }
@@ -142,6 +146,7 @@ export function validateSqlReportExportFormat(format: string): SqlReportExportFo
 }
 
 export function validateSqlReportStatus(status: string): SqlReportStatus {
+  requireString(status, 'status');
   if (!SQL_REPORT_STATUSES.includes(status as SqlReportStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${SQL_REPORT_STATUSES.join(', ')} (got "${status}").`);
   }

--- a/packages/core/src/bloomreachSurveys.ts
+++ b/packages/core/src/bloomreachSurveys.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const CREATE_SURVEY_ACTION_TYPE = 'surveys.create_survey';
@@ -113,6 +113,7 @@ const MIN_QUESTION_TEXT_LENGTH = 1;
 const MAX_QUESTION_OPTIONS = 20;
 
 export function validateSurveyName(name: string): string {
+  requireString(name, 'survey name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_SURVEY_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Survey name must not be empty.');
@@ -124,6 +125,7 @@ export function validateSurveyName(name: string): string {
 }
 
 export function validateSurveyStatus(status: string): SurveyStatus {
+  requireString(status, 'status');
   if (!SURVEY_STATUSES.includes(status as SurveyStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${SURVEY_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -131,6 +133,7 @@ export function validateSurveyStatus(status: string): SurveyStatus {
 }
 
 export function validateSurveyId(id: string): string {
+  requireString(id, 'surveyId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Survey ID must not be empty.');
@@ -139,6 +142,7 @@ export function validateSurveyId(id: string): string {
 }
 
 export function validateQuestionType(type: string): SurveyQuestionType {
+  requireString(type, 'question type');
   if (!SURVEY_QUESTION_TYPES.includes(type as SurveyQuestionType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `question type must be one of: ${SURVEY_QUESTION_TYPES.join(', ')} (got "${type}").`);
   }
@@ -146,6 +150,7 @@ export function validateQuestionType(type: string): SurveyQuestionType {
 }
 
 export function validateQuestionText(text: string): string {
+  requireString(text, 'question text');
   const trimmed = text.trim();
   if (trimmed.length < MIN_QUESTION_TEXT_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Question text must not be empty.');
@@ -157,6 +162,7 @@ export function validateQuestionText(text: string): string {
 }
 
 export function validateQuestions(questions: SurveyQuestion[]): SurveyQuestion[] {
+  requireArray(questions, 'questions');
   if (questions.length < MIN_QUESTIONS) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Survey must include at least ${MIN_QUESTIONS} question.`);
   }

--- a/packages/core/src/bloomreachTagManager.ts
+++ b/packages/core/src/bloomreachTagManager.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray, requireObject } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 /** Action type for creating a managed tag. */
@@ -132,6 +132,7 @@ const MAX_PRIORITY = 1000;
 
 /** @throws {Error} If tag name is empty or exceeds 200 characters. */
 export function validateTagName(name: string): string {
+  requireString(name, 'Tag name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_TAG_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag name must not be empty.');
@@ -144,6 +145,7 @@ export function validateTagName(name: string): string {
 
 /** @throws {Error} If tag ID is empty or exceeds 500 characters. */
 export function validateTagId(tagId: string): string {
+  requireString(tagId, 'Tag ID');
   const trimmed = tagId.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Tag ID must not be empty.');
@@ -156,6 +158,7 @@ export function validateTagId(tagId: string): string {
 
 /** @throws {Error} If JS code is empty or exceeds 100000 characters. */
 export function validateJsCode(code: string): string {
+  requireString(code, 'JS code');
   if (code.trim().length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'JS code must not be empty.');
   }
@@ -167,6 +170,7 @@ export function validateJsCode(code: string): string {
 
 /** @throws {Error} If status is not a recognised tag status. */
 export function validateTagStatus(status: string): TagStatus {
+  requireString(status, 'status');
   const trimmed = status.trim();
   if (!TAG_STATUSES.includes(trimmed as TagStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${TAG_STATUSES.join(', ')} (got "${status}").`);
@@ -176,6 +180,7 @@ export function validateTagStatus(status: string): TagStatus {
 
 /** @throws {Error} If URL is empty or exceeds 2000 characters. */
 export function validatePageUrl(url: string): string {
+  requireString(url, 'Page URL');
   const trimmed = url.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Page URL must not be empty.');
@@ -188,6 +193,7 @@ export function validatePageUrl(url: string): string {
 
 /** @throws {Error} If events are empty, too many, invalid, or not unique. */
 export function validateEvents(events: string[]): string[] {
+  requireArray(events, 'events');
   if (events.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Events must not be empty.');
   }
@@ -197,6 +203,7 @@ export function validateEvents(events: string[]): string[] {
 
   const validated: string[] = [];
   for (const eventName of events) {
+    requireString(eventName, 'Event name');
     const trimmed = eventName.trim();
     if (trimmed.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event name must not be empty.');
@@ -219,6 +226,7 @@ export function validateEvents(events: string[]): string[] {
 export function validateCustomerAttributes(
   attrs: Record<string, string>,
 ): Record<string, string> {
+  requireObject(attrs, 'customerAttributes');
   const entries = Object.entries(attrs);
   if (entries.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer attributes must not be empty.');
@@ -229,6 +237,7 @@ export function validateCustomerAttributes(
 
   const validated: Record<string, string> = {};
   for (const [key, value] of entries) {
+    requireString(value, `customerAttributes.${key}`);
     const trimmedKey = key.trim();
     if (trimmedKey.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Customer attribute key must not be empty.');

--- a/packages/core/src/bloomreachTracking.ts
+++ b/packages/core/src/bloomreachTracking.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray, requireObject } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { bloomreachApiFetch, buildTrackingPath } from './bloomreachApiClient.js';
 
@@ -94,6 +94,7 @@ export interface BatchResponse {
 const MAX_FIELD_LENGTH = 500;
 
 export function validateTrackingCustomerIds(ids: TrackingCustomerIds): TrackingCustomerIds {
+  requireObject(ids, 'customerIds');
   const hasAtLeastOne = Object.values(ids).some(
     (value) => typeof value === 'string' && value.trim().length > 0,
   );
@@ -120,6 +121,7 @@ export function validateTrackingCustomerIds(ids: TrackingCustomerIds): TrackingC
 }
 
 export function validateEventType(eventType: string): string {
+  requireString(eventType, 'Event type');
   const trimmed = eventType.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Event type must not be empty.');
@@ -131,6 +133,7 @@ export function validateEventType(eventType: string): string {
 }
 
 export function validateBatchCommands(commands: BatchCommand[]): BatchCommand[] {
+  requireArray(commands, 'commands');
   if (!Array.isArray(commands) || commands.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one batch command must be provided.');
   }
@@ -150,6 +153,7 @@ export function validateBatchCommands(commands: BatchCommand[]): BatchCommand[] 
 
     let commandId: string | undefined;
     if (command.commandId !== undefined) {
+      requireString(command.commandId, `commands[${index}].commandId`);
       const trimmedCommandId = command.commandId.trim();
       if (trimmedCommandId.length === 0) {
         throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Batch command at index ${index} has an empty commandId.`);
@@ -169,6 +173,7 @@ export function validateBatchCommands(commands: BatchCommand[]): BatchCommand[] 
 }
 
 export function validateTrackingConsentCategory(category: string): string {
+  requireString(category, 'category');
   const trimmed = category.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Consent category must not be empty.');
@@ -180,6 +185,7 @@ export function validateTrackingConsentCategory(category: string): string {
 }
 
 export function validateConsentAction(action: string): 'accept' | 'reject' {
+  requireString(action, 'action');
   const normalized = action.trim().toLowerCase();
   if (normalized !== 'accept' && normalized !== 'reject') {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `Consent action must be 'accept' or 'reject' (got '${action}').`);
@@ -188,6 +194,7 @@ export function validateConsentAction(action: string): 'accept' | 'reject' {
 }
 
 export function validateCampaignType(campaignType: string): string {
+  requireString(campaignType, 'Campaign type');
   const trimmed = campaignType.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign type must not be empty.');
@@ -199,6 +206,7 @@ export function validateCampaignType(campaignType: string): string {
 }
 
 export function validateCampaignAction(action: string): string {
+  requireString(action, 'action');
   const trimmed = action.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Campaign action must not be empty.');

--- a/packages/core/src/bloomreachTrends.ts
+++ b/packages/core/src/bloomreachTrends.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import { validateDateRange } from './bloomreachPerformance.js';
 import type { DateRangeFilter } from './bloomreachPerformance.js';
@@ -90,6 +90,7 @@ const MAX_TREND_NAME_LENGTH = 200;
 const MIN_TREND_NAME_LENGTH = 1;
 
 export function validateTrendName(name: string): string {
+  requireString(name, 'Trend name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_TREND_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Trend name must not be empty.');
@@ -101,6 +102,7 @@ export function validateTrendName(name: string): string {
 }
 
 export function validateTrendGranularity(granularity: string): TrendGranularity {
+  requireString(granularity, 'granularity');
   if (!TREND_GRANULARITIES.includes(granularity as TrendGranularity)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `granularity must be one of: ${TREND_GRANULARITIES.join(', ')} (got "${granularity}").`);
   }
@@ -108,6 +110,7 @@ export function validateTrendGranularity(granularity: string): TrendGranularity 
 }
 
 export function validateTrendAnalysisId(id: string): string {
+  requireString(id, 'Trend analysis ID');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Trend analysis ID must not be empty.');
@@ -246,7 +249,11 @@ export class BloomreachTrendsService {
     const granularity =
       input.granularity !== undefined ? validateTrendGranularity(input.granularity) : undefined;
 
-    const events = input.events.map((event) => event.trim()).filter(Boolean);
+    requireArray(input.events, 'events');
+    const events = input.events.map((event) => {
+      requireString(event, 'event name');
+      return event.trim();
+    }).filter(Boolean);
     if (events.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'events must contain at least one event name.');
     }

--- a/packages/core/src/bloomreachUseCases.ts
+++ b/packages/core/src/bloomreachUseCases.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 
 export const DEPLOY_USE_CASE_ACTION_TYPE = 'use_cases.deploy';
@@ -91,6 +91,7 @@ export interface PreparedUseCaseAction {
 }
 
 export function validateUseCaseId(id: string): string {
+  requireString(id, 'useCaseId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Use case ID must not be empty.');
@@ -99,6 +100,7 @@ export function validateUseCaseId(id: string): string {
 }
 
 export function validateUseCaseSearchQuery(query: string): string {
+  requireString(query, 'search query');
   const trimmed = query.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Search query must not be empty.');
@@ -107,6 +109,7 @@ export function validateUseCaseSearchQuery(query: string): string {
 }
 
 export function validateGoalCategory(category: string): UseCaseGoalCategory {
+  requireString(category, 'category');
   if (!USE_CASE_GOAL_CATEGORIES.includes(category as UseCaseGoalCategory)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `category must be one of: ${USE_CASE_GOAL_CATEGORIES.join(', ')} (got "${category}").`);
   }
@@ -114,6 +117,7 @@ export function validateGoalCategory(category: string): UseCaseGoalCategory {
 }
 
 export function validateUseCaseTag(tag: string): UseCaseTag {
+  requireString(tag, 'tag');
   if (!USE_CASE_TAGS.includes(tag as UseCaseTag)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `tag must be one of: ${USE_CASE_TAGS.join(', ')} (got "${tag}").`);
   }

--- a/packages/core/src/bloomreachVouchers.ts
+++ b/packages/core/src/bloomreachVouchers.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireString, requireArray } from './errors.js';
 import type { BloomreachApiConfig } from './bloomreachApiClient.js';
 import {
   validateListLimit as validateVoucherListLimit,
@@ -108,6 +108,7 @@ const MAX_REDEMPTIONS_LIMIT = 1_000_000;
 
 /** @throws {Error} If name is empty or exceeds 200 characters. */
 export function validatePoolName(name: string): string {
+  requireString(name, 'name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_POOL_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Pool name must not be empty.');
@@ -120,6 +121,7 @@ export function validatePoolName(name: string): string {
 
 /** @throws {Error} If pool ID is empty or exceeds 500 characters. */
 export function validatePoolId(poolId: string): string {
+  requireString(poolId, 'Pool ID');
   const trimmed = poolId.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Pool ID must not be empty.');
@@ -132,6 +134,7 @@ export function validatePoolId(poolId: string): string {
 
 /** @throws {Error} If any voucher code is empty, exceeds 200 chars, or batch exceeds 10,000. */
 export function validateVoucherCodes(codes: string[]): string[] {
+  requireArray(codes, 'codes');
   if (codes.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one voucher code must be provided.');
   }
@@ -140,6 +143,7 @@ export function validateVoucherCodes(codes: string[]): string[] {
   }
   const validated: string[] = [];
   for (const code of codes) {
+    requireString(code, 'Voucher code');
     const trimmed = code.trim();
     if (trimmed.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Voucher code must not be empty.');
@@ -178,6 +182,7 @@ export function validateRedemptionRules(rules: RedemptionRules): RedemptionRules
     }
   }
   if (rules.expiresAt !== undefined) {
+    requireString(rules.expiresAt, 'Expiration date');
     const trimmed = rules.expiresAt.trim();
     if (trimmed.length === 0) {
       throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Expiration date must not be empty.');
@@ -195,6 +200,10 @@ export function validateVoucherSource(
   voucherCodes?: string[],
   autoGenerateCount?: number,
 ): void {
+  if (voucherCodes !== undefined) {
+    requireArray(voucherCodes, 'voucherCodes');
+  }
+
   if (
     (voucherCodes === undefined || voucherCodes.length === 0) &&
     autoGenerateCount === undefined

--- a/packages/core/src/bloomreachWeblayers.ts
+++ b/packages/core/src/bloomreachWeblayers.ts
@@ -1,5 +1,5 @@
 import { validateProject } from './bloomreachDashboards.js';
-import { BloomreachBuddyError } from './errors.js';
+import { BloomreachBuddyError, requireArray, requireObject, requireString } from './errors.js';
 import {
   bloomreachApiFetch,
   buildWebxpPath,
@@ -150,6 +150,7 @@ const MIN_AB_TEST_VARIANTS = 2;
 const MAX_AB_TEST_VARIANTS = 10;
 
 export function validateWeblayerName(name: string): string {
+  requireString(name, 'weblayer name');
   const trimmed = name.trim();
   if (trimmed.length < MIN_WEBLAYER_NAME_LENGTH) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Weblayer name must not be empty.');
@@ -161,6 +162,7 @@ export function validateWeblayerName(name: string): string {
 }
 
 export function validateWeblayerStatus(status: string): WeblayerStatus {
+  requireString(status, 'status');
   if (!WEBLAYER_STATUSES.includes(status as WeblayerStatus)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `status must be one of: ${WEBLAYER_STATUSES.join(', ')} (got "${status}").`);
   }
@@ -168,6 +170,7 @@ export function validateWeblayerStatus(status: string): WeblayerStatus {
 }
 
 export function validateWeblayerId(id: string): string {
+  requireString(id, 'weblayerId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Weblayer ID must not be empty.');
@@ -176,6 +179,7 @@ export function validateWeblayerId(id: string): string {
 }
 
 export function validateBanditId(id: string): string {
+  requireString(id, 'banditId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Bandit ID must not be empty.');
@@ -184,6 +188,7 @@ export function validateBanditId(id: string): string {
 }
 
 export function validateVariants(variants: WeblayerVariant[]): WeblayerVariant[] {
+  requireArray(variants, 'variants');
   if (!Array.isArray(variants) || variants.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'At least one variant must be provided.');
   }
@@ -196,6 +201,7 @@ export function validateVariants(variants: WeblayerVariant[]): WeblayerVariant[]
 }
 
 export function validateVariantId(id: string): string {
+  requireString(id, 'variantId');
   const trimmed = id.trim();
   if (trimmed.length === 0) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', 'Variant ID must not be empty.');
@@ -204,6 +210,7 @@ export function validateVariantId(id: string): string {
 }
 
 export function validateWeblayerDisplayType(displayType: string): WeblayerDisplayType {
+  requireString(displayType, 'displayType');
   if (!WEBLAYER_DISPLAY_TYPES.includes(displayType as WeblayerDisplayType)) {
     throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `displayType must be one of: ${WEBLAYER_DISPLAY_TYPES.join(', ')} (got "${displayType}").`);
   }
@@ -211,36 +218,40 @@ export function validateWeblayerDisplayType(displayType: string): WeblayerDispla
 }
 
 export function validateWeblayerABTestConfig(config: WeblayerABTestConfig): WeblayerABTestConfig {
+  requireObject(config, 'ab test config');
+  const validatedConfig = config as WeblayerABTestConfig;
   if (
-    !Number.isInteger(config.variants) ||
-    config.variants < MIN_AB_TEST_VARIANTS ||
-    config.variants > MAX_AB_TEST_VARIANTS
+    !Number.isInteger(validatedConfig.variants) ||
+    validatedConfig.variants < MIN_AB_TEST_VARIANTS ||
+    validatedConfig.variants > MAX_AB_TEST_VARIANTS
   ) {
-    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${config.variants}).`);
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test variants must be an integer between ${MIN_AB_TEST_VARIANTS} and ${MAX_AB_TEST_VARIANTS} (got ${validatedConfig.variants}).`);
   }
-  if (config.splitPercentage !== undefined) {
-    if (config.splitPercentage < 0 || config.splitPercentage > 100) {
-      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test split percentage must be between 0 and 100 (got ${config.splitPercentage}).`);
+  if (validatedConfig.splitPercentage !== undefined) {
+    if (validatedConfig.splitPercentage < 0 || validatedConfig.splitPercentage > 100) {
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `A/B test split percentage must be between 0 and 100 (got ${validatedConfig.splitPercentage}).`);
     }
   }
-  return config;
+  return validatedConfig;
 }
 
 export function validateDisplayConditions(
   conditions: WeblayerDisplayConditions,
 ): WeblayerDisplayConditions {
-  if (conditions.delayMs !== undefined && conditions.delayMs < 0) {
-    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `delayMs must be greater than or equal to 0 (got ${conditions.delayMs}).`);
+  requireObject(conditions, 'display conditions');
+  const validatedConditions = conditions as WeblayerDisplayConditions;
+  if (validatedConditions.delayMs !== undefined && validatedConditions.delayMs < 0) {
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `delayMs must be greater than or equal to 0 (got ${validatedConditions.delayMs}).`);
   }
-  if (conditions.scrollPercentage !== undefined) {
-    if (conditions.scrollPercentage < 0 || conditions.scrollPercentage > 100) {
-      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `scrollPercentage must be between 0 and 100 (got ${conditions.scrollPercentage}).`);
+  if (validatedConditions.scrollPercentage !== undefined) {
+    if (validatedConditions.scrollPercentage < 0 || validatedConditions.scrollPercentage > 100) {
+      throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `scrollPercentage must be between 0 and 100 (got ${validatedConditions.scrollPercentage}).`);
     }
   }
-  if (conditions.frequencyCap !== undefined && conditions.frequencyCap < 1) {
-    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `frequencyCap must be greater than or equal to 1 (got ${conditions.frequencyCap}).`);
+  if (validatedConditions.frequencyCap !== undefined && validatedConditions.frequencyCap < 1) {
+    throw new BloomreachBuddyError('ACTION_PRECONDITION_FAILED', `frequencyCap must be greater than or equal to 1 (got ${validatedConditions.frequencyCap}).`);
   }
-  return conditions;
+  return validatedConditions;
 }
 
 export function buildWeblayersUrl(project: string): string {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -99,3 +99,50 @@ export function toErrorPayload(error: unknown): ErrorPayload {
   }
   return { code: 'UNKNOWN', message: String(error), details: {} };
 }
+
+// ---------------------------------------------------------------------------
+// Runtime input guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime guard — asserts that `value` is a non-null string.
+ * Throws `ACTION_PRECONDITION_FAILED` when called with null, undefined, or a
+ * non-string value.  Use at the top of validation helpers to protect against
+ * untyped MCP tool inputs (`Record<string, unknown>`).
+ */
+export function requireString(value: unknown, fieldName: string): asserts value is string {
+  if (value == null || typeof value !== 'string') {
+    throw new BloomreachBuddyError(
+      'ACTION_PRECONDITION_FAILED',
+      `${fieldName} is required and must be a string.`,
+    );
+  }
+}
+
+/**
+ * Runtime guard — asserts that `value` is a non-null array.
+ * Throws `ACTION_PRECONDITION_FAILED` when called with null, undefined, or a
+ * non-array value.
+ */
+export function requireArray(value: unknown, fieldName: string): asserts value is unknown[] {
+  if (!Array.isArray(value)) {
+    throw new BloomreachBuddyError(
+      'ACTION_PRECONDITION_FAILED',
+      `${fieldName} is required and must be an array.`,
+    );
+  }
+}
+
+/**
+ * Runtime guard — asserts that `value` is a non-null, non-array object.
+ * Throws `ACTION_PRECONDITION_FAILED` when called with null, undefined, or a
+ * non-object value.
+ */
+export function requireObject(value: unknown, fieldName: string): asserts value is Record<string, unknown> {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new BloomreachBuddyError(
+      'ACTION_PRECONDITION_FAILED',
+      `${fieldName} is required and must be an object.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Add runtime null/undefined guards to **all 130+ `prepare_*` methods** across all 35 service files, preventing crashes when AI agents omit required fields in MCP tool calls.

## Problem

MCP tool inputs are `Record<string, unknown>` — TypeScript types aren't enforced at runtime. When an AI agent omits a required field like `steps` or `name`, validation functions crash with unhelpful errors:

```
❌ Cannot read properties of undefined (reading 'length')
❌ Cannot read properties of undefined (reading 'trim')
```

## Solution

1. **Added `requireString()`, `requireArray()`, `requireObject()` runtime guard utilities** to `errors.ts` — reusable assertion helpers that throw `BloomreachBuddyError` with `ACTION_PRECONDITION_FAILED` and a helpful message.

2. **Applied guards to all validation functions** across all 35 service files — guards are placed at the top of each validation function, before any property access that could crash.

3. **Fixed inline operations** in `prepare_*` methods that bypassed validation functions (direct `.trim()`, `.map()`, `.length` calls).

### Before vs After

| Scenario | Before | After |
|---|---|---|
| `prepareCreateFunnelAnalysis` without `steps` | `Cannot read properties of undefined (reading 'length')` | `steps is required and must be an array.` |
| `prepareCreateRetentionAnalysis` without `name` | `Cannot read properties of undefined (reading 'trim')` | `Retention name is required and must be a string.` |
| `prepareCreateSegmentation` without `conditions` | Crash on `.length` | `conditions is required and must be an array.` |
| `prepareCreateTag` without `jsCode` | Crash on `.trim()` | `JS code is required and must be a string.` |
| Any `prepare_*` without `project` | Crash on `.trim()` | `project is required and must be a string.` |

## Files Changed

- **`errors.ts`**: Added 3 guard utilities (`requireString`, `requireArray`, `requireObject`)
- **35 service files**: Added guards to all validation functions
- **6 test files**: Added 51 new tests for null/undefined input scenarios

## Quality Gates

- ✅ TypeScript typecheck: clean
- ✅ ESLint: clean
- ✅ Tests: 4,967 passed (including 51 new guard tests), 0 failures
- ✅ Build: all 3 packages built successfully
- ✅ Manual QA: verified all 5 issue scenarios + spot-checked 10 additional services

Closes #184
