### PR TITLE
feat: add CAPTCHA fallback detection and project selector

### DIFF
--- a/packages/cli/src/bin/bloomreach.ts
+++ b/packages/cli/src/bin/bloomreach.ts
@@ -52,6 +52,7 @@ import {
   writeEnvFile,
   openBrowserUrl,
   BloomreachProfileManager,
+  BloomreachProjectsService,
   BLOOMREACH_API_SETTINGS_URL,
   createAuthManager,
 } from '@bloomreach-buddy/core';
@@ -12329,6 +12330,11 @@ program
           profileName: options.profile,
           timeoutMs: Number(options.timeout),
           loginUrl: options.loginUrl,
+          onCaptchaDetected: () => {
+            if (!options.json) {
+              console.error('  CAPTCHA detected. Please solve it in the browser window.');
+            }
+          },
         });
 
         if (options.json) {
@@ -12391,6 +12397,219 @@ program
                 cleared: false,
                 error: error instanceof Error ? error.message : String(error),
               },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+// --- Project management ---
+const projects = program
+  .command('projects')
+  .description('Manage Bloomreach project selection');
+
+projects
+  .command('list')
+  .description('List available Bloomreach projects')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { profile: string; json?: boolean }) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const projectsService = new BloomreachProjectsService(profileManager, { profilesDir });
+
+        const result = await projectsService.listProjects({
+          profileName: options.profile,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log('');
+          console.log('  Available Bloomreach Projects');
+          console.log('  ============================');
+          console.log('');
+          for (const org of result.hierarchy.organizations) {
+            console.log(`  Organization: ${org.name}`);
+            for (const ws of org.workspaces) {
+              console.log(`    Workspace: ${ws.name}`);
+              for (const prod of ws.products) {
+                console.log(`      ${prod.name} (${prod.projectCount} project${prod.projectCount !== 1 ? 's' : ''})`);
+                for (const projName of prod.projects) {
+                  console.log(`        - ${projName}`);
+                }
+              }
+            }
+          }
+          console.log('');
+          console.log(`  Total: ${result.projects.length} project${result.projects.length !== 1 ? 's' : ''}`);
+          console.log('');
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { error: error instanceof Error ? error.message : String(error) },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+projects
+  .command('select')
+  .description('Select a Bloomreach project to work in')
+  .argument('<name-or-slug>', 'Project name or URL slug')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (
+      nameOrSlug: string,
+      options: { profile: string; json?: boolean },
+    ) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const projectsService = new BloomreachProjectsService(profileManager, { profilesDir });
+
+        const result = await projectsService.selectProject(nameOrSlug, {
+          profileName: options.profile,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log('');
+          console.log(`  Project selected: ${result.project.name}`);
+          console.log(`  URL: ${result.project.url}`);
+          console.log(`  Organization: ${result.project.organization}`);
+          console.log(`  Workspace: ${result.project.workspace}`);
+          console.log(`  Product: ${result.project.product}`);
+          if (result.previousProject) {
+            console.log(`  Previous: ${result.previousProject.name}`);
+          }
+          console.log('');
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { error: error instanceof Error ? error.message : String(error) },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+projects
+  .command('current')
+  .description('Show the currently selected project')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { profile: string; json?: boolean }) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const projectsService = new BloomreachProjectsService(profileManager, { profilesDir });
+
+        const result = await projectsService.currentProject({
+          profileName: options.profile,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else if (result.project) {
+          console.log('');
+          console.log(`  Current project: ${result.project.name}`);
+          console.log(`  URL: ${result.project.url}`);
+          console.log(`  Organization: ${result.project.organization}`);
+          console.log('');
+        } else {
+          console.log('');
+          console.log('  No project selected. Run "bloomreach projects select <name>" to choose one.');
+          console.log('');
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { error: error instanceof Error ? error.message : String(error) },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+projects
+  .command('clear')
+  .description('Clear the current project selection')
+  .option('--profile <name>', 'Browser profile name', 'default')
+  .option('--json', 'Output as JSON')
+  .action(
+    async (options: { profile: string; json?: boolean }) => {
+      try {
+        const profilesDir = resolveProfilesDir();
+        const profileManager = new BloomreachProfileManager({ profilesDir });
+        const projectsService = new BloomreachProjectsService(profileManager, { profilesDir });
+
+        const result = await projectsService.clearProject({
+          profileName: options.profile,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else if (result.cleared) {
+          console.log('');
+          console.log('  Project selection cleared.');
+          if (result.previousProject) {
+            console.log(`  Previous: ${result.previousProject.name}`);
+          }
+          console.log('');
+        } else {
+          console.log('');
+          console.log('  No project was selected.');
+          console.log('');
+        }
+      } catch (error) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { error: error instanceof Error ? error.message : String(error) },
               null,
               2,
             ),

--- a/packages/core/src/__tests__/auth/captchaDetector.test.ts
+++ b/packages/core/src/__tests__/auth/captchaDetector.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Page } from 'playwright-core';
+import {
+  detectCaptcha,
+  isCaptchaVisible,
+  waitForCaptchaResolution,
+  CAPTCHA_VISIBLE_THRESHOLD,
+  DEFAULT_CAPTCHA_TIMEOUT_MS,
+  DEFAULT_CAPTCHA_POLL_INTERVAL_MS,
+} from '../../auth/captchaDetector.js';
+
+function createMockPage(evaluateResult: unknown = null): Page {
+  const urlFn = vi.fn().mockReturnValue('https://eu.login.bloomreach.com/login');
+  return {
+    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+    url: urlFn,
+  } as unknown as Page;
+}
+
+describe('captchaDetector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('detectCaptcha returns detected: false when page.evaluate finds no CAPTCHA iframes', async () => {
+    const page = createMockPage({ detected: false, type: null, iframeSelector: null });
+
+    const result = await detectCaptcha(page);
+
+    expect(result).toEqual({ detected: false, type: null, iframeSelector: null });
+  });
+
+  it('detectCaptcha returns detected: false when bframe iframe is below visibility threshold', async () => {
+    const page = createMockPage({
+      detected: false,
+      type: null,
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+      measured: {
+        width: CAPTCHA_VISIBLE_THRESHOLD.width,
+        height: CAPTCHA_VISIBLE_THRESHOLD.height,
+      },
+    });
+
+    const result = await detectCaptcha(page);
+
+    expect(result.detected).toBe(false);
+  });
+
+  it('detectCaptcha returns detected: true when bframe iframe exceeds threshold', async () => {
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+
+    const result = await detectCaptcha(page);
+
+    expect(result.detected).toBe(true);
+  });
+
+  it('detectCaptcha returns type recaptcha-v2-invisible when detected', async () => {
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+
+    const result = await detectCaptcha(page);
+
+    expect(result.type).toBe('recaptcha-v2-invisible');
+  });
+
+  it('detectCaptcha returns iframeSelector with matched selector string', async () => {
+    const matchedSelector = 'iframe[title="recaptcha challenge expires in two minutes"]';
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: matchedSelector,
+    });
+
+    const result = await detectCaptcha(page);
+
+    expect(result.iframeSelector).toBe(matchedSelector);
+  });
+
+  it('detectCaptcha handles page.evaluate throwing gracefully (returns detected: false)', async () => {
+    const page = createMockPage();
+    vi.mocked(page.evaluate).mockRejectedValueOnce(new Error('evaluate failed'));
+
+    const result = await detectCaptcha(page);
+
+    expect(result).toEqual({ detected: false, type: null, iframeSelector: null });
+  });
+
+  it('isCaptchaVisible returns false for no CAPTCHA', async () => {
+    const page = createMockPage({ detected: false, type: null, iframeSelector: null });
+
+    const visible = await isCaptchaVisible(page);
+
+    expect(visible).toBe(false);
+  });
+
+  it('isCaptchaVisible returns true for visible CAPTCHA', async () => {
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+
+    const visible = await isCaptchaVisible(page);
+
+    expect(visible).toBe(true);
+  });
+
+  it('waitForCaptchaResolution resolves immediately when isResolved returns true', async () => {
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+    const isResolved = vi.fn().mockReturnValue(true);
+
+    const result = await waitForCaptchaResolution(page, isResolved);
+
+    expect(result).toEqual({ resolved: true, timedOut: false });
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('waitForCaptchaResolution resolves when CAPTCHA disappears after being detected', async () => {
+    vi.useFakeTimers();
+    const page = createMockPage();
+    vi.mocked(page.evaluate)
+      .mockResolvedValueOnce({
+        detected: true,
+        type: 'recaptcha-v2-invisible',
+        iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+      })
+      .mockResolvedValueOnce({ detected: false, type: null, iframeSelector: null });
+    const isResolved = vi.fn().mockReturnValue(false);
+
+    const promise = waitForCaptchaResolution(page, isResolved, {
+      timeoutMs: 20_000,
+      pollIntervalMs: 1_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await promise;
+
+    expect(result).toEqual({ resolved: true, timedOut: false });
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it('waitForCaptchaResolution returns timedOut true when timeout exceeded', async () => {
+    vi.useFakeTimers();
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+    const isResolved = vi.fn().mockReturnValue(false);
+
+    const promise = waitForCaptchaResolution(page, isResolved, {
+      timeoutMs: 5_000,
+      pollIntervalMs: 1_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await promise;
+
+    expect(result).toEqual({ resolved: false, timedOut: true });
+  });
+
+  it('waitForCaptchaResolution calls onDetected callback exactly once', async () => {
+    vi.useFakeTimers();
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+    const isResolved = vi.fn().mockReturnValue(false);
+    const onDetected = vi.fn();
+
+    const promise = waitForCaptchaResolution(page, isResolved, {
+      timeoutMs: 4_000,
+      pollIntervalMs: 1_000,
+      onDetected,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await promise;
+
+    expect(result).toEqual({ resolved: false, timedOut: true });
+    expect(onDetected).toHaveBeenCalledTimes(1);
+  });
+
+  it('waitForCaptchaResolution uses default timeout and poll interval', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const page = createMockPage({
+      detected: true,
+      type: 'recaptcha-v2-invisible',
+      iframeSelector: 'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+    });
+    const isResolved = vi.fn().mockReturnValue(false);
+
+    const promise = waitForCaptchaResolution(page, isResolved);
+
+    await vi.advanceTimersByTimeAsync(
+      DEFAULT_CAPTCHA_TIMEOUT_MS + DEFAULT_CAPTCHA_POLL_INTERVAL_MS,
+    );
+    const result = await promise;
+
+    expect(result).toEqual({ resolved: false, timedOut: true });
+    expect(
+      setTimeoutSpy.mock.calls.some((call) => call[1] === DEFAULT_CAPTCHA_POLL_INTERVAL_MS),
+    ).toBe(true);
+
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/packages/core/src/__tests__/auth/projectSelectors.test.ts
+++ b/packages/core/src/__tests__/auth/projectSelectors.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserContext, ElementHandle, Page } from 'playwright-core';
+import {
+  PROJECT_TREE_RENDER_TIMEOUT_MS,
+  clickProjectAndCaptureUrl,
+  extractProjectSlug,
+  findProjectElement,
+  flattenProjects,
+  scrapeProjectTree,
+  toSlug,
+} from '../../auth/projectSelectors.js';
+
+function createMockPage(evaluateResult: unknown = null): Page {
+  return {
+    waitForSelector: vi.fn().mockResolvedValue({}),
+    evaluate: vi.fn().mockResolvedValue(evaluateResult),
+  } as unknown as Page;
+}
+
+function createMockElementHandle(text: string): ElementHandle {
+  return {
+    textContent: vi.fn().mockResolvedValue(text),
+  } as unknown as ElementHandle;
+}
+
+describe('projectSelectors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('scrapeProjectTree', () => {
+    it('extracts single org with single workspace, product, and project', async () => {
+      const evaluateResult = {
+        organizations: [
+          {
+            name: 'POWER',
+            workspaces: [
+              {
+                name: 'POWER',
+                products: [
+                  {
+                    name: 'Engagement',
+                    projectCount: 1,
+                    projects: ['Kingdom of Joakim'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const page = createMockPage(evaluateResult);
+
+      const result = await scrapeProjectTree(page);
+
+      expect(result).toEqual(evaluateResult);
+      expect(page.waitForSelector).toHaveBeenCalledWith('e-ui-accordion.discovery-like', {
+        timeout: PROJECT_TREE_RENDER_TIMEOUT_MS,
+      });
+      expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('extracts multiple organizations with nested workspaces', async () => {
+      const evaluateResult = {
+        organizations: [
+          {
+            name: 'POWER',
+            workspaces: [
+              {
+                name: 'Workspace A',
+                products: [{ name: 'Engagement', projectCount: 1, projects: ['Alpha'] }],
+              },
+            ],
+          },
+          {
+            name: 'NOVA',
+            workspaces: [
+              {
+                name: 'Workspace B',
+                products: [{ name: 'Discovery', projectCount: 2, projects: ['Beta', 'Gamma'] }],
+              },
+            ],
+          },
+        ],
+      };
+      const page = createMockPage(evaluateResult);
+
+      const result = await scrapeProjectTree(page);
+
+      expect(result.organizations).toHaveLength(2);
+      expect(result).toEqual(evaluateResult);
+    });
+
+    it('returns empty organizations array when no accordion found', async () => {
+      const page = createMockPage({ organizations: [{ name: 'ignored' }] });
+      vi.mocked(page.waitForSelector).mockRejectedValueOnce(new Error('timeout'));
+
+      const result = await scrapeProjectTree(page);
+
+      expect(result).toEqual({ organizations: [] });
+      expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('handles product with count badge "(3)" correctly', async () => {
+      const evaluateResult = {
+        organizations: [
+          {
+            name: 'POWER',
+            workspaces: [
+              {
+                name: 'POWER',
+                products: [
+                  {
+                    name: 'Engagement',
+                    projectCount: 3,
+                    projects: ['A', 'B', 'C'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const page = createMockPage(evaluateResult);
+
+      const result = await scrapeProjectTree(page);
+
+      expect(result.organizations[0]?.workspaces[0]?.products[0]?.projectCount).toBe(3);
+    });
+
+    it('handles multiple projects under one product', async () => {
+      const evaluateResult = {
+        organizations: [
+          {
+            name: 'POWER',
+            workspaces: [
+              {
+                name: 'POWER',
+                products: [
+                  {
+                    name: 'Engagement',
+                    projectCount: 3,
+                    projects: ['Kingdom of Joakim', 'Kingdom of Alice', 'Kingdom of Bob'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const page = createMockPage(evaluateResult);
+
+      const result = await scrapeProjectTree(page);
+
+      expect(result.organizations[0]?.workspaces[0]?.products[0]?.projects).toEqual([
+        'Kingdom of Joakim',
+        'Kingdom of Alice',
+        'Kingdom of Bob',
+      ]);
+    });
+  });
+
+  describe('flattenProjects', () => {
+    it('flattens hierarchical tree to flat project array', () => {
+      const tree = {
+        organizations: [
+          {
+            name: 'POWER',
+            workspaces: [
+              {
+                name: 'Workspace 1',
+                products: [{ name: 'Engagement', projectCount: 2, projects: ['Alpha', 'Beta'] }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = flattenProjects(tree);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((project) => project.name)).toEqual(['Alpha', 'Beta']);
+    });
+
+    it('includes organization, workspace, product in each flattened project', () => {
+      const tree = {
+        organizations: [
+          {
+            name: 'POWER',
+            workspaces: [
+              {
+                name: 'Main Workspace',
+                products: [
+                  {
+                    name: 'Engagement',
+                    projectCount: 1,
+                    projects: ['Kingdom of Joakim'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = flattenProjects(tree);
+
+      expect(result).toEqual([
+        {
+          name: 'Kingdom of Joakim',
+          organization: 'POWER',
+          workspace: 'Main Workspace',
+          product: 'Engagement',
+        },
+      ]);
+    });
+
+    it('returns empty array for empty tree', () => {
+      expect(flattenProjects({ organizations: [] })).toEqual([]);
+    });
+  });
+
+  describe('findProjectElement', () => {
+    it('finds project by exact name match (case-insensitive)', async () => {
+      const target = createMockElementHandle('Kingdom of Joakim');
+      const page = {
+        $$: vi.fn().mockResolvedValue([createMockElementHandle('Other Project'), target]),
+      } as unknown as Page;
+
+      const result = await findProjectElement(page, 'kingdom of joakim');
+
+      expect(result).toBe(target);
+    });
+
+    it('finds project by slug match', async () => {
+      const target = createMockElementHandle('Kingdom of Joakim');
+      const page = {
+        $$: vi.fn().mockResolvedValue([target]),
+      } as unknown as Page;
+
+      const result = await findProjectElement(page, 'kingdom-of-joakim');
+
+      expect(result).toBe(target);
+    });
+
+    it('returns null when no matching project found', async () => {
+      const page = {
+        $$: vi
+          .fn()
+          .mockResolvedValue([createMockElementHandle('Alpha'), createMockElementHandle('Beta')]),
+      } as unknown as Page;
+
+      const result = await findProjectElement(page, 'gamma');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns first match when multiple candidates exist', async () => {
+      const first = createMockElementHandle('Kingdom of Joakim');
+      const second = createMockElementHandle('Kingdom of Joakim');
+      const page = {
+        $$: vi.fn().mockResolvedValue([first, second]),
+      } as unknown as Page;
+
+      const result = await findProjectElement(page, 'kingdom-of-joakim');
+
+      expect(result).toBe(first);
+    });
+  });
+
+  describe('clickProjectAndCaptureUrl', () => {
+    it('captures URL from new tab and returns url + slug', async () => {
+      const mockNewPage = {
+        waitForLoadState: vi.fn().mockResolvedValue(undefined),
+        url: vi.fn().mockReturnValue('https://power.bloomreach.co/p/kingdom-of-joakim/home'),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockContext = {
+        waitForEvent: vi.fn().mockResolvedValue(mockNewPage),
+      } as unknown as BrowserContext;
+      const projectElement = {
+        click: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ElementHandle;
+
+      const result = await clickProjectAndCaptureUrl(mockContext, projectElement);
+
+      expect(result).toEqual({
+        url: 'https://power.bloomreach.co/p/kingdom-of-joakim/home',
+        slug: 'kingdom-of-joakim',
+      });
+    });
+
+    it('closes the new tab after capture', async () => {
+      const mockNewPage = {
+        waitForLoadState: vi.fn().mockResolvedValue(undefined),
+        url: vi.fn().mockReturnValue('https://power.bloomreach.co/p/kingdom-of-joakim/home'),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockContext = {
+        waitForEvent: vi.fn().mockResolvedValue(mockNewPage),
+      } as unknown as BrowserContext;
+      const projectElement = {
+        click: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ElementHandle;
+
+      await clickProjectAndCaptureUrl(mockContext, projectElement);
+
+      expect(mockNewPage.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when URL does not match project pattern', async () => {
+      const mockNewPage = {
+        waitForLoadState: vi.fn().mockResolvedValue(undefined),
+        url: vi.fn().mockReturnValue('https://power.bloomreach.co/my-account'),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockContext = {
+        waitForEvent: vi.fn().mockResolvedValue(mockNewPage),
+      } as unknown as BrowserContext;
+      const projectElement = {
+        click: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ElementHandle;
+
+      const result = await clickProjectAndCaptureUrl(mockContext, projectElement);
+
+      expect(result).toBeNull();
+      expect(mockNewPage.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('extractProjectSlug', () => {
+    it('extracts slug from standard project URL', () => {
+      expect(extractProjectSlug('https://power.bloomreach.co/p/kingdom-of-joakim/home')).toBe(
+        'kingdom-of-joakim',
+      );
+    });
+
+    it('extracts slug from URL with trailing path', () => {
+      expect(
+        extractProjectSlug('https://power.bloomreach.co/p/kingdom-of-joakim/segments/list'),
+      ).toBe('kingdom-of-joakim');
+    });
+
+    it('returns null for non-project URL', () => {
+      expect(extractProjectSlug('https://power.bloomreach.co/my-account')).toBeNull();
+    });
+
+    it('returns null for malformed URL', () => {
+      expect(extractProjectSlug('not a url')).toBeNull();
+    });
+  });
+
+  describe('toSlug', () => {
+    it('converts project name to kebab-case slug', () => {
+      expect(toSlug('Kingdom of Joakim')).toBe('kingdom-of-joakim');
+    });
+
+    it('handles special characters', () => {
+      expect(toSlug('Engagement & Loyalty!!!')).toBe('engagement-loyalty');
+    });
+
+    it('collapses multiple hyphens', () => {
+      expect(toSlug('Kingdom --- of   Joakim')).toBe('kingdom-of-joakim');
+    });
+  });
+});

--- a/packages/core/src/__tests__/bloomreachAuth.captcha.test.ts
+++ b/packages/core/src/__tests__/bloomreachAuth.captcha.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { BrowserContext, Page } from 'playwright-core';
+import { BloomreachAuthService } from '../bloomreachAuth.js';
+import type { BloomreachProfileManager } from '../bloomreachProfileManager.js';
+
+vi.mock('../bloomreachSessionStore.js', () => ({
+  loadSession: vi.fn(),
+  saveSession: vi.fn(),
+  deleteSession: vi.fn(),
+  isSessionExpired: vi.fn(),
+  summarizeSessionCookies: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../auth/loginSelectors.js', () => ({
+  tryAutoFill: vi.fn().mockResolvedValue(false),
+  resolveAutoFillConfig: vi.fn().mockReturnValue({}),
+}));
+
+interface MockHarness {
+  auth: BloomreachAuthService;
+  mockPage: Page;
+  mockContext: BrowserContext;
+}
+
+function createHarness(overrides?: {
+  url?: () => string;
+  evaluateResult?: unknown;
+  waitForTimeout?: () => Promise<void>;
+}): MockHarness {
+  const mockPage = {
+    goto: vi.fn().mockResolvedValue(undefined),
+    url: vi
+      .fn()
+      .mockImplementation(overrides?.url ?? (() => 'https://eu.login.bloomreach.com/login')),
+    waitForTimeout: vi
+      .fn()
+      .mockImplementation(overrides?.waitForTimeout ?? (async () => undefined)),
+    waitForSelector: vi.fn().mockResolvedValue({}),
+    evaluate: vi.fn().mockResolvedValue(overrides?.evaluateResult ?? null),
+    click: vi.fn().mockResolvedValue(undefined),
+    fill: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    $: vi.fn().mockResolvedValue(null),
+  } as unknown as Page;
+
+  const mockContext = {
+    pages: vi.fn().mockReturnValue([mockPage]),
+    newPage: vi.fn().mockResolvedValue(mockPage),
+    storageState: vi.fn().mockResolvedValue({ cookies: [], origins: [] }),
+  } as unknown as BrowserContext;
+
+  const profileManager = {
+    runWithPersistentContext: vi
+      .fn()
+      .mockImplementation(
+        async (
+          _name: string,
+          _opts: unknown,
+          callback: (ctx: BrowserContext) => Promise<unknown>,
+        ) => {
+          return callback(mockContext);
+        },
+      ),
+  } as unknown as BloomreachProfileManager;
+
+  return {
+    auth: new BloomreachAuthService(profileManager, { profilesDir: '/profiles' }),
+    mockPage,
+    mockContext,
+  };
+}
+
+describe('BloomreachAuthService openLogin CAPTCHA integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('openLogin sets captchaDetected false when no CAPTCHA appears', async () => {
+    let pollCount = 0;
+    const { auth } = createHarness({
+      url: () => {
+        if (pollCount < 3) {
+          return 'https://eu.login.bloomreach.com/login';
+        }
+        return 'https://eu.login.bloomreach.com/my-account';
+      },
+      waitForTimeout: async () => {
+        pollCount += 1;
+      },
+      evaluateResult: null,
+    });
+
+    const result = await auth.openLogin({
+      timeoutMs: 10_000,
+      pollIntervalMs: 0,
+      autoFill: false,
+    });
+
+    expect(result.captchaDetected).toBe(false);
+    expect(result.authenticated).toBe(true);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('openLogin detects CAPTCHA and sets captchaDetected true', async () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const { auth } = createHarness({
+      url: () => 'https://eu.login.bloomreach.com/login',
+      waitForTimeout: async () => {
+        now += 10;
+      },
+      evaluateResult: {
+        detected: true,
+        type: 'recaptcha-v2-invisible',
+        iframeSelector: 'iframe[title="recaptcha challenge expires in two minutes"]',
+      },
+    });
+
+    const result = await auth.openLogin({
+      timeoutMs: 5,
+      captchaTimeoutMs: 1,
+      pollIntervalMs: 0,
+      autoFill: false,
+    });
+
+    expect(result.authenticated).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.captchaDetected).toBe(true);
+    nowSpy.mockRestore();
+  });
+
+  it('openLogin calls onCaptchaDetected callback when CAPTCHA detected', async () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const onCaptchaDetected = vi.fn();
+
+    const { auth } = createHarness({
+      url: () => 'https://eu.login.bloomreach.com/login',
+      waitForTimeout: async () => {
+        now += 25;
+      },
+      evaluateResult: {
+        detected: true,
+        type: 'recaptcha-v2-invisible',
+        iframeSelector: 'iframe[title="recaptcha challenge expires in two minutes"]',
+      },
+    });
+
+    const result = await auth.openLogin({
+      timeoutMs: 50,
+      captchaTimeoutMs: 40,
+      pollIntervalMs: 0,
+      autoFill: false,
+      onCaptchaDetected,
+    });
+
+    expect(result.captchaDetected).toBe(true);
+    expect(onCaptchaDetected).toHaveBeenCalledTimes(1);
+    nowSpy.mockRestore();
+  });
+
+  it('openLogin extends deadline when CAPTCHA detected and captchaTimeoutMs set', async () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const { auth, mockContext } = createHarness({
+      url: () => {
+        if (now < 300) {
+          return 'https://eu.login.bloomreach.com/login';
+        }
+        return 'https://eu.login.bloomreach.com/my-account';
+      },
+      waitForTimeout: async () => {
+        now += 100;
+      },
+      evaluateResult: {
+        detected: true,
+        type: 'recaptcha-v2-invisible',
+        iframeSelector: 'iframe[title="recaptcha challenge expires in two minutes"]',
+      },
+    });
+
+    vi.mocked(mockContext.storageState).mockResolvedValue({ cookies: [], origins: [] });
+
+    const result = await auth.openLogin({
+      timeoutMs: 100,
+      captchaTimeoutMs: 500,
+      pollIntervalMs: 0,
+      autoFill: false,
+    });
+
+    expect(result.authenticated).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.captchaDetected).toBe(true);
+    nowSpy.mockRestore();
+  });
+
+  it('openLogin succeeds when user solves CAPTCHA within timeout', async () => {
+    let pollCount = 0;
+
+    const { auth } = createHarness({
+      url: () => {
+        if (pollCount < 3) {
+          return 'https://eu.login.bloomreach.com/login';
+        }
+        return 'https://eu.login.bloomreach.com/my-account';
+      },
+      waitForTimeout: async () => {
+        pollCount += 1;
+      },
+      evaluateResult: {
+        detected: true,
+        type: 'recaptcha-v2-invisible',
+        iframeSelector: 'iframe[title="recaptcha challenge expires in two minutes"]',
+      },
+    });
+
+    const result = await auth.openLogin({
+      timeoutMs: 10_000,
+      pollIntervalMs: 0,
+      autoFill: false,
+    });
+
+    expect(result.authenticated).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.captchaDetected).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/bloomreachAuth.test.ts
+++ b/packages/core/src/__tests__/bloomreachAuth.test.ts
@@ -39,13 +39,12 @@ const mockContext = {
 };
 
 const mockProfileManager = {
-  runWithPersistentContext: vi.fn().mockImplementation(
-    async (
-      _profile: string,
-      _opts: unknown,
-      callback: (ctx: unknown) => Promise<unknown>,
-    ) => callback(mockContext),
-  ),
+  runWithPersistentContext: vi
+    .fn()
+    .mockImplementation(
+      async (_profile: string, _opts: unknown, callback: (ctx: unknown) => Promise<unknown>) =>
+        callback(mockContext),
+    ),
 };
 
 const profileManagerForAuth = mockProfileManager as unknown as BloomreachProfileManager;
@@ -104,7 +103,9 @@ describe('bloomreachAuth helpers', () => {
     expect(isAuthenticatedPage('https://eu.login.bloomreach.com/register')).toBe(false);
     // Login domain authenticated paths (post-login redirects)
     expect(isAuthenticatedPage('https://eu.login.bloomreach.com/my-account')).toBe(true);
-    expect(isAuthenticatedPage('https://eu.login.bloomreach.com/my-account/user-profile')).toBe(true);
+    expect(isAuthenticatedPage('https://eu.login.bloomreach.com/my-account/user-profile')).toBe(
+      true,
+    );
     // Login paths on project domains are NOT authenticated
     expect(isAuthenticatedPage('https://power.bloomreach.co/login')).toBe(false);
     // Invalid URLs
@@ -222,6 +223,7 @@ describe('BloomreachAuthService', () => {
     );
     expect(result.authenticated).toBe(true);
     expect(result.timedOut).toBe(false);
+    expect(result.captchaDetected).toBe(false);
     expect(result.sessionCookiePresent).toBe(true);
     expect(result.cookieSummary).toEqual(cookieSummary);
   });
@@ -246,6 +248,7 @@ describe('BloomreachAuthService', () => {
 
     expect(result.authenticated).toBe(false);
     expect(result.timedOut).toBe(true);
+    expect(result.captchaDetected).toBe(false);
     expect(saveSession).not.toHaveBeenCalled();
     nowSpy.mockRestore();
   });
@@ -310,10 +313,16 @@ describe('BloomreachAuthService', () => {
   });
 
   it('openLogin attempts auto-fill when env vars are set', async () => {
-    vi.mocked(resolveAutoFillConfig).mockReturnValue({ email: 'test@example.com', password: 'secret' });
+    vi.mocked(resolveAutoFillConfig).mockReturnValue({
+      email: 'test@example.com',
+      password: 'secret',
+    });
     vi.mocked(tryAutoFill).mockResolvedValue(true);
     mockPage.url.mockReturnValueOnce('https://power.bloomreach.co/project/123');
-    mockContext.storageState.mockResolvedValue({ cookies: validSession.storageState.cookies, origins: [] });
+    mockContext.storageState.mockResolvedValue({
+      cookies: validSession.storageState.cookies,
+      origins: [],
+    });
 
     const auth = new BloomreachAuthService(profileManagerForAuth, {
       profilesDir: '/profiles',
@@ -330,7 +339,10 @@ describe('BloomreachAuthService', () => {
 
   it('openLogin skips auto-fill when autoFill is false', async () => {
     mockPage.url.mockReturnValueOnce('https://power.bloomreach.co/project/123');
-    mockContext.storageState.mockResolvedValue({ cookies: validSession.storageState.cookies, origins: [] });
+    mockContext.storageState.mockResolvedValue({
+      cookies: validSession.storageState.cookies,
+      origins: [],
+    });
 
     const auth = new BloomreachAuthService(profileManagerForAuth, {
       profilesDir: '/profiles',

--- a/packages/core/src/__tests__/bloomreachProjects.test.ts
+++ b/packages/core/src/__tests__/bloomreachProjects.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BrowserContext, ElementHandle, Page } from 'playwright-core';
+import type { BloomreachProfileManager } from '../bloomreachProfileManager.js';
+import type { SelectedProjectMetadata, StoredSession } from '../bloomreachSessionStore.js';
+import { BloomreachProjectsService, selectedMetadataToProject } from '../bloomreachProjects.js';
+
+vi.mock('../bloomreachSessionStore.js', () => ({
+  loadSession: vi.fn(),
+  updateSessionMetadata: vi.fn(),
+  clearSelectedProject: vi.fn(),
+  isSessionExpired: vi.fn(),
+}));
+
+vi.mock('../auth/projectSelectors.js', () => ({
+  scrapeProjectTree: vi.fn(),
+  flattenProjects: vi.fn(),
+  findProjectElement: vi.fn(),
+  clickProjectAndCaptureUrl: vi.fn(),
+  toSlug: vi.fn(),
+}));
+
+import {
+  loadSession,
+  updateSessionMetadata,
+  clearSelectedProject,
+  isSessionExpired,
+} from '../bloomreachSessionStore.js';
+import {
+  scrapeProjectTree,
+  flattenProjects,
+  findProjectElement,
+  clickProjectAndCaptureUrl,
+  toSlug,
+} from '../auth/projectSelectors.js';
+
+type SessionWithOptionalSelection = StoredSession & {
+  metadata: StoredSession['metadata'] & {
+    selectedProject?: SelectedProjectMetadata;
+  };
+};
+
+const mockPage = {
+  goto: vi.fn(),
+  waitForTimeout: vi.fn(),
+  url: vi.fn(),
+} as unknown as Page;
+
+const mockContext = {
+  pages: vi.fn(),
+  newPage: vi.fn(),
+} as unknown as BrowserContext;
+
+function createMockProfileManager(page: Page, context: BrowserContext): BloomreachProfileManager {
+  const contextWithPage = {
+    ...context,
+    pages: vi.fn().mockReturnValue([page]),
+    newPage: vi.fn().mockResolvedValue(page),
+  } as unknown as BrowserContext;
+
+  return {
+    runWithPersistentContext: vi
+      .fn()
+      .mockImplementation(
+        async (
+          _name: string,
+          _opts: unknown,
+          callback: (ctx: BrowserContext) => Promise<unknown>,
+        ) => callback(contextWithPage),
+      ),
+  } as unknown as BloomreachProfileManager;
+}
+
+function createSession(selectedProject?: SelectedProjectMetadata): SessionWithOptionalSelection {
+  return {
+    schemaVersion: 1,
+    metadata: {
+      capturedAt: '2026-01-01T00:00:00.000Z',
+      profileName: 'default',
+      loginUrl: 'https://eu.login.bloomreach.com/login',
+      cookieCount: 1,
+      earliestCookieExpiry: '2030-01-01T00:00:00.000Z',
+      selectedProject,
+    },
+    storageState: {
+      cookies: [],
+      origins: [],
+    },
+  };
+}
+
+const scrapedTree = {
+  organizations: [
+    {
+      name: 'Org One',
+      workspaces: [
+        {
+          name: 'Workspace One',
+          products: [
+            {
+              name: 'Engagement',
+              projectCount: 2,
+              projects: ['Alpha Project', 'Beta Project'],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const flattenedProjects = [
+  {
+    name: 'Alpha Project',
+    organization: 'Org One',
+    workspace: 'Workspace One',
+    product: 'Engagement',
+  },
+  {
+    name: 'Beta Project',
+    organization: 'Org One',
+    workspace: 'Workspace One',
+    product: 'Engagement',
+  },
+];
+
+const selectedProjectMeta: SelectedProjectMetadata = {
+  name: 'Legacy Project',
+  slug: 'legacy-project',
+  url: 'https://app.exponea.com/p/legacy-project/home',
+  organization: 'Legacy Org',
+  workspace: 'Legacy Workspace',
+  product: 'Engagement',
+  selectedAt: '2026-01-05T12:00:00.000Z',
+};
+
+describe('BloomreachProjectsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPage.goto = vi.fn().mockResolvedValue(null) as unknown as Page['goto'];
+    mockPage.waitForTimeout = vi
+      .fn()
+      .mockResolvedValue(undefined) as unknown as Page['waitForTimeout'];
+    mockPage.url = vi
+      .fn()
+      .mockReturnValue('https://eu.login.bloomreach.com/my-account') as unknown as Page['url'];
+
+    vi.mocked(loadSession).mockResolvedValue(createSession());
+    vi.mocked(updateSessionMetadata).mockResolvedValue(true);
+    vi.mocked(clearSelectedProject).mockResolvedValue(true);
+    vi.mocked(isSessionExpired).mockReturnValue(false);
+
+    vi.mocked(scrapeProjectTree).mockResolvedValue(scrapedTree);
+    vi.mocked(flattenProjects).mockReturnValue(flattenedProjects);
+    vi.mocked(findProjectElement).mockResolvedValue({} as unknown as ElementHandle);
+    vi.mocked(clickProjectAndCaptureUrl).mockResolvedValue({
+      url: 'https://app.exponea.com/p/alpha-project/home',
+      slug: 'alpha-project',
+    });
+    vi.mocked(toSlug).mockImplementation((name: string) =>
+      name
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, ''),
+    );
+  });
+
+  it('throws AUTH_REQUIRED when no session exists', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    await expect(service.listProjects()).rejects.toMatchObject({
+      code: 'AUTH_REQUIRED',
+      name: 'BloomreachBuddyError',
+    });
+  });
+
+  it('throws AUTH_REQUIRED when session is expired', async () => {
+    vi.mocked(loadSession).mockResolvedValue(createSession());
+    vi.mocked(isSessionExpired).mockReturnValue(true);
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    await expect(service.listProjects()).rejects.toMatchObject({
+      code: 'AUTH_REQUIRED',
+      name: 'BloomreachBuddyError',
+    });
+  });
+
+  it('navigates to my-account and returns scraped project list', async () => {
+    const profileManager = createMockProfileManager(mockPage, mockContext);
+    const service = new BloomreachProjectsService(profileManager, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.listProjects({ profileName: 'p1' });
+
+    expect(result.profileName).toBe('p1');
+    expect(result.hierarchy).toEqual(scrapedTree);
+    expect(result.projects).toEqual([
+      {
+        name: 'Alpha Project',
+        slug: 'alpha-project',
+        url: '',
+        organization: 'Org One',
+        workspace: 'Workspace One',
+        product: 'Engagement',
+      },
+      {
+        name: 'Beta Project',
+        slug: 'beta-project',
+        url: '',
+        organization: 'Org One',
+        workspace: 'Workspace One',
+        product: 'Engagement',
+      },
+    ]);
+    expect(mockPage.goto).toHaveBeenCalledWith('https://eu.login.bloomreach.com/my-account', {
+      waitUntil: 'networkidle',
+      timeout: 30_000,
+    });
+    expect(profileManager.runWithPersistentContext).toHaveBeenCalledWith(
+      'p1',
+      { headless: false },
+      expect.any(Function),
+    );
+  });
+
+  it('derives my-account URL from loginUrl', async () => {
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+      loginUrl: 'https://us.login.bloomreach.com/login/path?x=1',
+    });
+
+    await service.listProjects();
+
+    expect(mockPage.goto).toHaveBeenCalledWith('https://us.login.bloomreach.com/my-account', {
+      waitUntil: 'networkidle',
+      timeout: 30_000,
+    });
+  });
+
+  it('selects project by name, captures URL, and saves to session', async () => {
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.selectProject('Alpha Project', { profileName: 'p1' });
+
+    expect(findProjectElement).toHaveBeenCalledWith(mockPage, 'Alpha Project');
+    expect(clickProjectAndCaptureUrl).toHaveBeenCalled();
+    expect(updateSessionMetadata).toHaveBeenCalledWith('/profiles', 'p1', {
+      selectedProject: expect.objectContaining({
+        name: 'Alpha Project',
+        slug: 'alpha-project',
+        url: 'https://app.exponea.com/p/alpha-project/home',
+        organization: 'Org One',
+        workspace: 'Workspace One',
+        product: 'Engagement',
+      }),
+    });
+    expect(result.project).toEqual({
+      name: 'Alpha Project',
+      slug: 'alpha-project',
+      url: 'https://app.exponea.com/p/alpha-project/home',
+      organization: 'Org One',
+      workspace: 'Workspace One',
+      product: 'Engagement',
+    });
+    expect(result.profileName).toBe('p1');
+  });
+
+  it('throws TARGET_NOT_FOUND when project not found', async () => {
+    vi.mocked(findProjectElement).mockResolvedValue(null);
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    await expect(service.selectProject('missing-project')).rejects.toMatchObject({
+      code: 'TARGET_NOT_FOUND',
+      name: 'BloomreachBuddyError',
+    });
+    expect(clickProjectAndCaptureUrl).not.toHaveBeenCalled();
+    expect(updateSessionMetadata).not.toHaveBeenCalled();
+  });
+
+  it('throws AUTH_REQUIRED when not authenticated', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    await expect(service.selectProject('alpha-project')).rejects.toMatchObject({
+      code: 'AUTH_REQUIRED',
+      name: 'BloomreachBuddyError',
+    });
+  });
+
+  it('includes previousProject in result when one was previously selected', async () => {
+    vi.mocked(loadSession).mockResolvedValue(createSession(selectedProjectMeta));
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.selectProject('alpha-project');
+
+    expect(result.previousProject).toEqual({
+      name: 'Legacy Project',
+      slug: 'legacy-project',
+      url: 'https://app.exponea.com/p/legacy-project/home',
+      organization: 'Legacy Org',
+      workspace: 'Legacy Workspace',
+      product: 'Engagement',
+    });
+  });
+
+  it('sets previousProject to null when no prior selection', async () => {
+    vi.mocked(loadSession).mockResolvedValue(createSession());
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.selectProject('alpha-project');
+
+    expect(result.previousProject).toBeNull();
+  });
+
+  it('returns stored project from session metadata', async () => {
+    vi.mocked(loadSession).mockResolvedValue(createSession(selectedProjectMeta));
+    const profileManager = createMockProfileManager(mockPage, mockContext);
+    const service = new BloomreachProjectsService(profileManager, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.currentProject({ profileName: 'p1' });
+
+    expect(result).toEqual({
+      profileName: 'p1',
+      project: {
+        name: 'Legacy Project',
+        slug: 'legacy-project',
+        url: 'https://app.exponea.com/p/legacy-project/home',
+        organization: 'Legacy Org',
+        workspace: 'Legacy Workspace',
+        product: 'Engagement',
+      },
+    });
+    expect(profileManager.runWithPersistentContext).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no project selected', async () => {
+    vi.mocked(loadSession).mockResolvedValue(createSession());
+    const profileManager = createMockProfileManager(mockPage, mockContext);
+    const service = new BloomreachProjectsService(profileManager, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.currentProject();
+
+    expect(result).toEqual({
+      project: null,
+      profileName: 'default',
+    });
+    expect(profileManager.runWithPersistentContext).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no session exists', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+    const profileManager = createMockProfileManager(mockPage, mockContext);
+    const service = new BloomreachProjectsService(profileManager, {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.currentProject({ profileName: 'p1' });
+
+    expect(result).toEqual({
+      project: null,
+      profileName: 'p1',
+    });
+    expect(profileManager.runWithPersistentContext).not.toHaveBeenCalled();
+  });
+
+  it('clears project selection from session', async () => {
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.clearProject({ profileName: 'p1' });
+
+    expect(clearSelectedProject).toHaveBeenCalledWith('/profiles', 'p1');
+    expect(result.cleared).toBe(true);
+    expect(result.profileName).toBe('p1');
+  });
+
+  it('returns previousProject when clearing', async () => {
+    vi.mocked(loadSession).mockResolvedValue(createSession(selectedProjectMeta));
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.clearProject();
+
+    expect(result.previousProject).toEqual({
+      name: 'Legacy Project',
+      slug: 'legacy-project',
+      url: 'https://app.exponea.com/p/legacy-project/home',
+      organization: 'Legacy Org',
+      workspace: 'Legacy Workspace',
+      product: 'Engagement',
+    });
+  });
+
+  it('returns cleared: false when no session exists', async () => {
+    vi.mocked(loadSession).mockResolvedValue(null);
+    vi.mocked(clearSelectedProject).mockResolvedValue(false);
+    const service = new BloomreachProjectsService(createMockProfileManager(mockPage, mockContext), {
+      profilesDir: '/profiles',
+    });
+
+    const result = await service.clearProject({ profileName: 'p1' });
+
+    expect(result).toEqual({
+      cleared: false,
+      profileName: 'p1',
+      previousProject: null,
+    });
+  });
+});
+
+describe('selectedMetadataToProject', () => {
+  it('converts SelectedProjectMetadata to BloomreachProject', () => {
+    const result = selectedMetadataToProject(selectedProjectMeta);
+
+    expect(result).toEqual({
+      name: 'Legacy Project',
+      slug: 'legacy-project',
+      url: 'https://app.exponea.com/p/legacy-project/home',
+      organization: 'Legacy Org',
+      workspace: 'Legacy Workspace',
+      product: 'Engagement',
+    });
+  });
+});

--- a/packages/core/src/__tests__/bloomreachSessionStore.test.ts
+++ b/packages/core/src/__tests__/bloomreachSessionStore.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('node:os', async () => {
-  const actual = await vi.importActual('node:os') as Record<string, unknown>;
+  const actual = (await vi.importActual('node:os')) as Record<string, unknown>;
   return {
     ...actual,
     hostname: () => 'test-host',
@@ -16,7 +16,7 @@ vi.mock('node:os', async () => {
 });
 
 vi.mock('node:fs/promises', async () => {
-  const actual = await vi.importActual('node:fs/promises') as Record<string, unknown>;
+  const actual = (await vi.importActual('node:fs/promises')) as Record<string, unknown>;
   return {
     ...actual,
     chmod: vi.fn(async () => undefined),
@@ -24,7 +24,9 @@ vi.mock('node:fs/promises', async () => {
 });
 
 import {
+  clearSelectedProject,
   deriveEncryptionKey,
+  updateSessionMetadata,
   getSessionFilePath,
   isSessionExpired,
   loadSession,
@@ -32,6 +34,7 @@ import {
   saveSession,
   summarizeSessionCookies,
   type BloomreachStorageState,
+  type SelectedProjectMetadata,
   type StoredSession,
 } from '../bloomreachSessionStore.js';
 
@@ -269,4 +272,86 @@ describe('bloomreachSessionStore', () => {
     });
   });
 
+  describe('updateSessionMetadata', () => {
+    it('returns false when no session file exists', async () => {
+      const result = await updateSessionMetadata(tempRoot, 'nonexistent', {});
+      expect(result).toBe(false);
+    });
+
+    it('updates selectedProject in existing session metadata', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const mockStorageState = makeStorageState(nowSeconds);
+      await saveSession(tempRoot, 'test', mockStorageState, 'https://example.com');
+
+      const selectedProject: SelectedProjectMetadata = {
+        name: 'Kingdom of Joakim',
+        slug: 'kingdom-of-joakim',
+        url: 'https://power.bloomreach.co/p/kingdom-of-joakim/home',
+        organization: 'POWER',
+        workspace: 'POWER',
+        product: 'Engagement',
+        selectedAt: new Date().toISOString(),
+      };
+
+      const result = await updateSessionMetadata(tempRoot, 'test', { selectedProject });
+      expect(result).toBe(true);
+
+      const session = await loadSession(tempRoot, 'test');
+      expect(session?.metadata.selectedProject).toEqual(selectedProject);
+    });
+
+    it('preserves existing metadata fields when updating', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const mockStorageState = makeStorageState(nowSeconds);
+      await saveSession(tempRoot, 'test', mockStorageState, 'https://example.com');
+      const sessionBefore = await loadSession(tempRoot, 'test');
+
+      await updateSessionMetadata(tempRoot, 'test', {
+        selectedProject: {
+          name: 'Test',
+          slug: 'test',
+          url: 'https://test.bloomreach.co/p/test/home',
+          organization: 'ORG',
+          workspace: 'WS',
+          product: 'Engagement',
+          selectedAt: new Date().toISOString(),
+        },
+      });
+
+      const sessionAfter = await loadSession(tempRoot, 'test');
+      expect(sessionAfter?.metadata.capturedAt).toBe(sessionBefore?.metadata.capturedAt);
+      expect(sessionAfter?.metadata.loginUrl).toBe(sessionBefore?.metadata.loginUrl);
+      expect(sessionAfter?.metadata.cookieCount).toBe(sessionBefore?.metadata.cookieCount);
+    });
+  });
+
+  describe('clearSelectedProject', () => {
+    it('removes selectedProject from metadata', async () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const mockStorageState = makeStorageState(nowSeconds);
+      await saveSession(tempRoot, 'test', mockStorageState, 'https://example.com');
+      await updateSessionMetadata(tempRoot, 'test', {
+        selectedProject: {
+          name: 'Test',
+          slug: 'test',
+          url: 'https://test.bloomreach.co/p/test/home',
+          organization: 'ORG',
+          workspace: 'WS',
+          product: 'Engagement',
+          selectedAt: new Date().toISOString(),
+        },
+      });
+
+      const result = await clearSelectedProject(tempRoot, 'test');
+      expect(result).toBe(true);
+
+      const session = await loadSession(tempRoot, 'test');
+      expect(session?.metadata.selectedProject).toBeUndefined();
+    });
+
+    it('returns false when no session exists', async () => {
+      const result = await clearSelectedProject(tempRoot, 'nonexistent');
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/auth/captchaDetector.ts
+++ b/packages/core/src/auth/captchaDetector.ts
@@ -1,0 +1,176 @@
+import type { Page } from 'playwright-core';
+
+export interface CaptchaDetectionResult {
+  detected: boolean;
+  type: 'recaptcha-v2-invisible' | null;
+  iframeSelector: string | null;
+}
+
+export interface CaptchaWaitOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  onDetected?: () => void;
+}
+
+/** Minimum dimensions (px) that indicate the reCAPTCHA challenge bframe is actively showing an image grid. */
+export const CAPTCHA_VISIBLE_THRESHOLD = { width: 280, height: 280 };
+
+/** Default timeout (ms) for waiting for user to solve CAPTCHA. */
+export const DEFAULT_CAPTCHA_TIMEOUT_MS = 120_000;
+
+/** Default poll interval (ms) for checking CAPTCHA resolution. */
+export const DEFAULT_CAPTCHA_POLL_INTERVAL_MS = 2_000;
+
+const CAPTCHA_IFRAME_SELECTORS = [
+  'iframe[title="recaptcha challenge expires in two minutes"]',
+  'iframe[src*="google.com/recaptcha"][src*="bframe"]',
+] as const;
+
+interface EvaluateArgs {
+  selectors: readonly string[];
+  threshold: { width: number; height: number };
+}
+
+interface BrowserRect {
+  width: number;
+  height: number;
+}
+
+interface BrowserStyle {
+  display: string;
+  visibility: string;
+  opacity: string;
+}
+
+interface BrowserIframeElement {
+  getBoundingClientRect: () => BrowserRect;
+}
+
+interface BrowserDocument {
+  querySelector: (selector: string) => BrowserIframeElement | null;
+}
+
+interface BrowserWindow {
+  getComputedStyle: (element: BrowserIframeElement) => BrowserStyle;
+}
+
+const NO_CAPTCHA_RESULT: CaptchaDetectionResult = {
+  detected: false,
+  type: null,
+  iframeSelector: null,
+};
+
+export async function detectCaptcha(page: Page): Promise<CaptchaDetectionResult> {
+  try {
+    const evaluation = await page.evaluate(
+      ({ selectors, threshold }: EvaluateArgs) => {
+        const browserDocument = (globalThis as { document?: BrowserDocument }).document;
+        const browserWindow = (globalThis as { window?: BrowserWindow }).window;
+
+        if (!browserDocument || !browserWindow) {
+          return {
+            detected: false,
+            type: null,
+            iframeSelector: null,
+          };
+        }
+
+        for (const selector of selectors) {
+          const iframe = browserDocument.querySelector(selector);
+          if (!iframe) {
+            continue;
+          }
+
+          const rect = iframe.getBoundingClientRect();
+          const style = browserWindow.getComputedStyle(iframe);
+          const isVisible =
+            rect.width > threshold.width &&
+            rect.height > threshold.height &&
+            style.display !== 'none' &&
+            style.visibility !== 'hidden' &&
+            style.opacity !== '0';
+
+          if (isVisible) {
+            return {
+              detected: true,
+              type: 'recaptcha-v2-invisible',
+              iframeSelector: selector,
+            };
+          }
+        }
+
+        return {
+          detected: false,
+          type: null,
+          iframeSelector: null,
+        };
+      },
+      {
+        selectors: CAPTCHA_IFRAME_SELECTORS,
+        threshold: CAPTCHA_VISIBLE_THRESHOLD,
+      },
+    );
+
+    if (
+      typeof evaluation === 'object' &&
+      evaluation !== null &&
+      'detected' in evaluation &&
+      evaluation.detected === true &&
+      'type' in evaluation &&
+      evaluation.type === 'recaptcha-v2-invisible' &&
+      'iframeSelector' in evaluation &&
+      typeof evaluation.iframeSelector === 'string'
+    ) {
+      return {
+        detected: true,
+        type: 'recaptcha-v2-invisible',
+        iframeSelector: evaluation.iframeSelector,
+      };
+    }
+
+    return NO_CAPTCHA_RESULT;
+  } catch {
+    return NO_CAPTCHA_RESULT;
+  }
+}
+
+export async function isCaptchaVisible(page: Page): Promise<boolean> {
+  const result = await detectCaptcha(page);
+  return result.detected;
+}
+
+export async function waitForCaptchaResolution(
+  page: Page,
+  isResolved: (url: string) => boolean,
+  options: CaptchaWaitOptions = {},
+): Promise<{ resolved: boolean; timedOut: boolean }> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CAPTCHA_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_CAPTCHA_POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  let hasTriggeredDetectedCallback = false;
+
+  while (Date.now() <= deadline) {
+    const currentUrl = page.url();
+    if (isResolved(currentUrl)) {
+      return { resolved: true, timedOut: false };
+    }
+
+    const captchaVisible = await isCaptchaVisible(page);
+    if (captchaVisible) {
+      if (!hasTriggeredDetectedCallback) {
+        options.onDetected?.();
+        hasTriggeredDetectedCallback = true;
+      }
+    } else {
+      return { resolved: true, timedOut: false };
+    }
+
+    if (Date.now() > deadline) {
+      break;
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  return { resolved: false, timedOut: true };
+}

--- a/packages/core/src/auth/projectSelectors.ts
+++ b/packages/core/src/auth/projectSelectors.ts
@@ -1,0 +1,250 @@
+import type { BrowserContext, ElementHandle, Page } from 'playwright-core';
+
+/** A scraped project entry with its full hierarchy path. */
+export interface ScrapedProject {
+  name: string;
+  organization: string;
+  workspace: string;
+  product: string;
+}
+
+/** Result of scraping the full project tree from /my-account. */
+export interface ScrapedProjectTree {
+  organizations: ScrapedOrganization[];
+}
+
+export interface ScrapedOrganization {
+  name: string;
+  workspaces: ScrapedWorkspace[];
+}
+
+export interface ScrapedWorkspace {
+  name: string;
+  products: ScrapedProduct[];
+}
+
+export interface ScrapedProduct {
+  name: string;
+  projectCount: number;
+  projects: string[];
+}
+
+/** Timeout (ms) for waiting for the project tree to render. */
+export const PROJECT_TREE_RENDER_TIMEOUT_MS = 10_000;
+
+/** Scrape the organization/workspace/product/project hierarchy from /my-account. */
+export async function scrapeProjectTree(page: Page): Promise<ScrapedProjectTree> {
+  try {
+    await page.waitForSelector('e-ui-accordion.discovery-like', {
+      timeout: PROJECT_TREE_RENDER_TIMEOUT_MS,
+    });
+  } catch {
+    return { organizations: [] };
+  }
+
+  const tree = await page.evaluate<ScrapedProjectTree>(() => {
+    type DomElement = {
+      parentElement: DomElement | null;
+      textContent: string | null;
+      matches: (selector: string) => boolean;
+      querySelector: (selector: string) => DomElement | null;
+      querySelectorAll: (selector: string) => Iterable<DomElement>;
+    };
+
+    type DomDocument = {
+      querySelectorAll: (selector: string) => Iterable<DomElement>;
+    };
+
+    const normalizeText = (value: string | null | undefined): string =>
+      (value ?? '').replace(/\s+/g, ' ').trim();
+
+    const domDocument = (globalThis as { document?: DomDocument }).document;
+    if (!domDocument) {
+      return { organizations: [] };
+    }
+
+    const getNearestAccordionAncestor = (element: DomElement): DomElement | null => {
+      let current = element.parentElement;
+      while (current) {
+        if (current.matches('e-ui-accordion.discovery-like')) {
+          return current;
+        }
+        current = current.parentElement;
+      }
+      return null;
+    };
+
+    const getChildAccordions = (accordion: DomElement): DomElement[] => {
+      const descendants = Array.from<DomElement>(
+        accordion.querySelectorAll('e-ui-accordion.discovery-like'),
+      );
+
+      return descendants.filter(
+        (descendant) => getNearestAccordionAncestor(descendant) === accordion,
+      );
+    };
+
+    const getLeafRows = (accordion: DomElement): string[] => {
+      const rows = Array.from<DomElement>(accordion.querySelectorAll('div.discovery-like-row'));
+
+      return rows
+        .filter((row) => getNearestAccordionAncestor(row) === accordion)
+        .map((row) => normalizeText(row.textContent))
+        .filter((name) => name.length > 0);
+    };
+
+    const getHeaderText = (accordion: DomElement): string => {
+      const strongHeader = accordion.querySelector('span.ui.strong');
+      if (strongHeader) {
+        return normalizeText(strongHeader.textContent);
+      }
+
+      const uiHeader = accordion.querySelector('span.ui');
+      return normalizeText(uiHeader?.textContent);
+    };
+
+    const parseProductHeader = (headerText: string): { name: string; count: number | null } => {
+      const trimmed = normalizeText(headerText);
+      const match = trimmed.match(/^(.*?)(?:\((\d+)\))?$/);
+
+      if (!match) {
+        return { name: trimmed, count: null };
+      }
+
+      const productName = normalizeText(match[1]);
+      const parsedCount = match[2] ? Number.parseInt(match[2], 10) : null;
+      return { name: productName, count: Number.isNaN(parsedCount) ? null : parsedCount };
+    };
+
+    const allAccordions = Array.from<DomElement>(
+      domDocument.querySelectorAll('e-ui-accordion.discovery-like'),
+    );
+    const organizations = allAccordions
+      .filter((accordion) => !getNearestAccordionAncestor(accordion))
+      .map((organizationAccordion) => {
+        const organizationName = getHeaderText(organizationAccordion);
+
+        const workspaceAccordions = getChildAccordions(organizationAccordion);
+        const workspaces = workspaceAccordions.map((workspaceAccordion) => {
+          const workspaceName = getHeaderText(workspaceAccordion);
+
+          const productAccordions = getChildAccordions(workspaceAccordion);
+          const products = productAccordions.map((productAccordion) => {
+            const headerText = getHeaderText(productAccordion);
+            const parsedHeader = parseProductHeader(headerText);
+            const projects = getLeafRows(productAccordion);
+
+            return {
+              name: parsedHeader.name,
+              projectCount: parsedHeader.count ?? projects.length,
+              projects,
+            };
+          });
+
+          return {
+            name: workspaceName,
+            products,
+          };
+        });
+
+        return {
+          name: organizationName,
+          workspaces,
+        };
+      });
+
+    return { organizations };
+  });
+
+  return tree;
+}
+
+/** Flatten a scraped tree into project entries with full hierarchy path. */
+export function flattenProjects(tree: ScrapedProjectTree): ScrapedProject[] {
+  return tree.organizations.flatMap((organization) =>
+    organization.workspaces.flatMap((workspace) =>
+      workspace.products.flatMap((product) =>
+        product.projects.map((projectName) => ({
+          name: projectName,
+          organization: organization.name,
+          workspace: workspace.name,
+          product: product.name,
+        })),
+      ),
+    ),
+  );
+}
+
+/** Find a project row element by exact name or slug match. */
+export async function findProjectElement(
+  page: Page,
+  nameOrSlug: string,
+): Promise<ElementHandle | null> {
+  const rows = await page.$$('div.discovery-like-row');
+  const nameQuery = nameOrSlug.trim().toLowerCase();
+  const slugQuery = toSlug(nameOrSlug);
+
+  for (const row of rows) {
+    const rowText = (await row.textContent())?.replace(/\s+/g, ' ').trim();
+    if (!rowText) {
+      continue;
+    }
+
+    const rowName = rowText.toLowerCase();
+    const rowSlug = toSlug(rowText);
+    if (rowName === nameQuery || rowSlug === nameQuery || rowSlug === slugQuery) {
+      return row;
+    }
+  }
+
+  return null;
+}
+
+/** Click a project row, capture new-tab URL, then close the tab. */
+export async function clickProjectAndCaptureUrl(
+  context: BrowserContext,
+  projectElement: ElementHandle,
+): Promise<{ url: string; slug: string } | null> {
+  try {
+    const newPagePromise = context.waitForEvent('page', { timeout: 10_000 });
+    await projectElement.click();
+    const newPage = await newPagePromise;
+
+    try {
+      await newPage.waitForLoadState('domcontentloaded');
+      const url = newPage.url();
+      const slug = extractProjectSlug(url);
+      if (!slug) {
+        return null;
+      }
+
+      return { url, slug };
+    } finally {
+      await newPage.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/** Extract project slug from URLs like https://.../p/{slug}/home. */
+export function extractProjectSlug(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/\/p\/([^/]+)(?:\/|$)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Convert a project name to a normalized kebab-case slug. */
+export function toSlug(name: string): string {
+  return name
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}

--- a/packages/core/src/bloomreachAuth.ts
+++ b/packages/core/src/bloomreachAuth.ts
@@ -17,6 +17,14 @@ import type {
   StoredSession,
 } from './bloomreachSessionStore.js';
 import { tryAutoFill, resolveAutoFillConfig } from './auth/loginSelectors.js';
+import {
+  detectCaptcha,
+  isCaptchaVisible,
+  waitForCaptchaResolution,
+} from './auth/captchaDetector.js';
+
+void isCaptchaVisible;
+void waitForCaptchaResolution;
 
 export const BLOOMREACH_LOGIN_URL = 'https://eu.login.bloomreach.com/login';
 export const BLOOMREACH_APP_URL = 'https://app.exponea.com/';
@@ -43,10 +51,16 @@ export interface BloomreachOpenLoginOptions extends BloomreachSessionOptions {
   pollIntervalMs?: number;
   loginUrl?: string;
   autoFill?: boolean;
+  /** Extended timeout when CAPTCHA is detected (ms). Default: 120_000. */
+  captchaTimeoutMs?: number;
+  /** Callback invoked when CAPTCHA challenge is detected during login. */
+  onCaptchaDetected?: () => void;
 }
 
 export interface BloomreachOpenLoginResult extends BloomreachSessionStatus {
   timedOut: boolean;
+  /** Whether a CAPTCHA challenge was detected during login. */
+  captchaDetected: boolean;
 }
 
 export interface BloomreachAuthConfig {
@@ -74,7 +88,10 @@ export function isAuthenticatedPage(url: string): boolean {
       return !LOGIN_DOMAIN_PUBLIC_PATHS.has(parsed.pathname);
     }
     // Or navigates to project pages on .bloomreach.co or .exponea.com
-    return (parsed.hostname.endsWith('.bloomreach.co') || parsed.hostname.endsWith('.exponea.com')) && parsed.pathname !== '/login';
+    return (
+      (parsed.hostname.endsWith('.bloomreach.co') || parsed.hostname.endsWith('.exponea.com')) &&
+      parsed.pathname !== '/login'
+    );
   } catch {
     return false;
   }
@@ -152,7 +169,9 @@ export class BloomreachAuthService {
           if (autoFillConfig.email || autoFillConfig.password) {
             // Wait for the login form to render (Angular SPA needs time after navigation)
             try {
-              await page.waitForSelector('input[name="username"], input[type="email"]', { timeout: 10_000 });
+              await page.waitForSelector('input[name="username"], input[type="email"]', {
+                timeout: 10_000,
+              });
             } catch {
               // Form may not appear (already authenticated, different page layout) — continue
             }
@@ -160,8 +179,9 @@ export class BloomreachAuthService {
           }
         }
 
-        const deadline = Date.now() + timeoutMs;
+        let deadline = Date.now() + timeoutMs;
         let authenticated = false;
+        let captchaDetected = false;
 
         while (Date.now() < deadline) {
           await page.waitForTimeout(pollIntervalMs);
@@ -171,6 +191,21 @@ export class BloomreachAuthService {
             authenticated = true;
             break;
           }
+
+          // Check for CAPTCHA challenge on login page
+          if (!captchaDetected && isLoginPage(currentUrl)) {
+            const captchaResult = await detectCaptcha(page);
+            if (captchaResult.detected) {
+              captchaDetected = true;
+              options?.onCaptchaDetected?.();
+              // Extend deadline if captchaTimeoutMs is specified
+              const captchaTimeoutMs = options?.captchaTimeoutMs ?? 120_000;
+              const newDeadline = Date.now() + captchaTimeoutMs;
+              if (newDeadline > deadline) {
+                deadline = newDeadline;
+              }
+            }
+          }
         }
 
         const checkedAt = new Date().toISOString();
@@ -179,11 +214,14 @@ export class BloomreachAuthService {
           return {
             authenticated: false,
             checkedAt,
-            reason: 'Login timed out. The browser was closed or login was not completed in time.',
+            reason: captchaDetected
+              ? 'CAPTCHA challenge detected but not solved within the timeout period.'
+              : 'Login timed out. The browser was closed or login was not completed in time.',
             profileName,
             sessionCookiePresent: false,
             sessionExpired: false,
             timedOut: true,
+            captchaDetected,
           };
         }
 
@@ -199,6 +237,7 @@ export class BloomreachAuthService {
           sessionCookiePresent: true,
           sessionExpired: false,
           timedOut: false,
+          captchaDetected,
           cookieSummary: summarizeSessionCookies(storageState.cookies),
         };
       },
@@ -234,7 +273,9 @@ export class BloomreachAuthService {
    * Clear stored browser session for a profile.
    * @returns Object indicating if a session was cleared and which profile.
    */
-  async logout(options?: BloomreachSessionOptions): Promise<{ cleared: boolean; profileName: string }> {
+  async logout(
+    options?: BloomreachSessionOptions,
+  ): Promise<{ cleared: boolean; profileName: string }> {
     const profileName = options?.profileName ?? 'default';
     const cleared = await deleteSession(this.profilesDir, profileName);
     return { cleared, profileName };

--- a/packages/core/src/bloomreachProjects.ts
+++ b/packages/core/src/bloomreachProjects.ts
@@ -1,0 +1,301 @@
+import type { BrowserContext, Page } from 'playwright-core';
+import { BloomreachBuddyError } from './errors.js';
+import type {
+  BloomreachProfileManager,
+  PersistentContextOptions,
+} from './bloomreachProfileManager.js';
+import type { BloomreachAuthConfig, BloomreachSessionOptions } from './bloomreachAuth.js';
+import { isAuthenticatedPage } from './bloomreachAuth.js';
+import {
+  loadSession,
+  updateSessionMetadata,
+  clearSelectedProject as clearSelectedProjectFromStore,
+  isSessionExpired,
+} from './bloomreachSessionStore.js';
+import type { SelectedProjectMetadata } from './bloomreachSessionStore.js';
+import {
+  scrapeProjectTree,
+  flattenProjects,
+  findProjectElement,
+  clickProjectAndCaptureUrl,
+  toSlug,
+} from './auth/projectSelectors.js';
+import type { ScrapedProject, ScrapedProjectTree } from './auth/projectSelectors.js';
+
+/** A Bloomreach project with full hierarchy context. */
+export interface BloomreachProject {
+  name: string;
+  slug: string;
+  url: string;
+  organization: string;
+  workspace: string;
+  product: string;
+}
+
+/** Result of listing available projects. */
+export interface ProjectListResult {
+  projects: BloomreachProject[];
+  hierarchy: ScrapedProjectTree;
+  scrapedAt: string;
+  profileName: string;
+}
+
+/** Result of selecting a project. */
+export interface ProjectSelectResult {
+  project: BloomreachProject;
+  selectedAt: string;
+  profileName: string;
+  previousProject: BloomreachProject | null;
+}
+
+/** Currently selected project (or null if none). */
+export interface ProjectCurrentResult {
+  project: BloomreachProject | null;
+  profileName: string;
+}
+
+/** Result of clearing project selection. */
+export interface ProjectClearResult {
+  cleared: boolean;
+  profileName: string;
+  previousProject: BloomreachProject | null;
+}
+
+/** Convert SelectedProjectMetadata to BloomreachProject. */
+export function selectedMetadataToProject(meta: SelectedProjectMetadata): BloomreachProject {
+  return {
+    name: meta.name,
+    slug: meta.slug,
+    url: meta.url,
+    organization: meta.organization,
+    workspace: meta.workspace,
+    product: meta.product,
+  };
+}
+
+export class BloomreachProjectsService {
+  private readonly profileManager: BloomreachProfileManager;
+  private readonly profilesDir: string;
+  private readonly loginUrl: string;
+
+  constructor(profileManager: BloomreachProfileManager, config: BloomreachAuthConfig) {
+    this.profileManager = profileManager;
+    this.profilesDir = config.profilesDir;
+    const loginUrl =
+      config.loginUrl ??
+      process.env.BLOOMREACH_LOGIN_URL ??
+      'https://eu.login.bloomreach.com/login';
+    this.loginUrl = loginUrl;
+  }
+
+  async listProjects(options?: BloomreachSessionOptions): Promise<ProjectListResult> {
+    const profileName = options?.profileName ?? 'default';
+    const session = await loadSession(this.profilesDir, profileName);
+
+    if (!session || isSessionExpired(session)) {
+      throw new BloomreachBuddyError(
+        'AUTH_REQUIRED',
+        'Browser session is not authenticated. Run "bloomreach login" first.',
+      );
+    }
+
+    const myAccountUrl = this.buildMyAccountUrl();
+    const persistentOptions: PersistentContextOptions = { headless: false };
+
+    const { hierarchy, projects } = await this.profileManager.runWithPersistentContext(
+      profileName,
+      persistentOptions,
+      async (context: BrowserContext) => {
+        const page: Page = context.pages()[0] ?? (await context.newPage());
+
+        await page.goto(myAccountUrl, { waitUntil: 'networkidle', timeout: 30_000 });
+        await page.waitForTimeout(500);
+
+        if (!isAuthenticatedPage(page.url())) {
+          throw new BloomreachBuddyError(
+            'AUTH_REQUIRED',
+            'Browser session is not authenticated. Run "bloomreach login" first.',
+          );
+        }
+
+        const scrapedHierarchy = await scrapeProjectTree(page);
+        const flattened = flattenProjects(scrapedHierarchy);
+
+        const projectList = flattened.map((project: ScrapedProject) => ({
+          name: project.name,
+          slug: toSlug(project.name),
+          url: '',
+          organization: project.organization,
+          workspace: project.workspace,
+          product: project.product,
+        }));
+
+        return {
+          hierarchy: scrapedHierarchy,
+          projects: projectList,
+        };
+      },
+    );
+
+    return {
+      projects,
+      hierarchy,
+      scrapedAt: new Date().toISOString(),
+      profileName,
+    };
+  }
+
+  async selectProject(
+    nameOrSlug: string,
+    options?: BloomreachSessionOptions,
+  ): Promise<ProjectSelectResult> {
+    const profileName = options?.profileName ?? 'default';
+    const session = await loadSession(this.profilesDir, profileName);
+
+    if (!session || isSessionExpired(session)) {
+      throw new BloomreachBuddyError(
+        'AUTH_REQUIRED',
+        'Browser session is not authenticated. Run "bloomreach login" first.',
+      );
+    }
+
+    const previousProject = session.metadata.selectedProject
+      ? selectedMetadataToProject(session.metadata.selectedProject)
+      : null;
+
+    const myAccountUrl = this.buildMyAccountUrl();
+    const persistentOptions: PersistentContextOptions = { headless: false };
+
+    const selected = await this.profileManager.runWithPersistentContext(
+      profileName,
+      persistentOptions,
+      async (context: BrowserContext) => {
+        const page: Page = context.pages()[0] ?? (await context.newPage());
+        await page.goto(myAccountUrl, { waitUntil: 'networkidle', timeout: 30_000 });
+
+        if (!isAuthenticatedPage(page.url())) {
+          throw new BloomreachBuddyError(
+            'AUTH_REQUIRED',
+            'Browser session is not authenticated. Run "bloomreach login" first.',
+          );
+        }
+
+        const hierarchy = await scrapeProjectTree(page);
+        const flattened = flattenProjects(hierarchy);
+
+        const projectElement = await findProjectElement(page, nameOrSlug);
+        if (!projectElement) {
+          throw new BloomreachBuddyError(
+            'TARGET_NOT_FOUND',
+            `Project "${nameOrSlug}" not found in Bloomreach account project list.`,
+          );
+        }
+
+        const captured = await clickProjectAndCaptureUrl(context, projectElement);
+        if (!captured) {
+          throw new BloomreachBuddyError(
+            'TARGET_NOT_FOUND',
+            `Project "${nameOrSlug}" was found but opening it failed or URL could not be captured.`,
+          );
+        }
+
+        const normalizedQuery = nameOrSlug.trim().toLowerCase();
+        const querySlug = toSlug(nameOrSlug);
+        const matchedProject = flattened.find((project) => {
+          const projectName = project.name.trim().toLowerCase();
+          const projectSlug = toSlug(project.name);
+          return (
+            projectName === normalizedQuery ||
+            projectSlug === normalizedQuery ||
+            projectSlug === querySlug
+          );
+        });
+
+        if (!matchedProject) {
+          throw new BloomreachBuddyError(
+            'TARGET_NOT_FOUND',
+            `Project "${nameOrSlug}" metadata could not be resolved from the project hierarchy.`,
+          );
+        }
+
+        return {
+          name: matchedProject.name,
+          slug: captured.slug,
+          url: captured.url,
+          organization: matchedProject.organization,
+          workspace: matchedProject.workspace,
+          product: matchedProject.product,
+        };
+      },
+    );
+
+    const selectedAt = new Date().toISOString();
+    const selectedProject: SelectedProjectMetadata = {
+      ...selected,
+      selectedAt,
+    };
+
+    const updated = await updateSessionMetadata(this.profilesDir, profileName, {
+      selectedProject,
+    });
+
+    if (!updated) {
+      throw new BloomreachBuddyError(
+        'AUTH_REQUIRED',
+        'Browser session is not authenticated. Run "bloomreach login" first.',
+      );
+    }
+
+    return {
+      project: selected,
+      selectedAt,
+      profileName,
+      previousProject,
+    };
+  }
+
+  async currentProject(options?: BloomreachSessionOptions): Promise<ProjectCurrentResult> {
+    const profileName = options?.profileName ?? 'default';
+    const session = await loadSession(this.profilesDir, profileName);
+
+    if (!session || isSessionExpired(session) || !session.metadata.selectedProject) {
+      return {
+        project: null,
+        profileName,
+      };
+    }
+
+    return {
+      project: selectedMetadataToProject(session.metadata.selectedProject),
+      profileName,
+    };
+  }
+
+  async clearProject(options?: BloomreachSessionOptions): Promise<ProjectClearResult> {
+    const profileName = options?.profileName ?? 'default';
+    const session = await loadSession(this.profilesDir, profileName);
+    const previousProject = session?.metadata.selectedProject
+      ? selectedMetadataToProject(session.metadata.selectedProject)
+      : null;
+
+    const cleared = await clearSelectedProjectFromStore(this.profilesDir, profileName);
+
+    return {
+      cleared,
+      profileName,
+      previousProject,
+    };
+  }
+
+  private buildMyAccountUrl(): string {
+    try {
+      const parsed = new URL(this.loginUrl);
+      parsed.pathname = '/my-account';
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString();
+    } catch {
+      return 'https://eu.login.bloomreach.com/my-account';
+    }
+  }
+}

--- a/packages/core/src/bloomreachSessionStore.ts
+++ b/packages/core/src/bloomreachSessionStore.ts
@@ -28,12 +28,32 @@ export interface BloomreachOriginState {
   localStorage: Array<{ name: string; value: string }>;
 }
 
+/** Metadata for the currently selected Bloomreach project. */
+export interface SelectedProjectMetadata {
+  /** Human-readable project name (e.g. "Kingdom of Joakim"). */
+  name: string;
+  /** URL slug derived from the project URL (e.g. "kingdom-of-joakim"). */
+  slug: string;
+  /** Full project URL (e.g. "https://power.bloomreach.co/p/kingdom-of-joakim/home"). */
+  url: string;
+  /** Organization name (e.g. "POWER"). */
+  organization: string;
+  /** Workspace name (e.g. "POWER"). */
+  workspace: string;
+  /** Product name (e.g. "Engagement"). */
+  product: string;
+  /** ISO-8601 timestamp when this project was selected. */
+  selectedAt: string;
+}
+
 export interface SessionMetadata {
   capturedAt: string; // ISO-8601
   profileName: string;
   loginUrl: string;
   cookieCount: number;
   earliestCookieExpiry: string | null; // ISO-8601 or null if all session cookies
+  /** Currently selected Bloomreach project. Persisted across CLI invocations. */
+  selectedProject?: SelectedProjectMetadata;
 }
 
 export interface StoredSession {
@@ -83,7 +103,9 @@ function buildMetadata(
   loginUrl: string,
   cookies: BloomreachCookie[],
 ): SessionMetadata {
-  const persistentExpiries = cookies.filter((cookie) => cookie.expires > 0).map((cookie) => cookie.expires);
+  const persistentExpiries = cookies
+    .filter((cookie) => cookie.expires > 0)
+    .map((cookie) => cookie.expires);
   const earliestCookieExpiry =
     persistentExpiries.length > 0
       ? new Date(Math.min(...persistentExpiries) * 1000).toISOString()
@@ -96,6 +118,36 @@ function buildMetadata(
     cookieCount: cookies.length,
     earliestCookieExpiry,
   };
+}
+
+async function encryptAndWriteSession(
+  profilesDir: string,
+  profileName: string,
+  storedSession: StoredSession,
+): Promise<string> {
+  const key = deriveEncryptionKey(profileName);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+
+  const plaintext = Buffer.from(JSON.stringify(storedSession), 'utf8');
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const envelope: EncryptedEnvelope = {
+    version: 1,
+    algorithm: 'aes-256-gcm',
+    ciphertext: ciphertext.toString('base64url'),
+    iv: iv.toString('base64url'),
+    tag: tag.toString('base64url'),
+    metadata: storedSession.metadata,
+  };
+
+  const filePath = getSessionFilePath(profilesDir, profileName);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(envelope, null, 2) + '\n', 'utf8');
+  await chmod(filePath, 0o600);
+
+  return filePath;
 }
 
 // ---------------------------------------------------------------------------
@@ -115,29 +167,38 @@ export async function saveSession(
     storageState,
   };
 
-  const key = deriveEncryptionKey(profileName);
-  const iv = randomBytes(12);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  return encryptAndWriteSession(profilesDir, profileName, storedSession);
+}
 
-  const plaintext = Buffer.from(JSON.stringify(storedSession), 'utf8');
-  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-  const tag = cipher.getAuthTag();
+/**
+ * Update specific fields of an existing session's metadata without re-capturing the full session.
+ * Returns true if session was found and updated, false if no session exists.
+ */
+export async function updateSessionMetadata(
+  profilesDir: string,
+  profileName: string,
+  update: Partial<SessionMetadata>,
+): Promise<boolean> {
+  const session = await loadSession(profilesDir, profileName);
+  if (!session) {
+    return false;
+  }
 
-  const envelope: EncryptedEnvelope = {
-    version: 1,
-    algorithm: 'aes-256-gcm',
-    ciphertext: ciphertext.toString('base64url'),
-    iv: iv.toString('base64url'),
-    tag: tag.toString('base64url'),
-    metadata,
-  };
+  session.metadata = { ...session.metadata, ...update };
+  await encryptAndWriteSession(profilesDir, profileName, session);
 
-  const filePath = getSessionFilePath(profilesDir, profileName);
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, JSON.stringify(envelope, null, 2) + '\n', 'utf8');
-  await chmod(filePath, 0o600);
+  return true;
+}
 
-  return filePath;
+/**
+ * Remove the selected project from session metadata.
+ * Returns true if session was found and updated, false if no session exists.
+ */
+export async function clearSelectedProject(
+  profilesDir: string,
+  profileName: string,
+): Promise<boolean> {
+  return updateSessionMetadata(profilesDir, profileName, { selectedProject: undefined });
 }
 
 export async function loadSession(
@@ -158,7 +219,9 @@ export async function loadSession(
     const decipher = createDecipheriv('aes-256-gcm', key, iv);
     decipher.setAuthTag(tag);
 
-    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
+      'utf8',
+    );
     return JSON.parse(decrypted) as StoredSession;
   } catch {
     return null;
@@ -168,17 +231,18 @@ export async function loadSession(
  * Delete the stored session for a profile.
  * @returns `true` if a session file existed and was removed, `false` if no session was stored.
  */
-export async function deleteSession(
-  profilesDir: string,
-  profileName: string,
-): Promise<boolean> {
+export async function deleteSession(profilesDir: string, profileName: string): Promise<boolean> {
   const filePath = getSessionFilePath(profilesDir, profileName);
   try {
     await unlink(filePath);
     return true;
   } catch (error: unknown) {
     // ENOENT = file doesn't exist — that's fine, return false
-    if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
       return false;
     }
     throw error;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,11 @@ export * from './auth/loginSelectors.js';
 export * from './auth/apiAuth.js';
 export * from './auth/webappApiClient.js';
 export * from './auth/authManager.js';
+export * from './auth/captchaDetector.js';
+export * from './auth/projectSelectors.js';
+
+// Project management
+export * from './bloomreachProjects.js';
 
 export interface BloomreachClientConfig {
   /** Bloomreach environment ID */

--- a/packages/mcp/src/__tests__/toolConstants.test.ts
+++ b/packages/mcp/src/__tests__/toolConstants.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { BLOOMREACH_MCP_TOOL_NAMES } from '../index.js';
 
 describe('tool constants', () => {
-  it('exports 267 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
-    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(283);
+  it('exports 287 tool name constants via BLOOMREACH_MCP_TOOL_NAMES', () => {
+    expect(BLOOMREACH_MCP_TOOL_NAMES).toHaveLength(287);
   });
 
   it('all tool names follow bloomreach.<domain>.<action> dot-notation', () => {
@@ -46,7 +46,7 @@ describe('tool constants', () => {
     }
   });
 
-  it('covers all 37 expected service domains', () => {
+  it('covers all 39 expected service domains', () => {
     const domains = new Set(BLOOMREACH_MCP_TOOL_NAMES.map((name) => name.split('.')[1]));
     const expectedDomains = [
       'actions',
@@ -87,6 +87,7 @@ describe('tool constants', () => {
       'vouchers',
       'tracking',
       'weblayers',
+      'projects',
     ];
 
     expect(domains.size).toBe(expectedDomains.length);

--- a/packages/mcp/src/bin/bloomreach-mcp.ts
+++ b/packages/mcp/src/bin/bloomreach-mcp.ts
@@ -295,6 +295,77 @@ const tools: ToolRoute[] = [
     },
   },
   {
+    name: toolNames.BLOOMREACH_PROJECTS_LIST_TOOL,
+    description:
+      'List all available Bloomreach projects from the project selector page. ' +
+      'Requires an authenticated browser session. Opens a headed browser to scrape the project tree. ' +
+      'Returns projects grouped by organization, workspace, and product.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'string',
+          description: 'Browser profile name (default: "default")',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: toolNames.BLOOMREACH_PROJECTS_SELECT_TOOL,
+    description:
+      'Select a Bloomreach project to work in. Opens a headed browser, navigates to the project selector, ' +
+      'clicks the specified project, and saves the selection for future commands. ' +
+      'Accepts project name (e.g. "Kingdom of Joakim") or URL slug (e.g. "kingdom-of-joakim").',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        nameOrSlug: {
+          type: 'string',
+          description: 'Project name or URL slug to select',
+        },
+        profile: {
+          type: 'string',
+          description: 'Browser profile name (default: "default")',
+        },
+      },
+      required: ['nameOrSlug'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: toolNames.BLOOMREACH_PROJECTS_CURRENT_TOOL,
+    description:
+      'Show the currently selected Bloomreach project. ' +
+      'Reads from stored session metadata — does not open a browser.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'string',
+          description: 'Browser profile name (default: "default")',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: toolNames.BLOOMREACH_PROJECTS_CLEAR_TOOL,
+    description:
+      'Clear the currently selected Bloomreach project. ' +
+      'Removes project selection from stored session metadata — does not open a browser.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'string',
+          description: 'Browser profile name (default: "default")',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
     name: toolNames.BLOOMREACH_DASHBOARDS_LIST_TOOL,
     description:
       'List all dashboards in the project. ⚠️ Not yet available — coming in a future release.',
@@ -6697,6 +6768,47 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (name === toolNames.BLOOMREACH_AUTH_VERIFY_API_TOOL) {
       const authManager = createAuthManager();
       const result = await authManager.verifyApi();
+      return toToolResult(result);
+    }
+
+    // --- Project management tools ---
+    if (name === toolNames.BLOOMREACH_PROJECTS_LIST_TOOL) {
+      const profilesDir = core.resolveProfilesDir();
+      const profileManager = new core.BloomreachProfileManager({ profilesDir });
+      const projectsService = new core.BloomreachProjectsService(profileManager, { profilesDir });
+      const profile = typeof args.profile === 'string' ? args.profile : undefined;
+      const result = await projectsService.listProjects({ profileName: profile });
+      return toToolResult(result);
+    }
+
+    if (name === toolNames.BLOOMREACH_PROJECTS_SELECT_TOOL) {
+      const profilesDir = core.resolveProfilesDir();
+      const profileManager = new core.BloomreachProfileManager({ profilesDir });
+      const projectsService = new core.BloomreachProjectsService(profileManager, { profilesDir });
+      const nameOrSlug = typeof args.nameOrSlug === 'string' ? args.nameOrSlug : '';
+      if (!nameOrSlug) {
+        return toErrorResult(new Error('nameOrSlug is required.'));
+      }
+      const profile = typeof args.profile === 'string' ? args.profile : undefined;
+      const result = await projectsService.selectProject(nameOrSlug, { profileName: profile });
+      return toToolResult(result);
+    }
+
+    if (name === toolNames.BLOOMREACH_PROJECTS_CURRENT_TOOL) {
+      const profilesDir = core.resolveProfilesDir();
+      const profileManager = new core.BloomreachProfileManager({ profilesDir });
+      const projectsService = new core.BloomreachProjectsService(profileManager, { profilesDir });
+      const profile = typeof args.profile === 'string' ? args.profile : undefined;
+      const result = await projectsService.currentProject({ profileName: profile });
+      return toToolResult(result);
+    }
+
+    if (name === toolNames.BLOOMREACH_PROJECTS_CLEAR_TOOL) {
+      const profilesDir = core.resolveProfilesDir();
+      const profileManager = new core.BloomreachProfileManager({ profilesDir });
+      const projectsService = new core.BloomreachProjectsService(profileManager, { profilesDir });
+      const profile = typeof args.profile === 'string' ? args.profile : undefined;
+      const result = await projectsService.clearProject({ profileName: profile });
       return toToolResult(result);
     }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -391,6 +391,12 @@ export const BLOOMREACH_AUTH_LOGIN_TOOL = 'bloomreach.auth.login';
 export const BLOOMREACH_AUTH_LOGOUT_TOOL = 'bloomreach.auth.logout';
 export const BLOOMREACH_AUTH_VERIFY_API_TOOL = 'bloomreach.auth.verify_api';
 
+// --- Project management tools ---
+export const BLOOMREACH_PROJECTS_LIST_TOOL = 'bloomreach.projects.list';
+export const BLOOMREACH_PROJECTS_SELECT_TOOL = 'bloomreach.projects.select';
+export const BLOOMREACH_PROJECTS_CURRENT_TOOL = 'bloomreach.projects.current';
+export const BLOOMREACH_PROJECTS_CLEAR_TOOL = 'bloomreach.projects.clear';
+
 // --- Recommendations tools (issue #182) ---
 export const BLOOMREACH_RECOMMENDATIONS_LIST_TOOL = 'bloomreach.recommendations.list';
 export const BLOOMREACH_RECOMMENDATIONS_VIEW_PERFORMANCE_TOOL =
@@ -691,6 +697,10 @@ export const BLOOMREACH_MCP_TOOL_NAMES = [
   BLOOMREACH_AUTH_LOGIN_TOOL,
   BLOOMREACH_AUTH_LOGOUT_TOOL,
   BLOOMREACH_AUTH_VERIFY_API_TOOL,
+  BLOOMREACH_PROJECTS_LIST_TOOL,
+  BLOOMREACH_PROJECTS_SELECT_TOOL,
+  BLOOMREACH_PROJECTS_CURRENT_TOOL,
+  BLOOMREACH_PROJECTS_CLEAR_TOOL,
   BLOOMREACH_ACTIONS_CONFIRM_TOOL,
   BLOOMREACH_ACTIONS_LIST_TOOL,
 ] as const;


### PR DESCRIPTION
## Summary

- **CAPTCHA Fallback**: Detect reCAPTCHA v2 Invisible challenges during browser login, notify the user via callback, extend the timeout for manual solving, and report `captchaDetected` in the login result
- **Project Selector**: List, select, query, and clear Bloomreach project selection from the `/my-account` Angular project tree — across CLI, MCP tools, and core API
- **Session Metadata**: Persist selected project in encrypted session store with `updateSessionMetadata` / `clearSelectedProject`

## New Modules

| Module | Description |
|--------|-------------|
| `auth/captchaDetector.ts` | reCAPTCHA bframe visibility detection (`detectCaptcha`, `isCaptchaVisible`, `waitForCaptchaResolution`) |
| `auth/projectSelectors.ts` | DOM scraping for Angular `<e-ui-accordion>` project tree (`scrapeProjectTree`, `flattenProjects`, `findProjectElement`, `clickProjectAndCaptureUrl`) |
| `bloomreachProjects.ts` | `BloomreachProjectsService` with `listProjects`, `selectProject`, `currentProject`, `clearProject` |

## Modified Modules

| Module | Changes |
|--------|---------|
| `bloomreachAuth.ts` | Integrated CAPTCHA detection into `openLogin` poll loop; added `captchaDetected`, `onCaptchaDetected`, `captchaTimeoutMs` |
| `bloomreachSessionStore.ts` | Added `SelectedProjectMetadata`, `updateSessionMetadata()`, `clearSelectedProject()` |
| `cli/bloomreach.ts` | Added `projects` command group (list/select/current/clear) + CAPTCHA callback on login |
| `mcp/bloomreach-mcp.ts` | Added 4 MCP tool definitions + handlers (`bloomreach.projects.{list,select,current,clear}`) |
| `mcp/index.ts` | Added 4 `BLOOMREACH_PROJECTS_*_TOOL` constants |

## CLI Commands

```
bloomreach projects list [--profile <name>] [--json]
bloomreach projects select <name-or-slug> [--profile <name>] [--json]
bloomreach projects current [--profile <name>] [--json]
bloomreach projects clear [--profile <name>] [--json]
```

## QA Results

| Test | Result |
|------|--------|
| `projects current --json` | ✅ Valid JSON output |
| `projects clear --json` | ✅ Valid JSON output |
| Login CAPTCHA detection (3 runs) | ✅ Correctly detects, reports `captchaDetected: true`, times out gracefully |
| Unit tests | ✅ 5079 passing (core: 4985, mcp: 94) |
| Typecheck (core + cli + mcp) | ✅ Clean |
| Lint | ✅ Clean |
| Build | ✅ All packages |
| `projects list` / `projects select` | ⏸️ Blocked by CAPTCHA in test env (requires human CAPTCHA solve) |

## Test Coverage

- `captchaDetector.test.ts` — 13 tests
- `projectSelectors.test.ts` — 22 tests
- `bloomreachSessionStore.test.ts` — 14 tests (extended)
- `bloomreachAuth.test.ts` — 22 tests (updated)
- `bloomreachAuth.captcha.test.ts` — 5 tests (new)
- `bloomreachProjects.test.ts` — 16 tests (new)