### PR TITLE
fix: use click+type instead of fill for Angular login form compatibility

### DIFF
--- a/packages/core/src/__tests__/auth/loginSelectors.test.ts
+++ b/packages/core/src/__tests__/auth/loginSelectors.test.ts
@@ -7,13 +7,14 @@ vi.mock('../../errors.js', async () => {
   return actual;
 });
 
-type MockPage = Pick<Page, '$' | 'fill' | 'click'>;
+type MockPage = Pick<Page, '$' | 'fill' | 'click' | 'type'>;
 
 function createMockPage(): MockPage {
   return {
     $: vi.fn(),
     fill: vi.fn(),
     click: vi.fn(),
+    type: vi.fn(),
   } as unknown as MockPage;
 }
 
@@ -115,6 +116,7 @@ describe('loginSelectors', () => {
     vi.mocked(page.$).mockResolvedValue(handle);
     vi.mocked(page.fill).mockResolvedValue(undefined);
     vi.mocked(page.click).mockResolvedValue(undefined);
+    vi.mocked(page.type).mockResolvedValue(undefined);
 
     const result = await loginSelectorsModule.tryAutoFill(page as Page, {
       email: 'test@example.com',
@@ -122,8 +124,12 @@ describe('loginSelectors', () => {
     });
 
     expect(result).toBe(true);
-    expect(page.fill).toHaveBeenCalledWith('[data-e2e-id="loginForm"] input[name="username"]', 'test@example.com');
-    expect(page.fill).toHaveBeenCalledWith('[data-e2e-id="loginForm"] input[name="password"]', 'secret');
+    // Each field: click(selector) + fill(selector, '') + type(selector, value)
+    expect(page.click).toHaveBeenCalledWith('[data-e2e-id="loginForm"] input[name="username"]');
+    expect(page.type).toHaveBeenCalledWith('[data-e2e-id="loginForm"] input[name="username"]', 'test@example.com', { delay: 20 });
+    expect(page.click).toHaveBeenCalledWith('[data-e2e-id="loginForm"] input[name="password"]');
+    expect(page.type).toHaveBeenCalledWith('[data-e2e-id="loginForm"] input[name="password"]', 'secret', { delay: 20 });
+    // Submit button click
     expect(page.click).toHaveBeenCalledWith('[data-e2e-id="loginScreenLoginButton"]');
   });
 
@@ -132,15 +138,14 @@ describe('loginSelectors', () => {
     const handle = { description: 'element handle' } as unknown as ElementHandle;
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.mocked(page.$).mockResolvedValue(handle);
-    vi.mocked(page.fill).mockRejectedValue(new Error('fill failed'));
+    vi.mocked(page.click).mockRejectedValue(new Error('click failed'));
 
     const result = await loginSelectorsModule.tryAutoFill(page as Page, {
       email: 'test@example.com',
     });
 
     expect(result).toBe(false);
-    expect(page.fill).toHaveBeenCalledTimes(4);
-    expect(page.click).not.toHaveBeenCalled();
+    expect(page.click).toHaveBeenCalledTimes(4);
     expect(console.warn).toHaveBeenCalled();
     warnSpy.mockRestore();
   });

--- a/packages/core/src/auth/loginSelectors.ts
+++ b/packages/core/src/auth/loginSelectors.ts
@@ -160,7 +160,13 @@ async function tryFillByCandidates(
 ): Promise<boolean> {
   for (const candidate of candidates) {
     try {
-      await page.fill(candidate.selector, value);
+      // Use click + clear + type instead of fill — Angular reactive forms
+      // need real keystroke events to update their internal model.
+      // page.fill() dispatches input/change but skips keydown/keyup
+      // which some SPA frameworks rely on for validation.
+      await page.click(candidate.selector);
+      await page.fill(candidate.selector, '');
+      await page.type(candidate.selector, value, { delay: 20 });
       return true;
     } catch (error) {
       const normalized = normalizeError(error, 'Field fill failed', candidate.selector);


### PR DESCRIPTION
## Summary

- Replaces `page.fill()` with `page.click()` + `page.fill('')` + `page.type(value, {delay: 20})` in `tryFillByCandidates()` to work with Angular reactive forms
- Angular forms listen for keydown/keyup events which `page.fill()` doesn't dispatch — `page.type()` simulates real keystrokes
- Updates loginSelectors tests to verify the new click+type pattern

## Testing

- All 42 loginSelectors tests pass
- Full test suite passes (9942 tests)
- Lint + typecheck clean